### PR TITLE
feat(pipeline): add player mention filtering

### DIFF
--- a/scripts/filter_player_mentions.py
+++ b/scripts/filter_player_mentions.py
@@ -1,0 +1,239 @@
+"""
+Filter comments to those mentioning tracked NBA players.
+
+Streams through cleaned JSONL, finds player mentions, and outputs
+only comments that mention at least one tracked player.
+
+Usage:
+    # Run with defaults (recommended)
+    uv run python -m scripts.filter_player_mentions
+
+    # Explicit paths
+    uv run python -m scripts.filter_player_mentions data/filtered/r_nba_cleaned.jsonl data/filtered/r_nba_player_mentions.jsonl
+
+    # Preview first 1K lines (for testing)
+    uv run python -m scripts.filter_player_mentions --limit 1000
+
+Input: Cleaned JSONL from clean_raw_comments.py
+Output: JSONL with only player-mentioning comments, plus mentioned_players field
+"""
+
+import argparse
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+
+from tqdm import tqdm
+
+from pipeline.processors import filter_player_mentions
+from utils.formatting import format_duration, format_size
+
+# -----------------------------------------------------------------------------
+# Logging setup
+# -----------------------------------------------------------------------------
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s | %(levelname)-8s | %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+
+# -----------------------------------------------------------------------------
+# Default paths
+# -----------------------------------------------------------------------------
+
+DEFAULT_INPUT = Path("data/filtered/r_nba_cleaned.jsonl")
+DEFAULT_OUTPUT = Path("data/filtered/r_nba_player_mentions.jsonl")
+
+
+# -----------------------------------------------------------------------------
+# Core processing
+# -----------------------------------------------------------------------------
+
+
+def count_lines(filepath: Path) -> int:
+    """
+    Count lines in a file for progress bar total.
+
+    Args:
+        filepath: Path to the file to count.
+
+    Returns:
+        Number of lines in the file.
+    """
+    logger.info(f"Counting lines in {filepath.name}...")
+    count = 0
+    with open(filepath) as f:
+        for _ in f:
+            count += 1
+    return count
+
+
+def process_file(
+    input_path: Path,
+    output_path: Path,
+    limit: int | None = None,
+    skip_line_count: bool = False,
+) -> tuple[dict[str, int], float]:
+    """
+    Stream process a JSONL file, filtering for player mentions.
+
+    Args:
+        input_path: Path to input JSONL file.
+        output_path: Path to write filtered JSONL.
+        limit: Optional max lines to process (for testing).
+        skip_line_count: Skip counting lines (faster start, no progress %).
+
+    Returns:
+        Tuple of (stats dict, elapsed_seconds).
+    """
+    stats = {
+        "total": 0,
+        "accepted": 0,
+        "rejected": 0,
+        "malformed": 0,
+    }
+
+    # Get total for progress bar (unless skipped or limited)
+    if limit:
+        total = limit
+    elif skip_line_count:
+        total = None
+    else:
+        total = count_lines(input_path)
+
+    # Ensure output directory exists
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    logger.info(f"Processing {input_path.name}...")
+
+    start_time = time.time()
+
+    with open(input_path) as f_in, open(output_path, "w") as f_out:
+        lines = tqdm(f_in, total=total, desc="Filtering", unit=" lines")
+
+        for i, line in enumerate(lines):
+            if limit and i >= limit:
+                break
+
+            line = line.strip()
+            if not line:
+                continue
+
+            stats["total"] += 1
+
+            # Parse JSON
+            try:
+                comment = json.loads(line)
+            except json.JSONDecodeError:
+                stats["malformed"] += 1
+                continue
+
+            # Filter for player mentions
+            result = filter_player_mentions(comment)
+
+            if result is None:
+                stats["rejected"] += 1
+            else:
+                stats["accepted"] += 1
+                f_out.write(json.dumps(result) + "\n")
+
+    elapsed = time.time() - start_time
+    return stats, elapsed
+
+
+# -----------------------------------------------------------------------------
+# CLI
+# -----------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Main entry point with CLI argument handling."""
+    parser = argparse.ArgumentParser(
+        description="Filter comments to those mentioning tracked NBA players"
+    )
+    parser.add_argument(
+        "input",
+        type=Path,
+        nargs="?",
+        default=DEFAULT_INPUT,
+        help=f"Path to input JSONL file (default: {DEFAULT_INPUT})",
+    )
+    parser.add_argument(
+        "output",
+        type=Path,
+        nargs="?",
+        default=DEFAULT_OUTPUT,
+        help=f"Path to write filtered JSONL output (default: {DEFAULT_OUTPUT})",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Process only first N lines (for testing)",
+    )
+    parser.add_argument(
+        "--skip-line-count",
+        action="store_true",
+        help="Skip counting lines (faster start, but no progress percentage)",
+    )
+    args = parser.parse_args()
+
+    # Validate input exists
+    if not args.input.exists():
+        logger.error(f"Input file not found: {args.input}")
+        sys.exit(1)
+
+    # Log configuration
+    logger.info("=" * 60)
+    logger.info("Filter Player Mentions")
+    logger.info("=" * 60)
+    logger.info(f"Input:  {args.input}")
+    logger.info(f"Output: {args.output}")
+    if args.limit:
+        logger.info(f"Limit:  {args.limit:,} lines")
+    logger.info("=" * 60)
+
+    # Get input size before processing
+    input_size = args.input.stat().st_size
+
+    # Process
+    stats, elapsed = process_file(
+        input_path=args.input,
+        output_path=args.output,
+        limit=args.limit,
+        skip_line_count=args.skip_line_count,
+    )
+
+    # Get output size
+    output_size = args.output.stat().st_size if args.output.exists() else 0
+    throughput = stats["total"] / elapsed if elapsed > 0 else 0
+
+    # Report results
+    logger.info("=" * 60)
+    logger.info("Processing Complete")
+    logger.info("=" * 60)
+    logger.info(f"Total processed:      {stats['total']:,}")
+    logger.info(f"Accepted:             {stats['accepted']:,}")
+    logger.info(f"Rejected:             {stats['rejected']:,}")
+    if stats["malformed"] > 0:
+        logger.info(f"Malformed:            {stats['malformed']:,}")
+
+    if stats["total"] > 0:
+        acceptance_rate = (stats["accepted"] / stats["total"]) * 100
+        logger.info(f"Acceptance rate:      {acceptance_rate:.2f}%")
+
+    logger.info("")
+    logger.info(f"Input size:           {format_size(input_size)}")
+    logger.info(f"Output size:          {format_size(output_size)}")
+    logger.info("")
+    logger.info(f"Time elapsed:         {format_duration(elapsed)}")
+    logger.info(f"Throughput:           {throughput:,.0f} comments/sec")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -333,3 +333,66 @@ def mock_rate_limited_response(mock_api_response) -> Callable[[int, int, int], M
         return mock_api_response(data=data, headers=headers)
 
     return _create_response
+
+
+# ---------------------------------------------------------------------------
+# Player mention fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def player_mention_comment() -> dict:
+    """Comment that mentions a tracked player (LeBron)."""
+    return {
+        "id": "player123",
+        "body": "LeBron is washed, can't believe we traded for him",
+        "author": "hoopsfan42",
+        "author_flair_text": "Lakers",
+        "author_flair_css_class": "lakers",
+        "subreddit": "nba",
+        "created_utc": 1709251200,
+        "score": 42,
+        "controversiality": 0,
+        "parent_id": "t1_xyz789",
+        "link_id": "t3_post123",
+    }
+
+
+@pytest.fixture
+def no_player_mention_comment() -> dict:
+    """Comment with no tracked player mentions."""
+    return {
+        "id": "noplayer456",
+        "body": "Great game last night, really exciting finish",
+        "author": "casualfan",
+        "author_flair_text": None,
+        "author_flair_css_class": None,
+        "subreddit": "nba",
+        "created_utc": 1709251200,
+        "score": 10,
+        "controversiality": 0,
+        "parent_id": "t1_aaa111",
+        "link_id": "t3_post456",
+    }
+
+
+@pytest.fixture
+def short_alias_false_positive_comment() -> dict:
+    """
+    Comment with words containing short aliases as substrings.
+
+    Tests word boundary matching - 'AD' should not match 'advertisement'.
+    """
+    return {
+        "id": "falsepos789",
+        "body": "This advertisement for java programming is bad",
+        "author": "techfan",
+        "author_flair_text": None,
+        "author_flair_css_class": None,
+        "subreddit": "nba",
+        "created_utc": 1709251200,
+        "score": 5,
+        "controversiality": 0,
+        "parent_id": "t1_bbb222",
+        "link_id": "t3_post789",
+    }

--- a/tests/unit/test_player_config.py
+++ b/tests/unit/test_player_config.py
@@ -1,0 +1,69 @@
+"""
+Tests for player configuration loading.
+
+Tests cover loading from YAML, caching behavior, and data structure validation.
+"""
+
+from utils.player_config import load_player_config
+
+
+class TestLoadPlayerConfig:
+    """Tests for load_player_config function."""
+
+    def test_returns_tuple_of_dict_and_frozenset(self):
+        """Config loader returns correct data types."""
+        players, short_aliases = load_player_config()
+
+        assert isinstance(players, dict)
+        assert isinstance(short_aliases, frozenset)
+
+    def test_players_dict_has_aliases(self):
+        """Each player in config has a list of aliases."""
+        players, _ = load_player_config()
+
+        for player_name, aliases in players.items():
+            assert isinstance(player_name, str)
+            assert isinstance(aliases, list)
+            assert len(aliases) > 0, f"{player_name} should have at least one alias"
+
+    def test_lebron_exists_with_expected_aliases(self):
+        """LeBron James exists and has key aliases."""
+        players, _ = load_player_config()
+
+        assert "LeBron James" in players
+        lebron_aliases = players["LeBron James"]
+
+        # Check for some expected aliases
+        assert "lebron" in lebron_aliases
+        assert "bron" in lebron_aliases
+        assert "lbj" in lebron_aliases
+
+    def test_short_aliases_are_lowercase(self):
+        """All short aliases are stored in lowercase."""
+        _, short_aliases = load_player_config()
+
+        for alias in short_aliases:
+            assert alias == alias.lower(), f"Short alias '{alias}' should be lowercase"
+
+    def test_short_aliases_contains_expected_entries(self):
+        """Short aliases includes known entries requiring word boundaries."""
+        _, short_aliases = load_player_config()
+
+        # These require word boundary matching
+        expected = {"ad", "curry", "james", "green", "ja"}
+        assert expected.issubset(short_aliases)
+
+    def test_caching_returns_same_object(self):
+        """Multiple calls return the same cached object."""
+        result1 = load_player_config()
+        result2 = load_player_config()
+
+        # Same tuple object (not just equal values)
+        assert result1 is result2
+
+    def test_players_count_reasonable(self):
+        """Config has a reasonable number of players (sanity check)."""
+        players, _ = load_player_config()
+
+        # Should have dozens of players, but not thousands
+        assert 30 < len(players) < 200

--- a/tests/unit/test_player_matcher.py
+++ b/tests/unit/test_player_matcher.py
@@ -1,0 +1,219 @@
+"""
+Tests for player mention matching logic.
+
+Tests cover find_player_mentions, filter_player_mentions, word boundary
+handling, and integration with CommentPipeline.
+"""
+
+
+from pipeline.processors import (
+    CommentPipeline,
+    find_player_mentions,
+    filter_player_mentions,
+)
+
+
+class TestFindPlayerMentions:
+    """Tests for find_player_mentions function."""
+
+    def test_finds_player_by_full_name(self):
+        """Finds player when full name is mentioned."""
+        text = "I think LeBron James is the GOAT"
+        result = find_player_mentions(text)
+
+        assert "LeBron James" in result
+
+    def test_finds_player_by_nickname(self):
+        """Finds player when nickname is used."""
+        text = "Steph just hit another 3!"
+        result = find_player_mentions(text)
+
+        assert "Stephen Curry" in result
+
+    def test_case_insensitive_matching(self):
+        """Matching is case insensitive."""
+        texts = [
+            "LEBRON is washed",
+            "lebron is washed",
+            "LeBrOn is washed",
+        ]
+
+        for text in texts:
+            result = find_player_mentions(text)
+            assert "LeBron James" in result, f"Should match: {text}"
+
+    def test_returns_empty_list_for_no_mentions(self):
+        """Returns empty list when no players mentioned."""
+        text = "The game was really exciting last night"
+        result = find_player_mentions(text)
+
+        assert result == []
+
+    def test_returns_empty_list_for_empty_text(self):
+        """Handles empty string gracefully."""
+        assert find_player_mentions("") == []
+
+    def test_returns_empty_list_for_none(self):
+        """Handles None gracefully."""
+        assert find_player_mentions(None) == []
+
+    def test_finds_multiple_players(self):
+        """Finds all mentioned players in text."""
+        text = "LeBron passed to Curry who missed, KD got the rebound"
+        result = find_player_mentions(text)
+
+        assert "LeBron James" in result
+        assert "Stephen Curry" in result
+        assert "Kevin Durant" in result
+
+    def test_returns_each_player_once(self):
+        """Each player appears only once even if mentioned multiple times."""
+        text = "LeBron to LeBron, he's talking to himself about LeBron"
+        result = find_player_mentions(text)
+
+        assert result.count("LeBron James") == 1
+
+
+class TestWordBoundaryMatching:
+    """Tests for short alias word boundary handling."""
+
+    def test_ad_matches_standalone(self):
+        """Short alias 'AD' matches when standalone."""
+        text = "AD had a great game"
+        result = find_player_mentions(text)
+
+        assert "Anthony Davis" in result
+
+    def test_ad_does_not_match_in_advertisement(self):
+        """Short alias 'AD' doesn't match within 'advertisement'."""
+        text = "This advertisement is annoying"
+        result = find_player_mentions(text)
+
+        assert "Anthony Davis" not in result
+
+    def test_ja_matches_standalone(self):
+        """Short alias 'Ja' matches when standalone."""
+        text = "Ja is so athletic"
+        result = find_player_mentions(text)
+
+        assert "Ja Morant" in result
+
+    def test_ja_does_not_match_in_java(self):
+        """Short alias 'Ja' doesn't match within 'java'."""
+        text = "I'm coding in java"
+        result = find_player_mentions(text)
+
+        assert "Ja Morant" not in result
+
+    def test_curry_matches_standalone(self):
+        """Short alias 'Curry' matches when standalone."""
+        text = "Curry for three!"
+        result = find_player_mentions(text)
+
+        assert "Stephen Curry" in result
+
+    def test_curry_does_not_match_in_currying(self):
+        """Short alias 'Curry' doesn't match within 'currying'."""
+        text = "I love currying functions in Haskell"
+        result = find_player_mentions(text)
+
+        assert "Stephen Curry" not in result
+
+    def test_green_matches_standalone(self):
+        """Short alias 'Green' matches when standalone."""
+        text = "Green got a technical"
+        result = find_player_mentions(text)
+
+        assert "Draymond Green" in result
+
+    def test_green_does_not_match_in_greenery(self):
+        """Short alias 'Green' doesn't match within 'greenery'."""
+        text = "The greenery in this park is beautiful"
+        result = find_player_mentions(text)
+
+        assert "Draymond Green" not in result
+
+
+class TestFilterPlayerMentions:
+    """Tests for filter_player_mentions function."""
+
+    def test_returns_none_for_no_mentions(self):
+        """Returns None when comment has no player mentions."""
+        comment = {"id": "123", "body": "Great game last night"}
+        result = filter_player_mentions(comment)
+
+        assert result is None
+
+    def test_returns_comment_with_mentions_field(self):
+        """Returns comment with mentioned_players field added."""
+        comment = {"id": "123", "body": "LeBron is washed"}
+        result = filter_player_mentions(comment)
+
+        assert result is not None
+        assert "mentioned_players" in result
+        assert "LeBron James" in result["mentioned_players"]
+
+    def test_preserves_original_fields(self):
+        """Original comment fields are preserved."""
+        comment = {
+            "id": "123",
+            "body": "LeBron is washed",
+            "author": "user1",
+            "score": 42,
+        }
+        result = filter_player_mentions(comment)
+
+        assert result["id"] == "123"
+        assert result["body"] == "LeBron is washed"
+        assert result["author"] == "user1"
+        assert result["score"] == 42
+
+    def test_does_not_mutate_original(self):
+        """Original comment dict is not modified."""
+        comment = {"id": "123", "body": "LeBron is washed"}
+        filter_player_mentions(comment)
+
+        assert "mentioned_players" not in comment
+
+    def test_handles_missing_body(self):
+        """Returns None when body field is missing."""
+        comment = {"id": "123"}
+        result = filter_player_mentions(comment)
+
+        assert result is None
+
+    def test_handles_empty_body(self):
+        """Returns None when body is empty string."""
+        comment = {"id": "123", "body": ""}
+        result = filter_player_mentions(comment)
+
+        assert result is None
+
+
+class TestPipelineIntegration:
+    """Tests for integration with CommentPipeline."""
+
+    def test_works_as_pipeline_step(self):
+        """filter_player_mentions works as a pipeline step."""
+        pipeline = CommentPipeline()
+        pipeline.add_step(filter_player_mentions)
+
+        comment = {"id": "123", "body": "LeBron played well"}
+        result = pipeline.process(comment)
+
+        assert result is not None
+        assert "mentioned_players" in result
+
+    def test_pipeline_tracks_rejection_stats(self):
+        """Pipeline tracks rejections from player filter."""
+        pipeline = CommentPipeline()
+        pipeline.add_step(filter_player_mentions)
+
+        # Process one with mention, one without
+        pipeline.process({"id": "1", "body": "LeBron scored 30"})
+        pipeline.process({"id": "2", "body": "Great game last night"})
+
+        stats = pipeline.stats
+        assert stats["total"] == 2
+        assert stats["accepted"] == 1
+        assert stats["rejected_filter_player_mentions"] == 1

--- a/utils/player_config.py
+++ b/utils/player_config.py
@@ -1,0 +1,39 @@
+"""
+Player configuration loading from YAML.
+
+This module provides cached access to player aliases and short alias lists
+from config/players.yaml for player mention detection.
+"""
+
+from functools import lru_cache
+from pathlib import Path
+
+import yaml
+
+
+CONFIG_PATH = Path(__file__).parent.parent / "config" / "players.yaml"
+
+
+@lru_cache(maxsize=1)
+def load_player_config() -> tuple[dict[str, list[str]], frozenset[str]]:
+    """
+    Load players and short_aliases from config/players.yaml.
+
+    Returns:
+        Tuple of (players dict, short_aliases frozenset).
+        - players: Dict mapping player name to list of aliases.
+        - short_aliases: Frozenset of aliases requiring word boundary matching.
+
+    Raises:
+        FileNotFoundError: If config file doesn't exist.
+        yaml.YAMLError: If config file is invalid YAML.
+    """
+    with open(CONFIG_PATH) as f:
+        config = yaml.safe_load(f)
+
+    players = config.get("players", {})
+    short_aliases = frozenset(
+        alias.lower() for alias in config.get("short_aliases", [])
+    )
+
+    return players, short_aliases


### PR DESCRIPTION
## Description

Extract player mention matching logic from notebook into reusable pipeline functions. This enables filtering comments to those mentioning tracked NBA players, with proper word boundary handling for short aliases (like "AD", "Curry") to avoid false positives.

## Changes

- Add `utils/player_config.py` with cached YAML config loading
- Add `find_player_mentions()` and `filter_player_mentions()` to `pipeline/processors.py`
- Add `scripts/filter_player_mentions.py` CLI script for filtering JSONL files
- Add 31 tests covering config loading, matcher logic, and word boundary handling
- Add player mention fixtures to `tests/conftest.py`

## Testing

- [x] All tests pass (`uv run pytest`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Added tests for new functionality (if applicable)
- [x] Manually verified changes work as expected

## Checklist

- [x] PR title follows format: `type(scope): subject`
- [x] Commits follow [git-strategy.md](docs/git-strategy.md)
- [x] No large data files included
- [x] Documentation updated (if applicable)

## Notes

Usage:
```bash
# Filter with limit for testing
uv run python -m scripts.filter_player_mentions --limit 1000

# Run with defaults
uv run python -m scripts.filter_player_mentions
```

Output format adds `mentioned_players` field to matching comments:
```json
{
  "id": "abc123",
  "body": "LeBron is washed",
  "mentioned_players": ["LeBron James"],
  ...
}
```