### PR TITLE
refactor(utils): extract formatting utilities to shared module

### DIFF
--- a/scripts/clean_raw_comments.py
+++ b/scripts/clean_raw_comments.py
@@ -35,6 +35,7 @@ from scripts.extract_filter import (
     has_valid_body,
     extract_fields,
 )
+from utils.formatting import format_duration, format_size
 
 # -----------------------------------------------------------------------------
 # Logging setup
@@ -74,30 +75,6 @@ def count_lines(filepath: Path) -> int:
         for _ in f:
             count += 1
     return count
-
-
-def format_size(size_bytes: int) -> str:
-    """Format bytes as human-readable string (KB, MB, GB)."""
-    for unit in ["B", "KB", "MB", "GB"]:
-        if size_bytes < 1024:
-            return f"{size_bytes:.1f} {unit}"
-        size_bytes /= 1024
-    return f"{size_bytes:.1f} TB"
-
-
-def format_duration(seconds: float) -> str:
-    """Format seconds as human-readable duration."""
-    if seconds < 60:
-        return f"{seconds:.1f}s"
-    elif seconds < 3600:
-        minutes = int(seconds // 60)
-        secs = int(seconds % 60)
-        return f"{minutes}m {secs}s"
-    else:
-        hours = int(seconds // 3600)
-        minutes = int((seconds % 3600) // 60)
-        secs = int(seconds % 60)
-        return f"{hours}h {minutes}m {secs}s"
 
 
 def process_line(line: str, stats: ProcessingStats) -> dict | None:

--- a/scripts/download_arctic_shift.py
+++ b/scripts/download_arctic_shift.py
@@ -60,6 +60,7 @@ from utils.constants import (
     SEASON_START_DATE,
     TARGET_SUBREDDITS,
 )
+from utils.formatting import format_duration
 
 # -----------------------------------------------------------------------------
 # Logging setup
@@ -130,27 +131,6 @@ def save_progress(progress_path: Path, progress: dict[str, Any]) -> None:
     with open(progress_path, "w") as f:
         json.dump(progress, f, indent=2)
     logger.debug(f"Progress saved to {progress_path}")
-
-def _format_duration(seconds: float) -> str:
-    """
-    Format a duration in seconds to human-readable string.
-    
-    Examples:
-        45.2 -> "45s"
-        125.7 -> "2m 6s"
-        3725.3 -> "1h 2m 5s"
-    """
-    if seconds < 60:
-        return f"{seconds:.0f}s"
-    elif seconds < 3600:
-        minutes = int(seconds // 60)
-        secs = int(seconds % 60)
-        return f"{minutes}m {secs}s"
-    else:
-        hours = int(seconds // 3600)
-        minutes = int((seconds % 3600) // 60)
-        secs = int(seconds % 60)
-        return f"{hours}h {minutes}m {secs}s"
 
 # -----------------------------------------------------------------------------
 # API interaction
@@ -429,7 +409,7 @@ def main() -> None:
             throughput = count / sub_elapsed if sub_elapsed > 0 else 0
             logger.info(
                 f"Completed {subreddit}: {count:,} comments "
-                f"in {_format_duration(sub_elapsed)} ({throughput:.1f} comments/sec)"
+                f"in {format_duration(sub_elapsed)} ({throughput:.1f} comments/sec)"
             )
             
         except KeyboardInterrupt:
@@ -462,7 +442,7 @@ def main() -> None:
     overall_throughput = total_comments / total_duration if total_duration > 0 else 0
     
     logger.info(f"This session: {len(session_stats)} subreddits, {total_comments:,} comments")
-    logger.info(f"Total time: {_format_duration(session_elapsed)} (avg {overall_throughput:.1f} comments/sec)")
+    logger.info(f"Total time: {format_duration(session_elapsed)} (avg {overall_throughput:.1f} comments/sec)")
     logger.info("")
     
     # Per-subreddit breakdown (sorted by count descending)
@@ -470,7 +450,7 @@ def main() -> None:
         throughput = stats["count"] / stats["duration"] if stats["duration"] > 0 else 0
         logger.info(
             f"  {sub}: {stats['count']:,} comments "
-            f"in {_format_duration(stats['duration'])} ({throughput:.1f}/sec)"
+            f"in {format_duration(stats['duration'])} ({throughput:.1f}/sec)"
         )
 
 if __name__ == "__main__":

--- a/tests/unit/test_formatting.py
+++ b/tests/unit/test_formatting.py
@@ -1,0 +1,112 @@
+"""Tests for utils.formatting module."""
+
+import pytest
+
+from utils.formatting import format_duration, format_size
+
+
+class TestFormatDuration:
+    """Tests for format_duration function."""
+
+    @pytest.mark.parametrize(
+        "seconds,expected",
+        [
+            (0, "0.0s"),
+            (0.0, "0.0s"),
+            (45.2, "45.2s"),
+            (59.9, "59.9s"),
+        ],
+    )
+    def test_sub_minute_values(self, seconds: float, expected: str):
+        """Verify sub-60 second values format with one decimal."""
+        assert format_duration(seconds) == expected
+
+    @pytest.mark.parametrize(
+        "seconds,expected",
+        [
+            (60, "1m 0s"),
+            (61, "1m 1s"),
+            (90, "1m 30s"),
+            (125, "2m 5s"),
+            (3599, "59m 59s"),
+        ],
+    )
+    def test_minute_values(self, seconds: float, expected: str):
+        """Verify minute-range values format as Xm Ys."""
+        assert format_duration(seconds) == expected
+
+    @pytest.mark.parametrize(
+        "seconds,expected",
+        [
+            (3600, "1h 0m 0s"),
+            (3661, "1h 1m 1s"),
+            (7325, "2h 2m 5s"),
+            (90000, "25h 0m 0s"),
+        ],
+    )
+    def test_hour_values(self, seconds: float, expected: str):
+        """Verify hour-range values format as Xh Ym Zs."""
+        assert format_duration(seconds) == expected
+
+    def test_float_precision_preserved(self):
+        """Verify float input works correctly."""
+        result = format_duration(45.123)
+        assert result == "45.1s"
+
+
+class TestFormatSize:
+    """Tests for format_size function."""
+
+    @pytest.mark.parametrize(
+        "size_bytes,expected",
+        [
+            (0, "0.0 B"),
+            (1, "1.0 B"),
+            (512, "512.0 B"),
+            (1023, "1023.0 B"),
+        ],
+    )
+    def test_byte_values(self, size_bytes: int, expected: str):
+        """Verify byte-range values stay in bytes."""
+        assert format_size(size_bytes) == expected
+
+    @pytest.mark.parametrize(
+        "size_bytes,expected",
+        [
+            (1024, "1.0 KB"),
+            (1536, "1.5 KB"),
+            (1048575, "1024.0 KB"),
+        ],
+    )
+    def test_kilobyte_values(self, size_bytes: int, expected: str):
+        """Verify KB-range values."""
+        assert format_size(size_bytes) == expected
+
+    @pytest.mark.parametrize(
+        "size_bytes,expected",
+        [
+            (1048576, "1.0 MB"),
+            (1572864, "1.5 MB"),
+            (1073741823, "1024.0 MB"),
+        ],
+    )
+    def test_megabyte_values(self, size_bytes: int, expected: str):
+        """Verify MB-range values."""
+        assert format_size(size_bytes) == expected
+
+    @pytest.mark.parametrize(
+        "size_bytes,expected",
+        [
+            (1073741824, "1.0 GB"),
+            (1610612736, "1.5 GB"),
+        ],
+    )
+    def test_gigabyte_values(self, size_bytes: int, expected: str):
+        """Verify GB-range values."""
+        assert format_size(size_bytes) == expected
+
+    def test_terabyte_values(self):
+        """Verify TB-range values."""
+        one_tb = 1024**4
+        assert format_size(one_tb) == "1.0 TB"
+        assert format_size(int(1.5 * one_tb)) == "1.5 TB"

--- a/utils/formatting.py
+++ b/utils/formatting.py
@@ -1,0 +1,41 @@
+"""Human-readable formatting utilities for durations and file sizes."""
+
+
+def format_duration(seconds: float) -> str:
+    """
+    Format seconds as human-readable duration.
+
+    Args:
+        seconds: Duration in seconds.
+
+    Returns:
+        Formatted string like "45.2s", "2m 5s", or "1h 2m 5s".
+    """
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    elif seconds < 3600:
+        minutes = int(seconds // 60)
+        secs = int(seconds % 60)
+        return f"{minutes}m {secs}s"
+    else:
+        hours = int(seconds // 3600)
+        minutes = int((seconds % 3600) // 60)
+        secs = int(seconds % 60)
+        return f"{hours}h {minutes}m {secs}s"
+
+
+def format_size(size_bytes: int) -> str:
+    """
+    Format bytes as human-readable string.
+
+    Args:
+        size_bytes: Size in bytes.
+
+    Returns:
+        Formatted string like "1.5 KB", "2.3 MB", or "1.0 GB".
+    """
+    for unit in ["B", "KB", "MB", "GB"]:
+        if size_bytes < 1024:
+            return f"{size_bytes:.1f} {unit}"
+        size_bytes /= 1024
+    return f"{size_bytes:.1f} TB"


### PR DESCRIPTION
## Description

Extract duplicated `format_duration` and `format_size` functions from scripts into a shared `utils/formatting.py` module. This eliminates code duplication and standardizes formatting behavior across the codebase.

Closes #3

## Changes

- Add `utils/formatting.py` with `format_duration` and `format_size` functions
- Add comprehensive parametrized tests in `tests/unit/test_formatting.py` (27 test cases)
- Update `scripts/clean_raw_comments.py` to import from shared module
- Update `scripts/download_arctic_shift.py` to import from shared module
- Standardize on `.1f` precision for sub-60 second durations

## Testing

- [x] All tests pass (`uv run pytest`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Added tests for new functionality (if applicable)
- [x] Manually verified changes work as expected

## Checklist

- [x] PR title follows format: `type(scope): subject`
- [x] Commits follow [git-strategy.md](docs/git-strategy.md)
- [x] No large data files included
- [x] Documentation updated (if applicable)

## Notes

The two original implementations had a minor difference: `clean_raw_comments.py` used `.1f` precision for sub-60 seconds ("45.2s") while `download_arctic_shift.py` used `.0f` ("45s"). Standardized on `.1f` for consistency with the public API.