### PR TITLE
feat(pipeline): add posts download script and player config

### DIFF
--- a/config/players.yaml
+++ b/config/players.yaml
@@ -1,0 +1,844 @@
+# NBA Player Aliases for Hate Detection
+# Includes negative/mocking nicknames as high-signal identifiers
+
+version: "1.0"
+season: "2024-25"
+
+# Short aliases that require word boundary matching (\b) to avoid false positives
+# These match common English words without proper boundaries
+short_aliases:
+  - ad
+  - ant
+  - ja
+  - fox
+  - og
+  - pg
+  - cp
+  - bam
+  - dame
+  - book
+  - zo
+  - kat
+  - kd
+  - ai
+  - tt
+
+players:
+  # Alphabetical by last name
+
+  Bam Adebayo:
+    - bam adebayo
+    - adebayo
+    - bam  # requires word boundary
+
+  Giannis Antetokounmpo:
+    - giannis antetokounmpo
+    - giannis
+    - antetokounmpo
+    - greek freak
+    - the greek freak
+    - gianni
+    # Negative
+    - giannis cant shoot
+    - freethrow merchant
+
+  Carmelo Anthony:
+    - carmelo anthony
+    - carmelo
+    - melo
+    - me7o
+    - hoodie melo
+    # Negative
+    - stay me7o
+    - olympic melo
+
+  OG Anunoby:
+    - og anunoby
+    - anunoby
+    - og  # requires word boundary
+    - prince ogugua
+
+  Marvin Bagley III:
+    - marvin bagley
+    - bagley
+    # Negative
+    - bust bagley
+
+  Lonzo Ball:
+    - lonzo ball
+    - lonzo
+    - zo  # requires word boundary
+    - ball brothers
+    # Negative
+    - lavar's son
+    - injury prone zo
+
+  LaMelo Ball:
+    - lamelo ball
+    - lamelo
+    - melo ball
+    # Negative
+    - lavar's other son
+
+  Paolo Banchero:
+    - paolo banchero
+    - banchero
+    - paolo
+    - pb
+
+  Desmond Bane:
+    - desmond bane
+    - bane
+    - des
+
+  Patrick Beverley:
+    - patrick beverley
+    - pat bev
+    - patbev
+    - beverley
+    # Negative
+    - dirty pat bev
+    - pest beverley
+    - bum beverley
+
+  Devin Booker:
+    - devin booker
+    - booker
+    - dbook
+    - d book
+    - book  # requires word boundary
+    # Negative
+    - empty stats booker
+    - bubble booker
+
+  Mikal Bridges:
+    - mikal bridges
+    - bridges
+    - mikal
+    - the warden
+
+  Dillon Brooks:
+    - dillon brooks
+    - brooks
+    - dillon
+    # Negative
+    - dirty brooks
+    - villain brooks
+    - big mouth brooks
+
+  Jaylen Brown:
+    - jaylen brown
+    - jaylen
+    - jb
+    # Negative
+    - robin to tatum
+
+  Jalen Brunson:
+    - jalen brunson
+    - brunson
+    - jalen
+    - jb
+    # Negative
+    - villain brunson
+    - short brunson
+
+  Jimmy Butler:
+    - jimmy butler
+    - butler
+    - jimmy
+    - jimmy buckets
+    - jimmy g buckets
+    - buckets
+    - himmy butler
+    # Negative
+    - playoff jimmy
+    - bubble jimmy
+    - toxic jimmy
+    - jimmy diva
+
+  Clint Capela:
+    - clint capela
+    - capela
+    - clint
+
+  Alex Caruso:
+    - alex caruso
+    - caruso
+    - the accountant
+    - bald mamba
+    - carushow
+
+  Stephen Curry:
+    - stephen curry
+    - steph curry
+    - curry
+    - steph
+    - wardell
+    - chef curry
+    - baby faced assassin
+    - skyfucker
+    # Negative
+    - stephew
+    - gravity merchant
+    - no fmvp curry
+
+  Anthony Davis:
+    - anthony davis
+    - ad  # requires word boundary
+    - the brow
+    - unibrow
+    # Negative
+    - adisney
+    - street clothes
+    - day to davis
+    - day-to-davis
+    - glass davis
+    - bubble champion
+
+  DeMar DeRozan:
+    - demar derozan
+    - derozan
+    - demar
+    - debo
+    - compton's finest
+
+  Luka Doncic:
+    - luka doncic
+    - luka
+    - doncic
+    - luka magic
+    - the don
+    - wonderboy
+    # Negative
+    - luka special
+    - fat luka
+    - chubby luka
+    - flopping luka
+    - whiny luka
+
+  Kevin Durant:
+    - kevin durant
+    - durant
+    - kd  # requires word boundary
+    - durantula
+    - slim reaper
+    - easy money sniper
+    - the servant
+    # Negative
+    - cupcake
+    - snake
+    - mr burner
+    - burner kd
+    - kd burner
+    - bus rider
+    - easy mode
+    - cant win with these cats
+
+  Anthony Edwards:
+    - anthony edwards
+    - ant  # requires word boundary
+    - ant man
+    - antman
+    - edwards
+    - a1 from day 1
+    # Negative
+    - chucker edwards
+
+  Joel Embiid:
+    - joel embiid
+    - embiid
+    - joel
+    - the process
+    - jojo
+    - do a 180
+    - troel embiid
+    # Negative
+    - jobiid
+    - emflop
+    - injury embiid
+    - load management joel
+    - no second round embiid
+    - choker embiid
+    - the processor
+
+  De'Aaron Fox:
+    - de'aaron fox
+    - deaaron fox
+    - fox  # requires word boundary
+    - swipa
+    - de'aaron
+    # Negative
+    - stat padder fox
+
+  Evan Fournier:
+    - evan fournier
+    - fournier
+    - evan
+    - dont google
+
+  Darius Garland:
+    - darius garland
+    - garland
+    - dg
+
+  Paul George:
+    - paul george
+    - pg  # requires word boundary
+    - pg13
+    - pg 13
+    # Negative
+    - playoff p
+    - pandemic p
+    - wayoff p
+    - way off p
+    - pushoff p
+    - no ot tonight
+    - 0 ot tonight
+
+  Shai Gilgeous-Alexander:
+    - shai gilgeous-alexander
+    - shai gilgeous alexander
+    - shai
+    - sga
+    - gilgeous-alexander
+    # Negative
+    - foul baiter shai
+    - free throw merchant
+
+  Rudy Gobert:
+    - rudy gobert
+    - gobert
+    - rudy
+    - the stifle tower
+    - gobzilla
+    # Negative
+    - rudymentary
+    - covid rudy
+    - microphone rudy
+    - minus rudy
+    - playoff gobert
+    - fraud gobert
+    - overpaid gobert
+
+  Aaron Gordon:
+    - aaron gordon
+    - gordon
+    - ag
+    - air gordon
+
+  Draymond Green:
+    - draymond green
+    - draymond
+    - green
+    - dray
+    - bdd
+    - day day
+    # Negative
+    - donkey
+    - dirty dray
+    - suspension green
+    - podcast draymond
+    - kicking green
+    - nut puncher
+
+  Tyrese Haliburton:
+    - tyrese haliburton
+    - haliburton
+    - tyrese
+    - hali
+
+  James Harden:
+    - james harden
+    - harden
+    - the beard
+    - fear the beard
+    - chef harden
+    # Negative
+    - flopper
+    - james floppen
+    - james soften
+    - strip club harden
+    - playoff choker
+    - foul merchant
+    - free throw merchant
+
+  Josh Hart:
+    - josh hart
+    - hart
+    - hartenstein
+
+  Tyler Herro:
+    - tyler herro
+    - herro
+    - boy wonder
+    - bucket
+
+  Chet Holmgren:
+    - chet holmgren
+    - chet
+    - holmgren
+    - chet the threat
+    - unicorn
+    # Negative
+    - injury chet
+    - skinny chet
+    - glass chet
+
+  Dwight Howard:
+    - dwight howard
+    - dwight
+    - howard
+    - superman
+    - d12
+    # Negative
+    - soft dwight
+    - drama dwight
+    - snake dwight
+
+  Brandon Ingram:
+    - brandon ingram
+    - ingram
+    - bi
+    - slim reefer
+    - sleepy b
+
+  Kyrie Irving:
+    - kyrie irving
+    - kyrie
+    - irving
+    - kai
+    - uncle drew
+    - world b flat
+    # Negative
+    - flat earther
+    - mr sage
+    - third eye
+    - antisemite
+    - part time kyrie
+    - mr enlightened
+
+  LeBron James:
+    - lebron james
+    - lebron
+    - bron
+    - lbj
+    - king james
+    - the king
+    - chosen one
+    - legoat
+    - le goat
+    - akron hammer
+    # Negative
+    - lemickey
+    - le mickey
+    - lebrick
+    - le brick
+    - lechoke
+    - le choke
+    - leflop
+    - le flop
+    - lefraud
+    - le fraud
+    - lequit
+    - le quit
+    - lestatpad
+    - le statpad
+    - lecoast
+    - le coast
+    - legm
+    - le gm
+    - lediva
+    - washed king
+    - lefirethiscoach
+    - china bron
+    - taco tuesday
+
+  Nikola Jokic:
+    - nikola jokic
+    - jokic
+    - nikola
+    - joker
+    - the joker
+    - big honey
+    - sombor shuffle
+    # Negative
+    - fat jokic
+    - unathletic jokic
+    - slow jokic
+
+  Tre Jones:
+    - tre jones
+    - tre
+
+  Caris LeVert:
+    - caris levert
+    - levert
+    - caris
+
+  Kawhi Leonard:
+    - kawhi leonard
+    - kawhi
+    - leonard
+    - the klaw
+    - the claw
+    - board man
+    - fun guy
+    - board man gets paid
+    # Negative
+    - load management
+    - mr load management
+    - sit out kawhi
+    - injury kawhi
+    - robot kawhi
+    - quitter kawhi
+
+  Damian Lillard:
+    - damian lillard
+    - lillard
+    - dame  # requires word boundary
+    - dame time
+    - dame dolla
+    - big game dame
+    - logo lillard
+    # Negative
+    - dame quit
+    - 0 rings dame
+    - padded stats
+
+  Zach LaVine:
+    - zach lavine
+    - lavine
+    - zach
+
+  Kevon Looney:
+    - kevon looney
+    - looney
+    - loon
+
+  Brook Lopez:
+    - brook lopez
+    - lopez
+    - splash mountain
+
+  Tyrese Maxey:
+    - tyrese maxey
+    - maxey
+    - tyrese
+
+  De'Anthony Melton:
+    - deanthony melton
+    - melton
+
+  Khris Middleton:
+    - khris middleton
+    - middleton
+    - khris
+    - khash money
+
+  Donovan Mitchell:
+    - donovan mitchell
+    - mitchell
+    - donovan
+    - spida
+    - spidaman
+    # Negative
+    - ball hog mitchell
+    - chucker mitchell
+
+  Ja Morant:
+    - ja morant
+    - morant
+    - ja  # requires word boundary
+    - temetrius
+    - point god ja
+    # Negative
+    - gun ja
+    - glock morant
+    - gangster ja
+    - suspended ja
+    - immature ja
+
+  Dejounte Murray:
+    - dejounte murray
+    - dejounte
+    - murray
+    - dj murray
+
+  Jamal Murray:
+    - jamal murray
+    - jamal
+    - blue arrow
+
+  Chris Paul:
+    - chris paul
+    - cp3
+    - cp  # requires word boundary
+    - point god
+    - the point god
+    - floor general
+    # Negative
+    - dirty cp3
+    - flopper paul
+    - first round paul
+    - playoff choker cp3
+    - cone paul
+    - cooked cp3
+
+  Jordan Poole:
+    - jordan poole
+    - poole
+    - jp
+    - poole party
+    # Negative
+    - party poole
+    - selfish poole
+    - chucker poole
+    - contract poole
+
+  Bobby Portis:
+    - bobby portis
+    - portis
+    - crazy eyes
+
+  Julius Randle:
+    - julius randle
+    - randle
+    - julius
+    - beyblade
+    # Negative
+    - spin randle
+    - turnover randle
+
+  Austin Reaves:
+    - austin reaves
+    - reaves
+    - ar15
+    - ar 15
+    - hillbilly kobe
+    # Negative
+    - overhyped reaves
+    - white boy hype
+
+  Rajon Rondo:
+    - rajon rondo
+    - rondo
+    - playoff rondo
+    - connect four rondo
+    # Negative
+    - regular season rondo
+    - quit rondo
+
+  Derrick Rose:
+    - derrick rose
+    - drose
+    - d rose
+    - rose
+    # Negative
+    - injury rose
+
+  D'Angelo Russell:
+    - d'angelo russell
+    - dangelo russell
+    - dlo
+    - d lo
+    - russell
+    - ice in my veins
+    # Negative
+    - snitch russell
+    - frozen russell
+    - ice in his veins (ironic)
+    - inconsistent dlo
+
+  Domantas Sabonis:
+    - domantas sabonis
+    - sabonis
+    - domas
+
+  Pascal Siakam:
+    - pascal siakam
+    - siakam
+    - pascal
+    - spicy p
+    - spinakam
+    # Negative
+    - mid siakam
+    - inconsistent p
+
+  Ben Simmons:
+    - ben simmons
+    - simmons
+    - ben
+    - young socialite
+    # Negative
+    - bum simmons
+    - scared simmons
+    - cant shoot
+    - back simmons
+    - socialite
+    - fresh prince (ironic)
+    - phantom injury
+    - mental health excuse
+    - pass up dunk
+
+  Marcus Smart:
+    - marcus smart
+    - smart
+    - marcus
+    # Negative
+    - flopper smart
+    - dirty smart
+
+  Jalen Smith:
+    - jalen smith
+    - stix
+
+  Jayson Tatum:
+    - jayson tatum
+    - tatum
+    - jt
+    - jayson
+    - the problem
+    # Negative
+    - kobe stan tatum
+    - hero ball tatum
+    - inconsistent tatum
+    - too long tatum
+
+  Klay Thompson:
+    - klay thompson
+    - klay
+    - thompson
+    - splash brother
+    - game 6 klay
+    - china klay
+    # Negative
+    - washed klay
+    - ig klay
+    - boat klay
+    - contract year klay
+
+  Karl-Anthony Towns:
+    - karl-anthony towns
+    - karl anthony towns
+    - towns
+    - kat  # requires word boundary
+    - big kat
+    # Negative
+    - soft kat
+    - charmin
+    - cant defend
+    - offensive only kat
+
+  Evan Turner:
+    - evan turner
+    - turner
+
+  Myles Turner:
+    - myles turner
+    - turner
+    - myles
+    # Negative
+    - trade turner
+    - always available turner
+
+  Fred VanVleet:
+    - fred vanvleet
+    - vanvleet
+    - fvv
+    - steady freddy
+    - freddy
+    # Negative
+    - bet on yourself
+    - overpaid fred
+
+  Nikola Vucevic:
+    - nikola vucevic
+    - vucevic
+    - vooch
+
+  Kemba Walker:
+    - kemba walker
+    - kemba
+    - cardiac kemba
+
+  John Wall:
+    - john wall
+    - wall
+    - j wall
+    # Negative
+    - contract wall
+    - cooked wall
+
+  Victor Wembanyama:
+    - victor wembanyama
+    - wembanyama
+    - wemby
+    - victor
+    - alien
+    - the alien
+    # Negative
+    - bust wemby
+    - overhyped
+    - skinny wemby
+
+  Russell Westbrook:
+    - russell westbrook
+    - westbrook
+    - russ
+    - brodie
+    - mr triple double
+    - why not
+    # Negative
+    - westbrick
+    - worstbrook
+    - westbroke
+    - westbrook statpad
+    - brick
+    - chucker
+    - reckless russ
+    - no bbiq
+
+  Andrew Wiggins:
+    - andrew wiggins
+    - wiggins
+    - wiggs
+    - two way wiggs
+    # Negative
+    - lazy wiggins
+    - potential wiggins
+    - maple jordan (ironic)
+
+  Zion Williamson:
+    - zion williamson
+    - zion
+    - williamson
+    - zanos
+    - air gumbo
+    # Negative
+    - wide zion
+    - big zion
+    - fat zion
+    - out of shape
+    - always injured
+    - load management zion
+    - big chungas
+
+  Trae Young:
+    - trae young
+    - trae
+    - young
+    - ice trae
+    # Negative
+    - ice trae (ironic)
+    - foul merchant
+    - foul baiter
+    - flopper trae
+    - villain trae
+    - bald spot
+    - hair plugs
+    - brick young
+
+  Ivica Zubac:
+    - ivica zubac
+    - zubac
+    - zu

