### PR TITLE
feat(pipeline): add core batch module for sentiment classification

### DIFF
--- a/notebooks/04_cost_analysis.ipynb
+++ b/notebooks/04_cost_analysis.ipynb
@@ -391,35 +391,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "body-length-dist",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Comment body length (characters):\n",
-      "  Min: 4\n",
-      "  Max: 1985\n",
-      "  Mean: 167\n",
-      "  Median: 106\n",
-      "  P95: 533\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Analyze comment body length distribution\n",
-    "body_lengths = [len(c[\"body\"]) for c in sample_comments]\n",
-    "\n",
-    "import statistics\n",
-    "print(\"Comment body length (characters):\")\n",
-    "print(f\"  Min: {min(body_lengths)}\")\n",
-    "print(f\"  Max: {max(body_lengths)}\")\n",
-    "print(f\"  Mean: {statistics.mean(body_lengths):.0f}\")\n",
-    "print(f\"  Median: {statistics.median(body_lengths):.0f}\")\n",
-    "print(f\"  P95: {sorted(body_lengths)[int(len(body_lengths) * 0.95)]:.0f}\")"
-   ]
+   "outputs": [],
+   "source": "import statistics\n\n# Analyze comment body length distribution\nbody_lengths = [len(c[\"body\"]) for c in sample_comments]\n\nprint(\"Comment body length (characters):\")\nprint(f\"  Min: {min(body_lengths)}\")\nprint(f\"  Max: {max(body_lengths)}\")\nprint(f\"  Mean: {statistics.mean(body_lengths):.0f}\")\nprint(f\"  Median: {statistics.median(body_lengths):.0f}\")\nprint(f\"  P95: {sorted(body_lengths)[int(len(body_lengths) * 0.95)]:.0f}\")"
   },
   {
    "cell_type": "markdown",
@@ -1716,109 +1692,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "id": "10d46001",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running validation (this will take a minute)...\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Validating: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 23/23 [00:49<00:00,  2.13s/it]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Validation complete!\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "import json as json_lib\n",
-    "\n",
-    "def parse_minimal_response(text: str) -> dict:\n",
-    "    \"\"\"Parse minimal JSON response.\"\"\"\n",
-    "    try:\n",
-    "        # Handle potential markdown wrapping\n",
-    "        clean = text.strip()\n",
-    "        if clean.startswith(\"```\"):\n",
-    "            clean = clean.split(\"```\")[1]\n",
-    "            if clean.startswith(\"json\"):\n",
-    "                clean = clean[4:]\n",
-    "        return json_lib.loads(clean)\n",
-    "    except:\n",
-    "        return {\"s\": \"error\", \"c\": 0, \"p\": None}\n",
-    "\n",
-    "def parse_original_response(text: str) -> dict:\n",
-    "    \"\"\"Parse original JSON response.\"\"\"\n",
-    "    try:\n",
-    "        clean = text.strip()\n",
-    "        if clean.startswith(\"```\"):\n",
-    "            clean = clean.split(\"```\")[1]\n",
-    "            if clean.startswith(\"json\"):\n",
-    "                clean = clean[4:]\n",
-    "        data = json_lib.loads(clean)\n",
-    "        # Normalize to minimal format\n",
-    "        sentiment_map = {\"positive\": \"pos\", \"negative\": \"neg\", \"neutral\": \"neu\"}\n",
-    "        return {\n",
-    "            \"s\": sentiment_map.get(data.get(\"sentiment\", \"\"), data.get(\"sentiment\", \"\")[:3]),\n",
-    "            \"c\": data.get(\"confidence\", 0),\n",
-    "            \"p\": data.get(\"target_player\")\n",
-    "        }\n",
-    "    except:\n",
-    "        return {\"s\": \"error\", \"c\": 0, \"p\": None}\n",
-    "\n",
-    "# Run validation\n",
-    "results = []\n",
-    "\n",
-    "print(\"Running validation (this will take a minute)...\\n\")\n",
-    "for i, test in enumerate(tqdm(VALIDATION_SET, desc=\"Validating\")):\n",
-    "    # Minimal prompt\n",
-    "    minimal_resp = client.messages.create(\n",
-    "        model=MODEL,\n",
-    "        max_tokens=50,\n",
-    "        temperature=0.0,\n",
-    "        messages=[{\"role\": \"user\", \"content\": build_minimal_prompt(test[\"text\"])}]\n",
-    "    )\n",
-    "    minimal_parsed = parse_minimal_response(minimal_resp.content[0].text)\n",
-    "    \n",
-    "    # Original prompt (for comparison)\n",
-    "    original_resp = client.messages.create(\n",
-    "        model=MODEL,\n",
-    "        max_tokens=150,\n",
-    "        temperature=0.0,\n",
-    "        system=SYSTEM_PROMPT,\n",
-    "        messages=[{\"role\": \"user\", \"content\": build_user_message(test[\"text\"])}]\n",
-    "    )\n",
-    "    original_parsed = parse_original_response(original_resp.content[0].text)\n",
-    "    \n",
-    "    results.append({\n",
-    "        \"text\": test[\"text\"],\n",
-    "        \"expected\": test[\"expected\"],\n",
-    "        \"expected_player\": test[\"player\"],\n",
-    "        \"minimal\": minimal_parsed,\n",
-    "        \"original\": original_parsed,\n",
-    "    })\n",
-    "\n",
-    "print(\"Validation complete!\")"
-   ]
+   "outputs": [],
+   "source": "import json as json_lib\n\ndef parse_minimal_response(text: str) -> dict:\n    \"\"\"Parse minimal JSON response.\"\"\"\n    try:\n        # Handle potential markdown wrapping\n        clean = text.strip()\n        if clean.startswith(\"```\"):\n            clean = clean.split(\"```\")[1]\n            if clean.startswith(\"json\"):\n                clean = clean[4:]\n        return json_lib.loads(clean)\n    except (json_lib.JSONDecodeError, ValueError):\n        return {\"s\": \"error\", \"c\": 0, \"p\": None}\n\ndef parse_original_response(text: str) -> dict:\n    \"\"\"Parse original JSON response.\"\"\"\n    try:\n        clean = text.strip()\n        if clean.startswith(\"```\"):\n            clean = clean.split(\"```\")[1]\n            if clean.startswith(\"json\"):\n                clean = clean[4:]\n        data = json_lib.loads(clean)\n        # Normalize to minimal format\n        sentiment_map = {\"positive\": \"pos\", \"negative\": \"neg\", \"neutral\": \"neu\"}\n        return {\n            \"s\": sentiment_map.get(data.get(\"sentiment\", \"\"), data.get(\"sentiment\", \"\")[:3]),\n            \"c\": data.get(\"confidence\", 0),\n            \"p\": data.get(\"target_player\")\n        }\n    except (json_lib.JSONDecodeError, KeyError):\n        return {\"s\": \"error\", \"c\": 0, \"p\": None}\n\n# Run validation\nresults = []\n\nprint(\"Running validation (this will take a minute)...\\n\")\nfor i, test in enumerate(tqdm(VALIDATION_SET, desc=\"Validating\")):\n    # Minimal prompt\n    minimal_resp = client.messages.create(\n        model=MODEL,\n        max_tokens=50,\n        temperature=0.0,\n        messages=[{\"role\": \"user\", \"content\": build_minimal_prompt(test[\"text\"])}]\n    )\n    minimal_parsed = parse_minimal_response(minimal_resp.content[0].text)\n    \n    # Original prompt (for comparison)\n    original_resp = client.messages.create(\n        model=MODEL,\n        max_tokens=150,\n        temperature=0.0,\n        system=SYSTEM_PROMPT,\n        messages=[{\"role\": \"user\", \"content\": build_user_message(test[\"text\"])}]\n    )\n    original_parsed = parse_original_response(original_resp.content[0].text)\n    \n    results.append({\n        \"text\": test[\"text\"],\n        \"expected\": test[\"expected\"],\n        \"expected_player\": test[\"player\"],\n        \"minimal\": minimal_parsed,\n        \"original\": original_parsed,\n    })\n\nprint(\"Validation complete!\")"
   },
   {
    "cell_type": "code",
@@ -2308,115 +2186,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "c98266ce",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Testing haiku-3...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "haiku-3: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████| 23/23 [00:11<00:00,  1.97it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Testing haiku-3.5...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "haiku-3.5: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████| 23/23 [00:19<00:00,  1.21it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Testing haiku-4.5...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "haiku-4.5: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████| 23/23 [00:13<00:00,  1.74it/s]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Done!\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Test all models against validation set\n",
-    "import json as json_lib\n",
-    "\n",
-    "def parse_minimal_response(text: str) -> dict:\n",
-    "    \"\"\"Parse minimal JSON response.\"\"\"\n",
-    "    try:\n",
-    "        # Handle potential markdown wrapping\n",
-    "        clean = text.strip()\n",
-    "        if clean.startswith(\"```\"):\n",
-    "            clean = clean.split(\"```\")[1]\n",
-    "            if clean.startswith(\"json\"):\n",
-    "                clean = clean[4:]\n",
-    "        return json_lib.loads(clean)\n",
-    "    except:\n",
-    "        return {\"s\": \"error\", \"c\": 0, \"p\": None}\n",
-    "\n",
-    "model_results = {}\n",
-    "\n",
-    "for model_name, model_info in MODELS.items():\n",
-    "    print(f\"\\nTesting {model_name}...\")\n",
-    "    results = []\n",
-    "    \n",
-    "    for test in tqdm(VALIDATION_SET, desc=model_name):\n",
-    "        response = client.messages.create(\n",
-    "            model=model_info[\"id\"],\n",
-    "            max_tokens=50,\n",
-    "            temperature=0.0,\n",
-    "            messages=[{\"role\": \"user\", \"content\": build_minimal_prompt(test[\"text\"])}]\n",
-    "        )\n",
-    "        \n",
-    "        parsed = parse_minimal_response(response.content[0].text)\n",
-    "        results.append({\n",
-    "            \"text\": test[\"text\"],\n",
-    "            \"expected\": test[\"expected\"],\n",
-    "            \"predicted\": parsed[\"s\"],\n",
-    "            \"input_tokens\": response.usage.input_tokens,\n",
-    "            \"output_tokens\": response.usage.output_tokens,\n",
-    "        })\n",
-    "    \n",
-    "    model_results[model_name] = results\n",
-    "\n",
-    "print(\"\\nDone!\")"
-   ]
+   "outputs": [],
+   "source": "# Test all models against validation set\n\ndef parse_minimal_response(text: str) -> dict:\n    \"\"\"Parse minimal JSON response.\"\"\"\n    try:\n        # Handle potential markdown wrapping\n        clean = text.strip()\n        if clean.startswith(\"```\"):\n            clean = clean.split(\"```\")[1]\n            if clean.startswith(\"json\"):\n                clean = clean[4:]\n        return json_lib.loads(clean)\n    except (json_lib.JSONDecodeError, ValueError):\n        return {\"s\": \"error\", \"c\": 0, \"p\": None}\n\nmodel_results = {}\n\nfor model_name, model_info in MODELS.items():\n    print(f\"\\nTesting {model_name}...\")\n    results = []\n    \n    for test in tqdm(VALIDATION_SET, desc=model_name):\n        response = client.messages.create(\n            model=model_info[\"id\"],\n            max_tokens=50,\n            temperature=0.0,\n            messages=[{\"role\": \"user\", \"content\": build_minimal_prompt(test[\"text\"])}]\n        )\n        \n        parsed = parse_minimal_response(response.content[0].text)\n        results.append({\n            \"text\": test[\"text\"],\n            \"expected\": test[\"expected\"],\n            \"predicted\": parsed[\"s\"],\n            \"input_tokens\": response.usage.input_tokens,\n            \"output_tokens\": response.usage.output_tokens,\n        })\n    \n    model_results[model_name] = results\n\nprint(\"\\nDone!\")"
   },
   {
    "cell_type": "code",

--- a/notebooks/04_cost_analysis.ipynb
+++ b/notebooks/04_cost_analysis.ipynb
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 1,
    "id": "imports",
    "metadata": {},
    "outputs": [
@@ -81,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 2,
    "id": "load-config",
    "metadata": {},
    "outputs": [
@@ -1245,23 +1245,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 3,
    "id": "404a3f5e",
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== MINIMAL PROMPT ===\n",
-      "Classify sentiment toward NBA players. \n",
-      "Slang: nasty/sick/filthy=positive, washed/brick/fraud/cooked=negative, GOAT=positive.\n",
-      "\n",
-      "Comment: Hate to say it but this was peak Chokic the last minute. Awful decision\n",
-      "\n",
-      "Respond ONLY with JSON: {\"s\":\"pos|neg|neu\",\"c\":0.0-1.0,\"p\":\"Player Name\"|null}\n",
-      "\n",
-      "Prompt length: 287 chars\n"
+     "ename": "NameError",
+     "evalue": "name 'sample_comments' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[3]\u001b[39m\u001b[32m, line 12\u001b[39m\n\u001b[32m      4\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[33mf\u001b[39m\u001b[33m\"\"\"\u001b[39m\u001b[33mClassify sentiment toward NBA players. \u001b[39m\n\u001b[32m      5\u001b[39m \u001b[33mSlang: nasty/sick/filthy=positive, washed/brick/fraud/cooked=negative, GOAT=positive.\u001b[39m\n\u001b[32m      6\u001b[39m \n\u001b[32m      7\u001b[39m \u001b[33mComment: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mcomment_body\u001b[38;5;132;01m}\u001b[39;00m\n\u001b[32m      8\u001b[39m \n\u001b[32m      9\u001b[39m \u001b[33mRespond ONLY with JSON: \u001b[39m\u001b[38;5;130;01m{{\u001b[39;00m\u001b[33m\"\u001b[39m\u001b[33ms\u001b[39m\u001b[33m\"\u001b[39m\u001b[33m:\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mpos|neg|neu\u001b[39m\u001b[33m\"\u001b[39m\u001b[33m,\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mc\u001b[39m\u001b[33m\"\u001b[39m\u001b[33m:0.0-1.0,\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mp\u001b[39m\u001b[33m\"\u001b[39m\u001b[33m:\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mPlayer Name\u001b[39m\u001b[33m\"\u001b[39m\u001b[33m|null\u001b[39m\u001b[38;5;130;01m}}\u001b[39;00m\u001b[33m\"\"\"\u001b[39m\n\u001b[32m     11\u001b[39m \u001b[38;5;66;03m# Test\u001b[39;00m\n\u001b[32m---> \u001b[39m\u001b[32m12\u001b[39m example = \u001b[43msample_comments\u001b[49m[\u001b[32m0\u001b[39m][\u001b[33m\"\u001b[39m\u001b[33mbody\u001b[39m\u001b[33m\"\u001b[39m]\n\u001b[32m     13\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33m\"\u001b[39m\u001b[33m=== MINIMAL PROMPT ===\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m     14\u001b[39m \u001b[38;5;28mprint\u001b[39m(build_minimal_prompt(example))\n",
+      "\u001b[31mNameError\u001b[39m: name 'sample_comments' is not defined"
      ]
     }
    ],
@@ -1658,7 +1654,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 5,
    "id": "4ffe4cc0",
    "metadata": {},
    "outputs": [
@@ -2257,8 +2253,393 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b7cf5af2",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Model Comparison: Haiku 3 vs 3.5 vs 4.5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "223ff5c2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Batch API Pricing Comparison:\n",
+      "Model        Input ($/MTok)   Output ($/MTok) \n",
+      "--------------------------------------------\n",
+      "haiku-3      $0.125           $0.625          \n",
+      "haiku-3.5    $0.400           $2.000          \n",
+      "haiku-4.5    $0.500           $2.500          \n"
+     ]
+    }
+   ],
+   "source": [
+    "MODELS = {\n",
+    "    \"haiku-3\": {\n",
+    "        \"id\": \"claude-3-haiku-20240307\",\n",
+    "        \"batch_input\": 0.125,   # $/MTok (50% off $0.25)\n",
+    "        \"batch_output\": 0.625,  # $/MTok (50% off $1.25)\n",
+    "    },\n",
+    "    \"haiku-3.5\": {\n",
+    "        \"id\": \"claude-3-5-haiku-20241022\", \n",
+    "        \"batch_input\": 0.40,    # $/MTok (50% off $0.80)\n",
+    "        \"batch_output\": 2.00,   # $/MTok (50% off $4.00)\n",
+    "    },\n",
+    "    \"haiku-4.5\": {\n",
+    "        \"id\": \"claude-haiku-4-5-20251001\",\n",
+    "        \"batch_input\": 0.50,    # $/MTok (50% off $1.00)\n",
+    "        \"batch_output\": 2.50,   # $/MTok (50% off $5.00)\n",
+    "    },\n",
+    "}\n",
+    "\n",
+    "print(\"Batch API Pricing Comparison:\")\n",
+    "print(f\"{'Model':<12} {'Input ($/MTok)':<16} {'Output ($/MTok)':<16}\")\n",
+    "print(\"-\" * 44)\n",
+    "for name, info in MODELS.items():\n",
+    "    print(f\"{name:<12} ${info['batch_input']:<15.3f} ${info['batch_output']:<15.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c98266ce",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Testing haiku-3...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "haiku-3: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████| 23/23 [00:11<00:00,  1.97it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Testing haiku-3.5...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "haiku-3.5: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████| 23/23 [00:19<00:00,  1.21it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Testing haiku-4.5...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "haiku-4.5: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████| 23/23 [00:13<00:00,  1.74it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Done!\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Test all models against validation set\n",
+    "import json as json_lib\n",
+    "\n",
+    "def parse_minimal_response(text: str) -> dict:\n",
+    "    \"\"\"Parse minimal JSON response.\"\"\"\n",
+    "    try:\n",
+    "        # Handle potential markdown wrapping\n",
+    "        clean = text.strip()\n",
+    "        if clean.startswith(\"```\"):\n",
+    "            clean = clean.split(\"```\")[1]\n",
+    "            if clean.startswith(\"json\"):\n",
+    "                clean = clean[4:]\n",
+    "        return json_lib.loads(clean)\n",
+    "    except:\n",
+    "        return {\"s\": \"error\", \"c\": 0, \"p\": None}\n",
+    "\n",
+    "model_results = {}\n",
+    "\n",
+    "for model_name, model_info in MODELS.items():\n",
+    "    print(f\"\\nTesting {model_name}...\")\n",
+    "    results = []\n",
+    "    \n",
+    "    for test in tqdm(VALIDATION_SET, desc=model_name):\n",
+    "        response = client.messages.create(\n",
+    "            model=model_info[\"id\"],\n",
+    "            max_tokens=50,\n",
+    "            temperature=0.0,\n",
+    "            messages=[{\"role\": \"user\", \"content\": build_minimal_prompt(test[\"text\"])}]\n",
+    "        )\n",
+    "        \n",
+    "        parsed = parse_minimal_response(response.content[0].text)\n",
+    "        results.append({\n",
+    "            \"text\": test[\"text\"],\n",
+    "            \"expected\": test[\"expected\"],\n",
+    "            \"predicted\": parsed[\"s\"],\n",
+    "            \"input_tokens\": response.usage.input_tokens,\n",
+    "            \"output_tokens\": response.usage.output_tokens,\n",
+    "        })\n",
+    "    \n",
+    "    model_results[model_name] = results\n",
+    "\n",
+    "print(\"\\nDone!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "3be326dc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "======================================================================\n",
+      "MODEL ACCURACY COMPARISON\n",
+      "======================================================================\n",
+      "\n",
+      "Model        Accuracy     Errors    \n",
+      "----------------------------------\n",
+      "haiku-3      78.3        % 5/23\n",
+      "haiku-3.5    91.3        % 2/23\n",
+      "haiku-4.5    95.7        % 1/23\n",
+      "\n",
+      "Model        Positive     Negative     Neutral     \n",
+      "------------------------------------------------\n",
+      "haiku-3      88%          83%          33%         \n",
+      "haiku-3.5    100%         83%          100%        \n",
+      "haiku-4.5    100%         92%          100%        \n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"=\" * 70)\n",
+    "print(\"MODEL ACCURACY COMPARISON\")\n",
+    "print(\"=\" * 70)\n",
+    "\n",
+    "print(f\"\\n{'Model':<12} {'Accuracy':<12} {'Errors':<10}\")\n",
+    "print(\"-\" * 34)\n",
+    "\n",
+    "for model_name, results in model_results.items():\n",
+    "    correct = sum(1 for r in results if r[\"predicted\"] == r[\"expected\"])\n",
+    "    accuracy = correct / len(results) * 100\n",
+    "    errors = len(results) - correct\n",
+    "    print(f\"{model_name:<12} {accuracy:<12.1f}% {errors}/{len(results)}\")\n",
+    "\n",
+    "# Breakdown by sentiment\n",
+    "print(f\"\\n{'Model':<12} {'Positive':<12} {'Negative':<12} {'Neutral':<12}\")\n",
+    "print(\"-\" * 48)\n",
+    "\n",
+    "for model_name, results in model_results.items():\n",
+    "    accs = []\n",
+    "    for sentiment in [\"pos\", \"neg\", \"neu\"]:\n",
+    "        subset = [r for r in results if r[\"expected\"] == sentiment]\n",
+    "        if subset:\n",
+    "            acc = sum(1 for r in subset if r[\"predicted\"] == sentiment) / len(subset) * 100\n",
+    "            accs.append(f\"{acc:.0f}%\")\n",
+    "        else:\n",
+    "            accs.append(\"N/A\")\n",
+    "    print(f\"{model_name:<12} {accs[0]:<12} {accs[1]:<12} {accs[2]:<12}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
    "id": "973d03fc",
    "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Haiku 3.5 Errors:\n",
+      "\n",
+      "  Text: \"Wow Simmons shot a three, league fucked\"\n",
+      "  Expected: neg | Predicted: pos\n",
+      "\n",
+      "  Text: \"ADisney only shows up in the bubble\"\n",
+      "  Expected: neg | Predicted: pos\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Show Haiku 3.5 errors\n",
+    "print(\"Haiku 3.5 Errors:\")\n",
+    "for r in model_results[\"haiku-3.5\"]:\n",
+    "    if r[\"predicted\"] != r[\"expected\"]:\n",
+    "        print(f\"\\n  Text: \\\"{r['text']}\\\"\")\n",
+    "        print(f\"  Expected: {r['expected']} | Predicted: {r['predicted']}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "728ca320",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "======================================================================\n",
+      "TOKEN USAGE COMPARISON\n",
+      "======================================================================\n",
+      "\n",
+      "Model        Avg Input    Avg Output  \n",
+      "------------------------------------\n",
+      "haiku-3      92.9         19.9        \n",
+      "haiku-3.5    92.9         25.5        \n",
+      "haiku-4.5    92.9         25.9        \n"
+     ]
+    }
+   ],
+   "source": [
+    "import statistics\n",
+    "\n",
+    "print(\"\\n\" + \"=\" * 70)\n",
+    "print(\"TOKEN USAGE COMPARISON\")\n",
+    "print(\"=\" * 70)\n",
+    "\n",
+    "print(f\"\\n{'Model':<12} {'Avg Input':<12} {'Avg Output':<12}\")\n",
+    "print(\"-\" * 36)\n",
+    "\n",
+    "for model_name, results in model_results.items():\n",
+    "    avg_input = statistics.mean(r[\"input_tokens\"] for r in results)\n",
+    "    avg_output = statistics.mean(r[\"output_tokens\"] for r in results)\n",
+    "    print(f\"{model_name:<12} {avg_input:<12.1f} {avg_output:<12.1f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "fda71fec",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "======================================================================\n",
+      "COST PROJECTION (1.94M comments)\n",
+      "======================================================================\n",
+      "\n",
+      "haiku-3:\n",
+      "  Input:  $22.51\n",
+      "  Output: $24.08\n",
+      "  TOTAL:  $46.60\n",
+      "\n",
+      "haiku-3.5:\n",
+      "  Input:  $72.04\n",
+      "  Output: $98.82\n",
+      "  TOTAL:  $170.86\n",
+      "\n",
+      "haiku-4.5:\n",
+      "  Input:  $90.05\n",
+      "  Output: $125.63\n",
+      "  TOTAL:  $215.68\n",
+      "\n",
+      "----------------------------------------\n",
+      "Model        Total Cost   vs Haiku 4.5   \n",
+      "----------------------------------------\n",
+      "haiku-3      $46.60       -$189.13 (80% cheaper)\n",
+      "haiku-3.5    $170.86      -$64.87 (28% cheaper)\n",
+      "haiku-4.5    $215.68      (baseline)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"\\n\" + \"=\" * 70)\n",
+    "print(\"COST PROJECTION (1.94M comments)\")\n",
+    "print(\"=\" * 70)\n",
+    "\n",
+    "COMMENT_COUNT = 1_939_268\n",
+    "\n",
+    "for model_name, results in model_results.items():\n",
+    "    model_info = MODELS[model_name]\n",
+    "    avg_input = statistics.mean(r[\"input_tokens\"] for r in results)\n",
+    "    avg_output = statistics.mean(r[\"output_tokens\"] for r in results)\n",
+    "    \n",
+    "    total_input = avg_input * COMMENT_COUNT\n",
+    "    total_output = avg_output * COMMENT_COUNT\n",
+    "    \n",
+    "    input_cost = (total_input / 1_000_000) * model_info[\"batch_input\"]\n",
+    "    output_cost = (total_output / 1_000_000) * model_info[\"batch_output\"]\n",
+    "    total_cost = input_cost + output_cost\n",
+    "    \n",
+    "    print(f\"\\n{model_name}:\")\n",
+    "    print(f\"  Input:  ${input_cost:.2f}\")\n",
+    "    print(f\"  Output: ${output_cost:.2f}\")\n",
+    "    print(f\"  TOTAL:  ${total_cost:.2f}\")\n",
+    "\n",
+    "# Summary table\n",
+    "print(\"\\n\" + \"-\" * 40)\n",
+    "print(f\"{'Model':<12} {'Total Cost':<12} {'vs Haiku 4.5':<15}\")\n",
+    "print(\"-\" * 40)\n",
+    "\n",
+    "baseline_cost = 235.73\n",
+    "for model_name, results in model_results.items():\n",
+    "    model_info = MODELS[model_name]\n",
+    "    avg_input = statistics.mean(r[\"input_tokens\"] for r in results)\n",
+    "    avg_output = statistics.mean(r[\"output_tokens\"] for r in results)\n",
+    "    \n",
+    "    total_input = avg_input * COMMENT_COUNT\n",
+    "    total_output = avg_output * COMMENT_COUNT\n",
+    "    \n",
+    "    input_cost = (total_input / 1_000_000) * model_info[\"batch_input\"]\n",
+    "    output_cost = (total_output / 1_000_000) * model_info[\"batch_output\"]\n",
+    "    total_cost = input_cost + output_cost\n",
+    "    \n",
+    "    if model_name == \"haiku-4.5\":\n",
+    "        baseline_cost = total_cost\n",
+    "        print(f\"{model_name:<12} ${total_cost:<11.2f} (baseline)\")\n",
+    "    else:\n",
+    "        savings = baseline_cost - total_cost\n",
+    "        pct = (1 - total_cost / baseline_cost) * 100\n",
+    "        print(f\"{model_name:<12} ${total_cost:<11.2f} -${savings:.2f} ({pct:.0f}% cheaper)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e9d120c6",
+   "metadata": {},
+   "outputs": [],
    "source": []
   }
  ],

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -1,11 +1,15 @@
 """Pipeline module for data processing."""
 
 from .arctic_shift import ArcticShiftClient