--- a/notebooks/03_posts_context_evaluation.ipynb
+++ b/notebooks/03_posts_context_evaluation.ipynb
@@ -1,0 +1,727 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0a5c0bff",
+   "metadata": {},
+   "source": [
+    "# Posts Context Evaluation\n",
+    "\n",
+    "**Objective:** Determine if post-title context improves player attribution for comments.\n",
+    "\n",
+    "From comments EDA, only 22.4% of comments explicitly mention player names. The remaining 77.6% may be attributable via their parent post's title.\n",
+    "\n",
+    "**Kill Question:** What % of post titles contain player names?\n",
+    "\n",
+    "| Threshold | Decision |\n",
+    "|-----------|----------|\n",
+    "| >50% | Post-context is valuable, continue evaluation |\n",
+    "| <30% | Not worth the complexity |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "888fcfbf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import yaml\n",
+    "from pathlib import Path\n",
+    "from datetime import datetime\n",
+    "\n",
+    "DATA_DIR = Path(\"data\")\n",
+    "POSTS_PATH = DATA_DIR / \"raw\" / \"r_nba_posts.jsonl\"\n",
+    "PLAYERS_CONFIG = Path(\"config/players.yaml\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77810d3b",
+   "metadata": {},
+   "source": [
+    "## Load Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f269629e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Posts loaded: 92,531\n"
+     ]
+    }
+   ],
+   "source": [
+    "posts = [json.loads(line) for line in POSTS_PATH.open()]\n",
+    "print(f\"Posts loaded: {len(posts):,}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ad813954",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Players tracked: 85\n"
+     ]
+    }
+   ],
+   "source": [
+    "with open(PLAYERS_CONFIG) as f:\n",
+    "    player_config = yaml.safe_load(f)\n",
+    "\n",
+    "PLAYER_PATTERNS = player_config[\"players\"]\n",
+    "print(f\"Players tracked: {len(PLAYER_PATTERNS)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "83edc8f7",
+   "metadata": {},
+   "source": [
+    "## Data Quality Check"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "22afe86d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Date range: 2024-10-01 to 2025-06-29\n",
+      "\n",
+      "Field completeness:\n",
+      "  id: 92,531 (100.0%)\n",
+      "  title: 92,531 (100.0%)\n",
+      "  link_flair_text: 15,609 (16.9%)\n",
+      "  author_flair_text: 42,071 (45.5%)\n",
+      "  score: 92,531 (100.0%)\n",
+      "  num_comments: 92,531 (100.0%)\n"
+     ]
+    }
+   ],
+   "source": [
+    "timestamps = [p.get(\"created_utc\", 0) for p in posts]\n",
+    "min_date = datetime.fromtimestamp(min(timestamps))\n",
+    "max_date = datetime.fromtimestamp(max(timestamps))\n",
+    "print(f\"Date range: {min_date.date()} to {max_date.date()}\")\n",
+    "\n",
+    "print(f\"\\nField completeness:\")\n",
+    "fields = [\"id\", \"title\", \"link_flair_text\", \"author_flair_text\", \"score\", \"num_comments\"]\n",
+    "for field in fields:\n",
+    "    present = sum(1 for p in posts if p.get(field) is not None)\n",
+    "    print(f\"  {field}: {present:,} ({present/len(posts)*100:.1f}%)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "639a0572",
+   "metadata": {},
+   "source": [
+    "## Kill Question: Player Mentions in Titles\n",
+    "\n",
+    "If <30% of titles mention players, post-context adds complexity without sufficient value."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "dbdae731",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Titles mentioning players: 62,789 / 92,531 (67.9%)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def mentions_player(text: str) -> tuple[bool, list[str]]:\n",
+    "    \"\"\"Check if text mentions any tracked player.\"\"\"\n",
+    "    if not text:\n",
+    "        return False, []\n",
+    "    text_lower = text.lower()\n",
+    "    found = []\n",
+    "    for player, aliases in PLAYER_PATTERNS.items():\n",
+    "        if any(alias in text_lower for alias in aliases):\n",
+    "            found.append(player)\n",
+    "    return len(found) > 0, found\n",
+    "\n",
+    "titles_with_players = 0\n",
+    "for post in posts:\n",
+    "    has_mention, _ = mentions_player(post.get(\"title\", \"\"))\n",
+    "    if has_mention:\n",
+    "        titles_with_players += 1\n",
+    "\n",
+    "pct = titles_with_players / len(posts) * 100\n",
+    "print(f\"Titles mentioning players: {titles_with_players:,} / {len(posts):,} ({pct:.1f}%)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d41a9ce",
+   "metadata": {},
+   "source": [
+    "**Result:** 67.9% of post titles mention at least one player.\n",
+    "\n",
+    "This exceeds the 50% threshold. Post-context is potentially valuable — continue evaluation.\n",
+    "\n",
+    "## Player Mention Comparison: Titles vs Comments\n",
+    "\n",
+    "Rerun player detection on comments using the same comprehensive player config to enable direct comparison."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "81234c53",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Comments mentioning players: 3,754,033 / 6,891,163 (54.5%)\n",
+      "Titles mentioning players:   62,789 / 92,531 (67.9%)\n"
+     ]
+    }
+   ],
+   "source": [
+    "COMMENTS_PATH = DATA_DIR / \"filtered\" / \"r_nba_cleaned.jsonl\"\n",
+    "\n",
+    "comment_count = 0\n",
+    "comments_with_players = 0\n",
+    "\n",
+    "with open(COMMENTS_PATH) as f:\n",
+    "    for line in f:\n",
+    "        comment = json.loads(line)\n",
+    "        comment_count += 1\n",
+    "        has_mention, _ = mentions_player(comment.get(\"body\", \"\"))\n",
+    "        if has_mention:\n",
+    "            comments_with_players += 1\n",
+    "\n",
+    "comment_pct = comments_with_players / comment_count * 100\n",
+    "title_pct = titles_with_players / len(posts) * 100\n",
+    "\n",
+    "print(f\"Comments mentioning players: {comments_with_players:,} / {comment_count:,} ({comment_pct:.1f}%)\")\n",
+    "print(f\"Titles mentioning players:   {titles_with_players:,} / {len(posts):,} ({title_pct:.1f}%)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "639ee160",
+   "metadata": {},
+   "source": [
+    "## False Positive Audit\n",
+    "\n",
+    "Test impact of word boundary matching for problematic aliases."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "0b7e92c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "\n",
+    "# Aliases that are too ambiguous even with word boundaries (remove entirely)\n",
+    "REMOVE_ENTIRELY = {\n",
+    "    \"ball\",  # \"ball movement\", \"ball handler\" — ubiquitous in NBA\n",
+    "    \"green\", # color\n",
+    "    \"brown\", # color\n",
+    "    \"rose\",  # common word\n",
+    "    \"young\", # \"young player\", \"young team\"\n",
+    "    \"wall\",  # \"hit a wall\"\n",
+    "    \"smart\", # \"smart play\"\n",
+    "    \"bridges\", # common word\n",
+    "    \"butler\", # common word\n",
+    "    \"turner\", # common surname\n",
+    "    \"gordon\", # common name\n",
+    "    \"murray\", # common name\n",
+    "    \"hart\",  # common word\n",
+    "    \"tre\",   # common word fragment\n",
+    "}\n",
+    "\n",
+    "# Aliases that need word boundary matching (from YAML + additional)\n",
+    "WORD_BOUNDARY_REQUIRED = set(player_config.get(\"short_aliases\", [])) | {\n",
+    "    \"curry\",   # food references\n",
+    "    \"booker\",  # common surname\n",
+    "    \"brooks\",  # common surname\n",
+    "    \"leonard\", # common name\n",
+    "    \"mitchell\", # common name\n",
+    "    \"edwards\", # common name\n",
+    "    \"thomas\",  # common name\n",
+    "    \"johnson\", # common name\n",
+    "    \"davis\",   # common name\n",
+    "    \"paul\",    # common first name\n",
+    "    \"james\",   # common first name\n",
+    "    \"george\",  # common first name\n",
+    "}\n",
+    "\n",
+    "def mentions_player_strict(text: str) -> tuple[bool, list[str]]:\n",
+    "    \"\"\"Stricter player detection with word boundaries for problematic aliases.\"\"\"\n",
+    "    if not text:\n",
+    "        return False, []\n",
+    "    text_lower = text.lower()\n",
+    "    found = []\n",
+    "    \n",
+    "    for player, aliases in PLAYER_PATTERNS.items():\n",
+    "        for alias in aliases:\n",
+    "            alias_lower = alias.lower()\n",
+    "            \n",
+    "            # Skip removed aliases\n",
+    "            if alias_lower in REMOVE_ENTIRELY:\n",
+    "                continue\n",
+    "            \n",
+    "            # Use word boundary for problematic aliases\n",
+    "            if alias_lower in WORD_BOUNDARY_REQUIRED:\n",
+    "                pattern = r'\\b' + re.escape(alias_lower) + r'\\b'\n",
+    "                if re.search(pattern, text_lower):\n",
+    "                    found.append(player)\n",
+    "                    break\n",
+    "            else:\n",
+    "                # Standard substring matching\n",
+    "                if alias_lower in text_lower:\n",
+    "                    found.append(player)\n",
+    "                    break\n",
+    "    \n",
+    "    return len(found) > 0, found"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "2838e35c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Title player mentions:\n",
+      "  Original: 62,789 (67.9%)\n",
+      "  Strict:   49,346 (53.3%)\n",
+      "  Diff:     13,443 (14.5%)\n"
+     ]
+    }
+   ],
+   "source": [
+    "titles_original = sum(1 for p in posts if mentions_player(p.get(\"title\", \"\"))[0])\n",
+    "titles_strict = sum(1 for p in posts if mentions_player_strict(p.get(\"title\", \"\"))[0])\n",
+    "\n",
+    "print(\"Title player mentions:\")\n",
+    "print(f\"  Original: {titles_original:,} ({titles_original/len(posts)*100:.1f}%)\")\n",
+    "print(f\"  Strict:   {titles_strict:,} ({titles_strict/len(posts)*100:.1f}%)\")\n",
+    "print(f\"  Diff:     {titles_original - titles_strict:,} ({(titles_original - titles_strict)/len(posts)*100:.1f}%)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "6e0503a4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Comment player mentions:\n",
+      "  Original: 3,754,033 (54.5%)\n",
+      "  Strict:   2,841,666 (41.2%)\n",
+      "  Diff:     912,367 (13.2%)\n"
+     ]
+    }
+   ],
+   "source": [
+    "comments_original = 0\n",
+    "comments_strict = 0\n",
+    "\n",
+    "with open(COMMENTS_PATH) as f:\n",
+    "    for line in f:\n",
+    "        body = json.loads(line).get(\"body\", \"\")\n",
+    "        if mentions_player(body)[0]:\n",
+    "            comments_original += 1\n",
+    "        if mentions_player_strict(body)[0]:\n",
+    "            comments_strict += 1\n",
+    "\n",
+    "print(f\"\\nComment player mentions:\")\n",
+    "print(f\"  Original: {comments_original:,} ({comments_original/comment_count*100:.1f}%)\")\n",
+    "print(f\"  Strict:   {comments_strict:,} ({comments_strict/comment_count*100:.1f}%)\")\n",
+    "print(f\"  Diff:     {comments_original - comments_strict:,} ({(comments_original - comments_strict)/comment_count*100:.1f}%)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4edad09",
+   "metadata": {},
+   "source": [
+    "## Flair Distribution Analysis\n",
+    "\n",
+    "Only 16.9% of posts have `link_flair_text`. Examine what's tagged and whether it's useful for filtering."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "ba968612",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Posts without flair: 76,922 (83.1%)\n",
+      "\n",
+      "Flair distribution:\n",
+      "  Highlight: 11,544 (12.5%)\n",
+      "  Post Game Thread: 1,565 (1.7%)\n",
+      "  Game Thread: 1,420 (1.5%)\n",
+      "  Index Thread: 250 (0.3%)\n",
+      "  Discussion: 243 (0.3%)\n",
+      "  News: 225 (0.2%)\n",
+      "  All-Access: 206 (0.2%)\n",
+      "  Original Content: 101 (0.1%)\n",
+      "  Self-Promo and Fan Art Thread: 39 (0.0%)\n",
+      "  Misleading: 8 (0.0%)\n",
+      "  TRASH TALK THREAD: 3 (0.0%)\n",
+      "  Announcement: 2 (0.0%)\n",
+      "  AMA: 1 (0.0%)\n",
+      "  Poll: 1 (0.0%)\n",
+      "  Mod Post: 1 (0.0%)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from collections import Counter\n",
+    "\n",
+    "flair_counts = Counter(p.get(\"link_flair_text\") for p in posts)\n",
+    "\n",
+    "# Separate None from actual flairs\n",
+    "no_flair = flair_counts.pop(None, 0)\n",
+    "print(f\"Posts without flair: {no_flair:,} ({no_flair/len(posts)*100:.1f}%)\\n\")\n",
+    "\n",
+    "print(\"Flair distribution:\")\n",
+    "for flair, count in flair_counts.most_common(20):\n",
+    "    pct = count / len(posts) * 100\n",
+    "    print(f\"  {flair}: {count:,} ({pct:.1f}%)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "1c643db5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Post lookup built: 92,531 posts\n"
+     ]
+    }
+   ],
+   "source": [
+    "# build post lookup for joining\n",
+    "posts_lookup = {p[\"id\"]: p for p in posts}\n",
+    "print(f\"Post lookup built: {len(posts_lookup):,} posts\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7ecfe07",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Comments joined: 6,883,715\n",
+      "Join failures: 7,448 (0.1%)\n",
+      "\n",
+      "Comments by post flair:\n",
+      "  No Flair: 4,073,826 (59.2%)\n",
+      "  Game Thread: 1,546,398 (22.5%)\n",
+      "  Highlight: 835,279 (12.1%)\n",
+      "  Post Game Thread: 345,563 (5.0%)\n",
+      "  News: 39,326 (0.6%)\n",
+      "  All-Access: 10,608 (0.2%)\n",
+      "  Index Thread: 10,373 (0.2%)\n",
+      "  Discussion: 6,887 (0.1%)\n",
+      "  Announcement: 5,513 (0.1%)\n",
+      "  Original Content: 4,888 (0.1%)\n",
+      "  Misleading: 3,055 (0.0%)\n",
+      "  TRASH TALK THREAD: 1,583 (0.0%)\n",
+      "  Poll: 306 (0.0%)\n",
+      "  Self-Promo and Fan Art Thread: 104 (0.0%)\n",
+      "  Mod Post: 6 (0.0%)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# comment distribution by flair\n",
+    "flair_comment_counts = Counter()\n",
+    "join_failures = 0\n",
+    "\n",
+    "with open(COMMENTS_PATH) as f:\n",
+    "    for line in f:\n",
+    "        comment = json.loads(line)\n",
+    "        link_id = comment.get(\"link_id\", \"\")\n",
+    "        post_id = link_id.replace(\"t3_\", \"\")\n",
+    "        \n",
+    "        post = posts_lookup.get(post_id)\n",
+    "        if post:\n",
+    "            flair = post.get(\"link_flair_text\") or \"No Flair\"\n",
+    "            flair_comment_counts[flair] += 1\n",
+    "        else:\n",
+    "            join_failures += 1\n",
+    "\n",
+    "total_joined = sum(flair_comment_counts.values())\n",
+    "print(f\"Comments joined: {total_joined:,}\")\n",
+    "print(f\"Join failures: {join_failures:,} ({join_failures/comment_count*100:.1f}%)\\n\")\n",
+    "\n",
+    "print(\"Comments by post flair:\")\n",
+    "for flair, count in flair_comment_counts.most_common(20):\n",
+    "    pct = count / total_joined * 100\n",
+    "    print(f\"  {flair}: {count:,} ({pct:.1f}%)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db30c03c",
+   "metadata": {},
+   "source": [
+    "## Player Mention Rate by Flair\n",
+    "\n",
+    "Determine which post types have highest signal for player attribution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "01b8c23f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Player mention rate by flair:\n",
+      "\n",
+      "Flair                         Mentions        Total     Rate\n",
+      "------------------------------------------------------------\n",
+      "No Flair                     1,794,315    4,073,826    44.0%\n",
+      "Game Thread                    548,199    1,546,398    35.5%\n",
+      "Highlight                      321,969      835,279    38.5%\n",
+      "Post Game Thread               143,271      345,563    41.5%\n",
+      "News                            15,290       39,326    38.9%\n",
+      "All-Access                       3,512       10,608    33.1%\n",
+      "Index Thread                     3,372       10,373    32.5%\n",
+      "Discussion                       3,226        6,887    46.8%\n",
+      "Announcement                     1,271        5,513    23.1%\n",
+      "Original Content                 2,323        4,888    47.5%\n"
+     ]
+    }
+   ],
+   "source": [
+    "flair_mention_counts = Counter()  # comments with player mentions\n",
+    "flair_total_counts = Counter()     # all comments\n",
+    "\n",
+    "with open(COMMENTS_PATH) as f:\n",
+    "    for line in f:\n",
+    "        comment = json.loads(line)\n",
+    "        link_id = comment.get(\"link_id\", \"\")\n",
+    "        post_id = link_id.replace(\"t3_\", \"\")\n",
+    "        \n",
+    "        post = posts_lookup.get(post_id)\n",
+    "        if not post:\n",
+    "            continue\n",
+    "            \n",
+    "        flair = post.get(\"link_flair_text\") or \"No Flair\"\n",
+    "        flair_total_counts[flair] += 1\n",
+    "        \n",
+    "        has_mention, _ = mentions_player_strict(comment.get(\"body\", \"\"))\n",
+    "        if has_mention:\n",
+    "            flair_mention_counts[flair] += 1\n",
+    "\n",
+    "print(\"Player mention rate by flair:\\n\")\n",
+    "print(f\"{'Flair':<25} {'Mentions':>12} {'Total':>12} {'Rate':>8}\")\n",
+    "print(\"-\" * 60)\n",
+    "\n",
+    "for flair, total in flair_total_counts.most_common(10):\n",
+    "    mentions = flair_mention_counts[flair]\n",
+    "    rate = mentions / total * 100\n",
+    "    print(f\"{flair:<25} {mentions:>12,} {total:>12,} {rate:>7.1f}%\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "173fadf1",
+   "metadata": {},
+   "source": [
+    "## Combined Coverage Analysis\n",
+    "\n",
+    "For comments without explicit player mentions, can post titles provide attribution?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "fe56bb52",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Combined coverage:\n",
+      "\n",
+      "  Comment + Title mention: 1,726,086 (25.1%)\n",
+      "  Comment only:            1,112,655 (16.2%)\n",
+      "  Title only:              2,120,662 (30.8%)\n",
+      "  Neither:                 1,924,312 (28.0%)\n",
+      "\n",
+      "  Total attributable:      4,959,403 (72.0%)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Track: comment has mention, title has mention, both, neither\n",
+    "\n",
+    "comment_only = 0\n",
+    "title_only = 0\n",
+    "both = 0\n",
+    "neither = 0\n",
+    "\n",
+    "with open(COMMENTS_PATH) as f:\n",
+    "    for line in f:\n",
+    "        comment = json.loads(line)\n",
+    "        link_id = comment.get(\"link_id\", \"\")\n",
+    "        post_id = link_id.replace(\"t3_\", \"\")\n",
+    "        \n",
+    "        post = posts_lookup.get(post_id)\n",
+    "        if not post:\n",
+    "            continue\n",
+    "        \n",
+    "        comment_mention, _ = mentions_player_strict(comment.get(\"body\", \"\"))\n",
+    "        title_mention, _ = mentions_player_strict(post.get(\"title\", \"\"))\n",
+    "        \n",
+    "        if comment_mention and title_mention:\n",
+    "            both += 1\n",
+    "        elif comment_mention:\n",
+    "            comment_only += 1\n",
+    "        elif title_mention:\n",
+    "            title_only += 1\n",
+    "        else:\n",
+    "            neither += 1\n",
+    "\n",
+    "total = comment_only + title_only + both + neither\n",
+    "\n",
+    "print(\"Combined coverage:\\n\")\n",
+    "print(f\"  Comment + Title mention: {both:,} ({both/total*100:.1f}%)\")\n",
+    "print(f\"  Comment only:            {comment_only:,} ({comment_only/total*100:.1f}%)\")\n",
+    "print(f\"  Title only:              {title_only:,} ({title_only/total*100:.1f}%)\")\n",
+    "print(f\"  Neither:                 {neither:,} ({neither/total*100:.1f}%)\")\n",
+    "print(f\"\\n  Total attributable:      {both + comment_only + title_only:,} ({(both + comment_only + title_only)/total*100:.1f}%)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed501d1d",
+   "metadata": {},
+   "source": [
+    "## Summary & Recommendation\n",
+    "\n",
+    "### Key Findings\n",
+    "\n",
+    "| Metric | Value |\n",
+    "|--------|-------|\n",
+    "| Posts downloaded | 92,531 |\n",
+    "| Date range | 2024-10-01 to 2025-06-29 |\n",
+    "| Join success rate | 99.9% |\n",
+    "\n",
+    "**Player Mention Rates (Strict Matching):**\n",
+    "\n",
+    "| Source | Mentions | Rate |\n",
+    "|--------|----------|------|\n",
+    "| Comment body | 2,841,666 | 41.2% |\n",
+    "| Post title | 49,346 | 53.3% |\n",
+    "\n",
+    "**Combined Coverage:**\n",
+    "\n",
+    "| Category | Comments | % |\n",
+    "|----------|----------|---|\n",
+    "| Comment + Title | 1,726,086 | 25.1% |\n",
+    "| Comment only | 1,112,655 | 16.2% |\n",
+    "| Title only (would be \"rescued\") | 2,120,662 | 30.8% |\n",
+    "| Neither | 1,924,312 | 28.0% |\n",
+    "\n",
+    "**Flair Analysis:**\n",
+    "\n",
+    "- 83.1% of posts have no flair — unreliable for filtering\n",
+    "- Game Threads: 22.5% of comments but only 35.5% player mention rate\n",
+    "- Flair-based filtering provides minimal signal improvement (~6pp)\n",
+    "\n",
+    "### Decision: Do Not Implement Post-Context Attribution\n",
+    "\n",
+    "**Rationale:**\n",
+    "\n",
+    "1. **2.84M player-mention comments is statistically robust** — no rescue needed\n",
+    "2. **Title-only attribution is noisy** — a comment on a \"LeBron\" post may not mention LeBron at all\n",
+    "3. **Flair filtering not worth it** — marginal signal improvement doesn't justify join complexity\n",
+    "4. **Budget fit** — 2.84M comments × ~$0.00005/comment ≈ $142, well within $200 ceiling\n",
+    "\n",
+    "### Pipeline Implication\n",
+    "\n",
+    "The `CommentPipeline` filters on **comment body player mentions only**. Posts data is not required."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6addda33",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/03_posts_context_evaluation.ipynb
+++ b/notebooks/03_posts_context_evaluation.ipynb
@@ -121,7 +121,7 @@
     "max_date = datetime.fromtimestamp(max(timestamps))\n",
     "print(f\"Date range: {min_date.date()} to {max_date.date()}\")\n",
     "\n",
-    "print(f\"\\nField completeness:\")\n",
+    "print(\"\\nField completeness:\")\n",
     "fields = [\"id\", \"title\", \"link_flair_text\", \"author_flair_text\", \"score\", \"num_comments\"]\n",
     "for field in fields:\n",
     "    present = sum(1 for p in posts if p.get(field) is not None)\n",
@@ -364,7 +364,7 @@
     "        if mentions_player_strict(body)[0]:\n",
     "            comments_strict += 1\n",
     "\n",
-    "print(f\"\\nComment player mentions:\")\n",
+    "print(\"\\nComment player mentions:\")\n",
     "print(f\"  Original: {comments_original:,} ({comments_original/comment_count*100:.1f}%)\")\n",
     "print(f\"  Strict:   {comments_strict:,} ({comments_strict/comment_count*100:.1f}%)\")\n",
     "print(f\"  Diff:     {comments_original - comments_strict:,} ({(comments_original - comments_strict)/comment_count*100:.1f}%)\")"

--- a/scripts/download_posts.py
+++ b/scripts/download_posts.py
@@ -1,0 +1,199 @@
+"""
+Download Reddit posts from Arctic Shift API.
+
+This script downloads posts from r/nba for the 2024-25 NBA season.
+Unlike download_comments.py, this script does not support resume - if interrupted,
+delete the output file and restart.
+
+Usage:
+    # Download posts
+    uv run python -m scripts.download_posts
+
+    # Force restart (delete existing file)
+    uv run python -m scripts.download_posts --force
+"""
+
+import argparse
+import json
+import logging
+import os
+import time
+from datetime import datetime
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from pipeline.arctic_shift import ArcticShiftClient
+from utils.constants import (
+    PRIMARY_SUBREDDIT,
+    RAW_DATA_SUBDIR,
+    SEASON_END_DATE,
+    SEASON_START_DATE,
+)
+from utils.formatting import format_duration
+
+# -----------------------------------------------------------------------------
+# Logging setup
+# -----------------------------------------------------------------------------
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s | %(levelname)-8s | %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+
+# -----------------------------------------------------------------------------
+# Helper functions
+# -----------------------------------------------------------------------------
+def get_data_dir() -> Path:
+    """
+    Get the data directory from environment or use default.
+
+    Returns:
+        Path to data directory.
+    """
+    load_dotenv()
+    data_dir = os.getenv("DATA_DIR", "./data")
+    return Path(data_dir)
+
+
+def date_to_epoch(date_str: str) -> int:
+    """
+    Convert ISO date string to Unix timestamp.
+
+    Args:
+        date_str: Date in YYYY-MM-DD format.
+
+    Returns:
+        Unix timestamp (seconds since epoch).
+    """
+    dt = datetime.strptime(date_str, "%Y-%m-%d")
+    return int(dt.timestamp())
+
+
+# -----------------------------------------------------------------------------
+# Download logic
+# -----------------------------------------------------------------------------
+def download_posts(
+    client: ArcticShiftClient,
+    output_path: Path,
+    start_timestamp: int,
+    end_timestamp: int,
+) -> int:
+    """
+    Download all posts for r/nba within the date range.
+
+    Uses ArcticShiftClient's generator-based API for memory-efficient
+    streaming to disk.
+
+    Args:
+        client: ArcticShiftClient instance.
+        output_path: Path to write JSONL file.
+        start_timestamp: Start of date range (Unix timestamp).
+        end_timestamp: End of date range (Unix timestamp).
+
+    Returns:
+        Total number of posts downloaded.
+    """
+    total_count = 0
+    last_timestamp = start_timestamp
+
+    with open(output_path, "w") as f:
+        for post in client.fetch_posts(
+            subreddit=PRIMARY_SUBREDDIT,
+            after=start_timestamp,
+            before=end_timestamp,
+        ):
+            f.write(json.dumps(post) + "\n")
+            total_count += 1
+
+            last_timestamp = post.get("created_utc", last_timestamp)
+
+            # Progress logging every 1000 posts
+            if total_count % 1000 == 0:
+                logger.info(
+                    f"  Progress: {total_count:,} posts "
+                    f"(up to {datetime.fromtimestamp(last_timestamp).date()})"
+                )
+
+    return total_count
+
+
+def main() -> None:
+    """
+    Main entry point - download r/nba posts.
+
+    Flow:
+        1. Parse CLI arguments
+        2. Check for existing file (delete if --force)
+        3. Download posts
+        4. Print summary
+    """
+    parser = argparse.ArgumentParser(
+        description="Download r/nba posts from Arctic Shift API"
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Delete existing file and restart",
+    )
+    args = parser.parse_args()
+
+    # Setup paths
+    data_dir = get_data_dir()
+    raw_dir = data_dir / RAW_DATA_SUBDIR
+    raw_dir.mkdir(parents=True, exist_ok=True)
+
+    output_path = raw_dir / f"r_{PRIMARY_SUBREDDIT}_posts.jsonl"
+
+    # Handle existing file
+    if output_path.exists():
+        if args.force:
+            output_path.unlink()
+            logger.info(f"Deleted existing file: {output_path}")
+        else:
+            logger.error(
+                f"Output file already exists: {output_path}\n"
+                "Use --force to delete and restart."
+            )
+            return
+
+    # Convert season dates to timestamps
+    start_ts = date_to_epoch(SEASON_START_DATE)
+    end_ts = date_to_epoch(SEASON_END_DATE)
+
+    logger.info("=" * 60)
+    logger.info("NBA Hate Tracker - Posts Download")
+    logger.info("=" * 60)
+    logger.info(f"Date range: {SEASON_START_DATE} to {SEASON_END_DATE}")
+    logger.info(f"Subreddit: r/{PRIMARY_SUBREDDIT}")
+    logger.info(f"Output: {output_path}")
+    logger.info("=" * 60)
+
+    start_time = time.time()
+
+    with ArcticShiftClient() as client:
+        count = download_posts(
+            client=client,
+            output_path=output_path,
+            start_timestamp=start_ts,
+            end_timestamp=end_ts,
+        )
+
+    elapsed = time.time() - start_time
+    throughput = count / elapsed if elapsed > 0 else 0
+
+    logger.info("=" * 60)
+    logger.info("Download Complete!")
+    logger.info("=" * 60)
+    logger.info(
+        f"Total: {count:,} posts in {format_duration(elapsed)} "
+        f"({throughput:.1f} posts/sec)"
+    )
+    logger.info(f"Output: {output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `scripts/download_posts.py` for fetching r/nba posts via Arctic Shift API
- Add `config/players.yaml` with 85 tracked players and their aliases
- Add evaluation notebook analyzing post-context value for player attribution

## Key Findings from Evaluation

| Metric | Value |
|--------|-------|
| Posts downloaded | 92,531 |
| Comments with player mentions | 2,841,666 (41.2%) |
| Total attributable via combined sources | 72.0% |

**Decision:** Post-context attribution not implemented — 2.84M player-mention comments provides statistically robust dataset without added complexity.

## Test plan
- [x] Run `uv run ruff check scripts/download_posts.py` — passes
- [x] Run `uv run python -m scripts.download_posts --help` — shows usage
- [x] Verify `config/players.yaml` loads correctly in notebook