+from .batch import build_prompt, calculate_cost, parse_response
 from .processors import CommentPipeline, extract_fields, has_valid_body
 
 __all__ = [
     "ArcticShiftClient",
     "CommentPipeline",
+    "build_prompt",
+    "calculate_cost",
     "extract_fields",
     "has_valid_body",
+    "parse_response",
 ]

--- a/pipeline/batch.py
+++ b/pipeline/batch.py
@@ -1,0 +1,104 @@
+"""Core batch processing functions for sentiment classification.
+
+Pure functions for prompt building, response parsing, and cost calculation.
+No API calls - designed for use with Anthropic Batch API.
+"""
+
+import json
+
+# Model configuration
+MODEL = "claude-haiku-4-5-20251001"
+TEMPERATURE = 0.0
+MAX_TOKENS = 50
+REQUESTS_PER_BATCH = 100_000
+
+# Batch API pricing (50% discount applied)
+INPUT_COST_PER_MTOK = 0.50  # $0.50 per million input tokens
+OUTPUT_COST_PER_MTOK = 2.50  # $2.50 per million output tokens
+
+
+def build_prompt(comment_body: str) -> str:
+    """
+    Build minimal prompt for sentiment classification.
+
+    Args:
+        comment_body: The raw Reddit comment text.
+
+    Returns:
+        The formatted prompt for the model.
+    """
+    return f"""Classify sentiment toward NBA players.
+Slang: nasty/sick/filthy=positive, washed/brick/fraud/cooked=negative, GOAT=positive.
+
+Comment: {comment_body}
+
+Respond ONLY with JSON: {{"s":"pos|neg|neu","c":0.0-1.0,"p":"Player Name"|null}}"""
+
+
+def parse_response(text: str) -> dict:
+    """
+    Parse the model response into a structured dict.
+
+    Handles three cases:
+    1. Valid JSON directly
+    2. JSON wrapped in markdown code blocks
+    3. Malformed responses
+
+    Args:
+        text: Raw text response from the model.
+
+    Returns:
+        Success: {"s": "pos|neg|neu", "c": float, "p": str|None}
+        Error: {"s": "error", "c": 0.0, "p": None, "raw": str}
+    """
+    if not text or not text.strip():
+        return {"s": "error", "c": 0.0, "p": None, "raw": text}
+
+    cleaned = text.strip()
+
+    # Handle markdown code blocks
+    if cleaned.startswith("```json"):
+        cleaned = cleaned[7:]
+    elif cleaned.startswith("```"):
+        cleaned = cleaned[3:]
+
+    if cleaned.endswith("```"):
+        cleaned = cleaned[:-3]
+
+    cleaned = cleaned.strip()
+
+    try:
+        result = json.loads(cleaned)
+
+        # Validate required fields
+        if "s" not in result:
+            return {"s": "error", "c": 0.0, "p": None, "raw": text}
+
+        # Normalize and validate sentiment value
+        sentiment = result.get("s", "")
+        if sentiment not in ("pos", "neg", "neu"):
+            return {"s": "error", "c": 0.0, "p": None, "raw": text}
+
+        return {
+            "s": result["s"],
+            "c": float(result.get("c", 0.0)),
+            "p": result.get("p"),
+        }
+    except (json.JSONDecodeError, ValueError, TypeError):
+        return {"s": "error", "c": 0.0, "p": None, "raw": text}
+
+
+def calculate_cost(input_tokens: int, output_tokens: int) -> float:
+    """
+    Calculate the USD cost for a batch API request.
+
+    Args:
+        input_tokens: Number of input tokens.
+        output_tokens: Number of output tokens.
+
+    Returns:
+        Total cost in USD.
+    """
+    input_cost = (input_tokens / 1_000_000) * INPUT_COST_PER_MTOK
+    output_cost = (output_tokens / 1_000_000) * OUTPUT_COST_PER_MTOK
+    return input_cost + output_cost

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -396,3 +396,65 @@ def short_alias_false_positive_comment() -> dict:
         "parent_id": "t1_bbb222",
         "link_id": "t3_post789",
     }
+
+
+# ---------------------------------------------------------------------------
+# Batch API / Sentiment response fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def valid_sentiment_responses() -> list[tuple[str, dict]]:
+    """
+    Valid JSON responses from sentiment classification.
+
+    Returns list of (raw_response, expected_parsed) tuples.
+    """
+    return [
+        (
+            '{"s": "pos", "c": 0.95, "p": "LeBron James"}',
+            {"s": "pos", "c": 0.95, "p": "LeBron James"},
+        ),
+        (
+            '{"s": "neg", "c": 0.8, "p": "Russell Westbrook"}',
+            {"s": "neg", "c": 0.8, "p": "Russell Westbrook"},
+        ),
+        (
+            '{"s": "neu", "c": 0.6, "p": null}',
+            {"s": "neu", "c": 0.6, "p": None},
+        ),
+        (
+            '{"s": "pos", "c": 0.9, "p": null}',
+            {"s": "pos", "c": 0.9, "p": None},
+        ),
+    ]
+
+
+@pytest.fixture
+def markdown_wrapped_responses() -> list[tuple[str, str, str | None]]:
+    """
+    Responses wrapped in markdown code blocks.
+
+    Returns list of (raw_response, expected_sentiment, expected_player) tuples.
+    """
+    return [
+        ('```json\n{"s": "pos", "c": 0.9, "p": "LeBron James"}\n```', "pos", "LeBron James"),
+        ('```\n{"s": "neg", "c": 0.75, "p": null}\n```', "neg", None),
+        ('```json{"s": "neu", "c": 0.5, "p": "Curry"}```', "neu", "Curry"),
+    ]
+
+
+@pytest.fixture
+def malformed_responses() -> list[str]:
+    """
+    Malformed responses that should return error dicts.
+
+    Includes: non-JSON, wrong field names, invalid values, etc.
+    """
+    return [
+        "not json at all",
+        '{"sentiment": "positive"}',  # Wrong field names
+        '{"s": "invalid", "c": 0.5}',  # Invalid sentiment value
+        "{malformed json",
+        "[]",  # Array instead of object
+    ]

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -1,0 +1,117 @@
+"""Tests for pipeline.batch module."""
+
+import pytest
+
+from pipeline.batch import build_prompt, calculate_cost, parse_response
+
+
+class TestBuildPrompt:
+    """Tests for build_prompt function."""
+
+    def test_format_contains_required_elements(self, valid_nba_comment: dict):
+        """Verify prompt contains classification instruction and JSON format."""
+        result = build_prompt(valid_nba_comment["body"])
+
+        assert "Classify sentiment" in result
+        assert "Comment:" in result
+        assert '"s":"pos|neg|neu"' in result
+
+    def test_preserves_comment_body(self, valid_nba_comment: dict):
+        """Verify comment body appears unchanged in output."""
+        body = valid_nba_comment["body"]
+        result = build_prompt(body)
+
+        assert body in result
+
+    def test_handles_special_characters(self):
+        """Verify special characters in comment are preserved."""
+        comment = 'Curry 3pt% is "insane" & he\'s cooking!'
+        result = build_prompt(comment)
+
+        assert comment in result
+
+    def test_handles_empty_string(self):
+        """Verify empty comment still produces valid prompt."""
+        result = build_prompt("")
+
+        assert "Classify sentiment" in result
+        assert "Comment:" in result
+
+
+class TestParseResponse:
+    """Tests for parse_response function."""
+
+    def test_valid_json(self, valid_sentiment_responses: list[tuple[str, dict]]):
+        """Verify valid JSON responses are parsed correctly."""
+        for raw_response, expected in valid_sentiment_responses:
+            result = parse_response(raw_response)
+            assert result == expected
+
+    def test_markdown_wrapped(
+        self, markdown_wrapped_responses: list[tuple[str, str, str | None]]
+    ):
+        """Verify markdown-wrapped JSON is handled correctly."""
+        for raw_response, expected_s, expected_p in markdown_wrapped_responses:
+            result = parse_response(raw_response)
+
+            assert result["s"] == expected_s
+            assert result["p"] == expected_p
+
+    def test_malformed_returns_error(self, malformed_responses: list[str]):
+        """Verify malformed responses return error dict with raw field."""
+        for raw_response in malformed_responses:
+            result = parse_response(raw_response)
+
+            assert result["s"] == "error"
+            assert result["c"] == 0.0
+            assert result["p"] is None
+            assert result["raw"] == raw_response
+
+    def test_empty_string(self):
+        """Verify empty string returns error dict."""
+        result = parse_response("")
+
+        assert result["s"] == "error"
+        assert result["c"] == 0.0
+        assert result["p"] is None
+        assert "raw" in result
+
+    def test_whitespace_only(self):
+        """Verify whitespace-only input returns error dict."""
+        result = parse_response("   \n\t  ")
+
+        assert result["s"] == "error"
+        assert result["c"] == 0.0
+        assert result["p"] is None
+
+
+class TestCalculateCost:
+    """Tests for calculate_cost function."""
+
+    def test_one_million_tokens_each(self):
+        """Verify cost for 1M input + 1M output tokens."""
+        # $0.50/M input + $2.50/M output = $3.00
+        cost = calculate_cost(input_tokens=1_000_000, output_tokens=1_000_000)
+        assert cost == pytest.approx(3.00)
+
+    def test_realistic_single_request(self):
+        """Verify cost for a realistic single request (~150 in, ~30 out)."""
+        cost = calculate_cost(input_tokens=150, output_tokens=30)
+
+        expected = (150 / 1_000_000) * 0.50 + (30 / 1_000_000) * 2.50
+        assert cost == pytest.approx(expected)
+
+    def test_zero_tokens(self):
+        """Verify zero tokens returns zero cost."""
+        cost = calculate_cost(input_tokens=0, output_tokens=0)
+        assert cost == 0.0
+
+    def test_only_input(self):
+        """Verify cost with only input tokens."""
+        cost = calculate_cost(input_tokens=1_000_000, output_tokens=0)
+        assert cost == pytest.approx(0.50)
+
+    def test_only_output(self):
+        """Verify cost with only output tokens."""
+        cost = calculate_cost(input_tokens=0, output_tokens=1_000_000)
+        assert cost == pytest.approx(2.50)


### PR DESCRIPTION
## Summary
- Add `pipeline/batch.py` with pure functions for Anthropic Batch API integration
- Implement minimal prompt format validated in cost analysis (80% token reduction vs full system prompt)
- Add response parsing with support for JSON, markdown-wrapped, and malformed responses
- Include cost calculation using batch API pricing ($0.50/M input, $2.50/M output)

## Changes
| File | Description |
|------|-------------|
| `pipeline/batch.py` | Core module with `build_prompt`, `parse_response`, `calculate_cost` |
| `tests/unit/test_batch.py` | 14 unit tests using shared fixtures |
| `tests/conftest.py` | New fixtures for sentiment response testing |
| `pipeline/__init__.py` | Export new functions |
| `notebooks/04_cost_analysis.ipynb` | Haiku model comparison and prompt optimization analysis |

## Test plan
- [x] All 131 unit tests passing
- [x] Ruff linting clean
- [x] Module imports verified

Closes #11