### PR TITLE
feat(pipeline): add batch API submission and results collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,7 @@ build/
 Thumbs.db
 
 # Project specific
-data/raw/
-data/filtered/
+data/
 *.jsonl
 *.json
 *.csv

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -1,7 +1,17 @@
 """Pipeline module for data processing."""
 
 from .arctic_shift import ArcticShiftClient
-from .batch import build_prompt, calculate_cost, format_batch_request, parse_response
+from .batch import (
+    build_prompt,
+    calculate_cost,
+    format_batch_request,
+    get_batch_status,
+    init_state,
+    load_state,
+    parse_response,
+    save_state,
+    submit_batch,
+)
 from .processors import CommentPipeline, extract_fields, has_valid_body
 
 __all__ = [
@@ -11,6 +21,11 @@ __all__ = [
     "calculate_cost",
     "extract_fields",
     "format_batch_request",
+    "get_batch_status",
     "has_valid_body",
+    "init_state",
+    "load_state",
     "parse_response",
+    "save_state",
+    "submit_batch",
 ]

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -4,6 +4,7 @@ from .arctic_shift import ArcticShiftClient
 from .batch import (
     build_prompt,
     calculate_cost,
+    download_results,
     format_batch_request,
     get_batch_status,
     init_state,
@@ -19,6 +20,7 @@ __all__ = [
     "CommentPipeline",
     "build_prompt",
     "calculate_cost",
+    "download_results",
     "extract_fields",
     "format_batch_request",
     "get_batch_status",

--- a/scripts/collect_results.py
+++ b/scripts/collect_results.py
@@ -1,0 +1,510 @@
+"""
+Collect batch results from the Anthropic Batch API.
+
+Polls for batch completion, downloads results, and produces the final
+sentiment.parquet file with parsed classifications joined to comment metadata.
+
+Usage:
+    # Check status and download completed batches (no waiting)
+    uv run python -m scripts.collect_results --no-wait
+
+    # Poll until all batches complete (default: check every 60s, max 24h)
+    uv run python -m scripts.collect_results
+
+    # Custom poll settings
+    uv run python -m scripts.collect_results --poll-interval 120 --max-wait 3600
+
+Input: data/batches/state.json, data/batches/requests/batch_NNN.jsonl
+Output:
+    - data/batches/responses/batch_NNN_results.jsonl (per batch)
+    - data/processed/sentiment.parquet (final joined output)
+    - data/batches/failed_requests.jsonl (if any failures)
+"""
+
+import argparse
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+
+import polars as pl
+from dotenv import load_dotenv
+
+from pipeline.batch import (
+    STATE_FILENAME,
+    calculate_cost,
+    download_results,
+    get_batch_status,
+    load_state,
+    parse_response,
+    save_state,
+)
+from utils.paths import get_batches_dir, get_filtered_dir, get_processed_dir
+
+# -----------------------------------------------------------------------------
+# Logging setup
+# -----------------------------------------------------------------------------
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s | %(levelname)-8s | %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+# -----------------------------------------------------------------------------
+# Constants
+# -----------------------------------------------------------------------------
+
+RESPONSES_SUBDIR = "responses"
+FILTERED_FILENAME = "r_nba_player_mentions.jsonl"
+OUTPUT_FILENAME = "sentiment.parquet"
+FAILED_FILENAME = "failed_requests.jsonl"
+
+# Output columns for sentiment.parquet
+OUTPUT_COLUMNS = [
+    "comment_id",
+    "body",
+    "author",
+    "author_flair_text",
+    "author_flair_css_class",
+    "created_utc",
+    "score",
+    "mentioned_players",
+    "sentiment",
+    "confidence",
+    "sentiment_player",
+    "input_tokens",
+    "output_tokens",
+]
+
+
+# -----------------------------------------------------------------------------
+# Helper functions
+# -----------------------------------------------------------------------------
+
+
+def get_pending_batches(state: dict) -> list[dict]:
+    """
+    Get batches that haven't finished processing yet.
+
+    Args:
+        state: Current state dict.
+
+    Returns:
+        List of batch entries with status != "ended".
+    """
+    return [b for b in state.get("batches", []) if b.get("status") != "ended"]
+
+
+def get_downloadable_batches(state: dict) -> list[dict]:
+    """
+    Get batches that are complete but haven't had results downloaded.
+
+    Args:
+        state: Current state dict.
+
+    Returns:
+        List of batch entries with status == "ended" and results_downloaded == False.
+    """
+    return [
+        b
+        for b in state.get("batches", [])
+        if b.get("status") == "ended" and not b.get("results_downloaded", False)
+    ]
+
+
+def poll_batch_statuses(state: dict) -> int:
+    """
+    Update status for all pending batches.
+
+    Args:
+        state: Current state dict (modified in place).
+
+    Returns:
+        Number of batches that transitioned to "ended" status.
+    """
+    pending = get_pending_batches(state)
+    newly_completed = 0
+
+    for batch in pending:
+        batch_id = batch["batch_id"]
+        try:
+            status = get_batch_status(batch_id)
+            old_status = batch.get("status")
+            batch["status"] = status["processing_status"]
+            batch["request_counts"] = status["request_counts"]
+            batch["ended_at"] = status["ended_at"]
+            batch["results_url"] = status["results_url"]
+
+            if old_status != "ended" and status["processing_status"] == "ended":
+                newly_completed += 1
+                logger.info(
+                    f"Batch {batch['batch_num']} completed: "
+                    f"{status['request_counts']['succeeded']} succeeded, "
+                    f"{status['request_counts']['errored']} errored"
+                )
+            else:
+                logger.debug(
+                    f"Batch {batch['batch_num']}: {status['processing_status']}"
+                )
+
+        except RuntimeError as e:
+            logger.error(f"Failed to get status for batch {batch_id}: {e}")
+
+    return newly_completed
+
+
+def download_batch_results(batch: dict, responses_dir: Path) -> Path:
+    """
+    Download and save results for a single batch.
+
+    Args:
+        batch: Batch entry dict from state.
+        responses_dir: Directory to save results.
+
+    Returns:
+        Path to the saved results file.
+    """
+    batch_id = batch["batch_id"]
+    batch_num = batch["batch_num"]
+    output_file = responses_dir / f"batch_{batch_num:03d}_results.jsonl"
+
+    logger.info(f"Downloading results for batch {batch_num}...")
+
+    results = download_results(batch_id)
+
+    responses_dir.mkdir(parents=True, exist_ok=True)
+    with open(output_file, "w") as f:
+        for result in results:
+            f.write(json.dumps(result) + "\n")
+
+    succeeded = sum(1 for r in results if r["result_type"] == "succeeded")
+    errored = sum(1 for r in results if r["result_type"] != "succeeded")
+    logger.info(
+        f"  -> Saved {len(results)} results ({succeeded} succeeded, {errored} failed)"
+    )
+
+    return output_file
+
+
+def poll_until_complete(
+    state: dict,
+    state_path: Path,
+    responses_dir: Path,
+    poll_interval: int,
+    max_wait: int,
+) -> bool:
+    """
+    Poll until all batches complete or timeout.
+
+    Downloads results as batches complete.
+
+    Args:
+        state: Current state dict (modified in place).
+        state_path: Path to save state file.
+        responses_dir: Directory to save results.
+        poll_interval: Seconds between status checks.
+        max_wait: Maximum wait time in seconds.
+
+    Returns:
+        True if all batches completed, False if timeout.
+    """
+    start_time = time.time()
+
+    while True:
+        # Check for newly completed batches
+        poll_batch_statuses(state)
+        save_state(state, state_path)
+
+        # Download any completed batches
+        downloadable = get_downloadable_batches(state)
+        for batch in downloadable:
+            try:
+                download_batch_results(batch, responses_dir)
+                batch["results_downloaded"] = True
+                save_state(state, state_path)
+            except RuntimeError as e:
+                logger.error(f"Failed to download batch {batch['batch_num']}: {e}")
+
+        # Check if all done
+        pending = get_pending_batches(state)
+        if not pending:
+            logger.info("All batches completed!")
+            return True
+
+        # Check timeout
+        elapsed = time.time() - start_time
+        if elapsed >= max_wait:
+            logger.warning(
+                f"Timeout after {elapsed:.0f}s with {len(pending)} batches pending"
+            )
+            return False
+
+        # Wait before next poll
+        remaining = max_wait - elapsed
+        wait_time = min(poll_interval, remaining)
+        logger.info(
+            f"Waiting {wait_time:.0f}s... "
+            f"({len(pending)} batches pending, {remaining:.0f}s remaining)"
+        )
+        time.sleep(wait_time)
+
+
+def build_sentiment_dataframe(
+    responses_dir: Path, filtered_path: Path, state: dict
+) -> tuple[pl.DataFrame, list[dict]]:
+    """
+    Build sentiment DataFrame by joining results with comment metadata.
+
+    Args:
+        responses_dir: Directory containing batch_NNN_results.jsonl files.
+        filtered_path: Path to filtered comments JSONL file.
+        state: State dict to update with token totals.
+
+    Returns:
+        Tuple of (sentiment DataFrame, list of failed requests).
+    """
+    # Load all results
+    results_files = sorted(responses_dir.glob("batch_*_results.jsonl"))
+    if not results_files:
+        raise FileNotFoundError(f"No results files found in {responses_dir}")
+
+    logger.info(f"Loading results from {len(results_files)} files...")
+
+    all_results = []
+    failed_requests = []
+    total_input_tokens = 0
+    total_output_tokens = 0
+
+    for results_file in results_files:
+        with open(results_file) as f:
+            for line in f:
+                if not line.strip():
+                    continue
+                result = json.loads(line)
+
+                if result["result_type"] == "succeeded":
+                    parsed = parse_response(result["content"])
+                    all_results.append(
+                        {
+                            "id": result["custom_id"],
+                            "sentiment": parsed["s"],
+                            "confidence": parsed["c"],
+                            "sentiment_player": parsed.get("p"),
+                            "input_tokens": result["input_tokens"],
+                            "output_tokens": result["output_tokens"],
+                        }
+                    )
+                    total_input_tokens += result["input_tokens"]
+                    total_output_tokens += result["output_tokens"]
+                else:
+                    failed_requests.append(result)
+
+    logger.info(f"Loaded {len(all_results)} successful results")
+    if failed_requests:
+        logger.warning(f"Found {len(failed_requests)} failed requests")
+
+    # Update state with token totals
+    state["total_input_tokens"] = total_input_tokens
+    state["total_output_tokens"] = total_output_tokens
+    state["estimated_cost_usd"] = calculate_cost(
+        total_input_tokens, total_output_tokens
+    )
+
+    # Create results DataFrame
+    results_df = pl.DataFrame(all_results)
+
+    # Load comments with lazy evaluation
+    logger.info(f"Loading comments from {filtered_path}...")
+    comments_df = pl.scan_ndjson(filtered_path).select(
+        [
+            pl.col("id"),
+            pl.col("body"),
+            pl.col("author"),
+            pl.col("author_flair_text"),
+            pl.col("author_flair_css_class"),
+            pl.col("created_utc"),
+            pl.col("score"),
+            pl.col("mentioned_players"),
+        ]
+    )
+
+    # Join results with comments
+    logger.info("Joining results with comments...")
+    results_count = len(all_results)
+    joined_df = (
+        comments_df.join(results_df.lazy(), on="id", how="inner")
+        .rename({"id": "comment_id"})
+        .select(OUTPUT_COLUMNS)
+        .collect()
+    )
+
+    # Validate join didn't drop rows
+    joined_count = len(joined_df)
+    if joined_count < results_count:
+        dropped = results_count - joined_count
+        logger.warning(
+            f"Join dropped {dropped} results "
+            f"({dropped / results_count * 100:.1f}% - comments may be missing from filtered file)"
+        )
+
+    logger.info(f"Final DataFrame: {joined_count} rows")
+
+    return joined_df, failed_requests
+
+
+# -----------------------------------------------------------------------------
+# CLI
+# -----------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Main entry point with CLI argument handling."""
+    load_dotenv()
+
+    parser = argparse.ArgumentParser(
+        description="Collect batch results from Anthropic Batch API"
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=int,
+        default=60,
+        metavar="N",
+        help="Seconds between status checks (default: 60)",
+    )
+    parser.add_argument(
+        "--max-wait",
+        type=int,
+        default=86400,
+        metavar="N",
+        help="Maximum wait time in seconds (default: 86400 = 24h)",
+    )
+    parser.add_argument(
+        "--no-wait",
+        action="store_true",
+        help="Check once, download completed batches, and exit",
+    )
+    args = parser.parse_args()
+
+    # Setup paths
+    batches_dir = get_batches_dir()
+    state_path = batches_dir / STATE_FILENAME
+    responses_dir = batches_dir / RESPONSES_SUBDIR
+    filtered_path = get_filtered_dir() / FILTERED_FILENAME
+    processed_dir = get_processed_dir()
+    output_path = processed_dir / OUTPUT_FILENAME
+    failed_path = batches_dir / FAILED_FILENAME
+
+    logger.info("=" * 60)
+    logger.info("Collect Batch Results")
+    logger.info("=" * 60)
+    logger.info(f"State file:    {state_path}")
+    logger.info(f"Responses dir: {responses_dir}")
+    logger.info(f"Output file:   {output_path}")
+    logger.info("=" * 60)
+
+    # Load state
+    state = load_state(state_path)
+    batch_count = len(state.get("batches", []))
+
+    if batch_count == 0:
+        logger.error("No batches found in state. Run submit_batches.py first.")
+        sys.exit(1)
+
+    if not filtered_path.exists():
+        logger.error(f"Filtered comments file not found: {filtered_path}")
+        sys.exit(1)
+
+    logger.info(f"Found {batch_count} batch(es) in state")
+
+    # Handle --no-wait mode
+    if args.no_wait:
+        logger.info("Running in --no-wait mode (single check)")
+
+        # Update statuses
+        poll_batch_statuses(state)
+        save_state(state, state_path)
+
+        # Download completed batches
+        downloadable = get_downloadable_batches(state)
+        for batch in downloadable:
+            try:
+                download_batch_results(batch, responses_dir)
+                batch["results_downloaded"] = True
+                save_state(state, state_path)
+            except RuntimeError as e:
+                logger.error(f"Failed to download batch {batch['batch_num']}: {e}")
+
+        pending = get_pending_batches(state)
+        if pending:
+            logger.info(f"{len(pending)} batch(es) still pending")
+        else:
+            logger.info("All batches completed!")
+
+    else:
+        # Poll until complete or timeout
+        logger.info(f"Polling every {args.poll_interval}s (max {args.max_wait}s)...")
+        completed = poll_until_complete(
+            state, state_path, responses_dir, args.poll_interval, args.max_wait
+        )
+        if not completed:
+            logger.warning("Exiting with pending batches due to timeout")
+
+    # Check if we can build the final output
+    pending = get_pending_batches(state)
+    not_downloaded = [
+        b for b in state.get("batches", []) if not b.get("results_downloaded", False)
+    ]
+
+    if pending or not_downloaded:
+        logger.info(
+            f"Cannot build final output: {len(pending)} pending, "
+            f"{len(not_downloaded)} not downloaded"
+        )
+        sys.exit(0)
+
+    # Build final sentiment.parquet
+    logger.info("=" * 60)
+    logger.info("Building sentiment.parquet...")
+    logger.info("=" * 60)
+
+    try:
+        sentiment_df, failed_requests = build_sentiment_dataframe(
+            responses_dir, filtered_path, state
+        )
+
+        # Save parquet
+        processed_dir.mkdir(parents=True, exist_ok=True)
+        sentiment_df.write_parquet(output_path)
+        logger.info(f"Wrote {len(sentiment_df)} rows to {output_path}")
+
+        # Save failed requests
+        if failed_requests:
+            with open(failed_path, "w") as f:
+                for req in failed_requests:
+                    f.write(json.dumps(req) + "\n")
+            logger.warning(
+                f"Wrote {len(failed_requests)} failed requests to {failed_path}"
+            )
+
+        # Update and save final state
+        save_state(state, state_path)
+        logger.info("=" * 60)
+        logger.info("Summary")
+        logger.info("=" * 60)
+        logger.info(f"Total input tokens:  {state['total_input_tokens']:,}")
+        logger.info(f"Total output tokens: {state['total_output_tokens']:,}")
+        logger.info(f"Estimated cost:      ${state['estimated_cost_usd']:.2f}")
+
+    except FileNotFoundError as e:
+        logger.error(f"Missing file: {e}")
+        sys.exit(1)
+    except Exception as e:
+        logger.error(f"Failed to build output: {e}")
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_batches.sh
+++ b/scripts/run_batches.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+while true; do
+    echo "=== $(date) ==="
+    
+    uv run python -m scripts.collect_results --no-wait
+    
+    PROCESSING=$(cat data/batches/state.json | jq '[.batches[] | select(.status != "ended")] | length')
+    
+    if [ "$PROCESSING" -gt 0 ]; then
+        echo "$PROCESSING batch(es) still processing, waiting..."
+    else
+        uv run python -m scripts.submit_batches --batches 1 || break
+    fi
+    
+    TOTAL=$(cat data/batches/state.json | jq '.batches | length')
+    PENDING=$(cat data/batches/state.json | jq '[.batches[] | select(.status != "ended")] | length')
+    
+    echo "Progress: $TOTAL/20 submitted, $PENDING processing"
+    
+    if [ "$TOTAL" -eq 20 ] && [ "$PENDING" -eq 0 ]; then
+        echo "All batches complete!"
+        break
+    fi
+    
+    echo "Sleeping 30 minutes..."
+    sleep 1800
+done

--- a/scripts/submit_batches.py
+++ b/scripts/submit_batches.py
@@ -1,0 +1,393 @@
+"""
+Submit batch files to the Anthropic Batch API.
+
+Submits prepared batch request files to the Anthropic Batch API with
+state tracking for resumability. Supports dry-run mode for cost estimation.
+
+Usage:
+    # Dry run - validate and estimate costs (no API calls)
+    uv run python -m scripts.submit_batches --dry-run
+
+    # Submit first batch only (for testing)
+    uv run python -m scripts.submit_batches --batches 1
+
+    # Submit all pending batches
+    uv run python -m scripts.submit_batches
+
+    # Resume after interruption (automatically skips submitted batches)
+    uv run python -m scripts.submit_batches
+
+Input: data/batches/requests/batch_NNN.jsonl files
+Output: data/batches/state.json tracking file
+"""
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from datetime import datetime, timezone
+
+from dotenv import load_dotenv
+
+from pipeline.batch import (
+    INPUT_COST_PER_MTOK,
+    MAX_TOKENS,
+    OUTPUT_COST_PER_MTOK,
+    STATE_FILENAME,
+    calculate_cost,
+    load_state,
+    save_state,
+    submit_batch,
+)
+from utils.paths import get_batches_dir
+
+# -----------------------------------------------------------------------------
+# Logging setup
+# -----------------------------------------------------------------------------
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s | %(levelname)-8s | %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+
+# -----------------------------------------------------------------------------
+# Constants
+# -----------------------------------------------------------------------------
+
+REQUESTS_SUBDIR = "requests"
+AVG_INPUT_TOKENS = 60  # From notebook cost analysis
+
+
+# -----------------------------------------------------------------------------
+# Helper functions
+# -----------------------------------------------------------------------------
+
+
+def discover_batch_files(requests_dir: Path) -> list[Path]:
+    """
+    Discover batch files in the requests directory.
+
+    Args:
+        requests_dir: Path to directory containing batch_NNN.jsonl files.
+
+    Returns:
+        Sorted list of batch file paths.
+    """
+    if not requests_dir.exists():
+        return []
+
+    files = sorted(requests_dir.glob("batch_*.jsonl"))
+    return files
+
+
+def is_batch_submitted(state: dict, filename: str) -> bool:
+    """
+    Check if a batch file has already been submitted.
+
+    Args:
+        state: Current state dict.
+        filename: Batch filename to check.
+
+    Returns:
+        True if already submitted, False otherwise.
+    """
+    return any(b["request_file"] == filename for b in state.get("batches", []))
+
+
+def count_requests(batch_file: Path) -> int:
+    """
+    Count the number of requests in a batch file.
+
+    Args:
+        batch_file: Path to JSONL batch file.
+
+    Returns:
+        Number of non-empty lines (requests) in the file.
+    """
+    count = 0
+    with open(batch_file) as f:
+        for line in f:
+            if line.strip():
+                count += 1
+    return count
+
+
+def validate_batch_file(batch_file: Path) -> tuple[bool, str]:
+    """
+    Validate a batch file has valid JSONL with required fields.
+
+    Args:
+        batch_file: Path to JSONL batch file.
+
+    Returns:
+        Tuple of (is_valid, error_message).
+    """
+    try:
+        with open(batch_file) as f:
+            for i, line in enumerate(f, 1):
+                line = line.strip()
+                if not line:
+                    continue
+
+                try:
+                    request = json.loads(line)
+                except json.JSONDecodeError as e:
+                    return False, f"Line {i}: Invalid JSON - {e}"
+
+                if "custom_id" not in request:
+                    return False, f"Line {i}: Missing 'custom_id' field"
+                if "params" not in request:
+                    return False, f"Line {i}: Missing 'params' field"
+
+        return True, ""
+    except OSError as e:
+        return False, f"Cannot read file: {e}"
+
+
+def estimate_batch_cost(request_count: int) -> float:
+    """
+    Estimate cost for a batch based on request count.
+
+    Uses average input tokens from notebook analysis and MAX_TOKENS for output.
+
+    Args:
+        request_count: Number of requests in the batch.
+
+    Returns:
+        Estimated cost in USD.
+    """
+    total_input = request_count * AVG_INPUT_TOKENS
+    total_output = request_count * MAX_TOKENS
+    return calculate_cost(total_input, total_output)
+
+
+def extract_batch_num(filename: str) -> int:
+    """
+    Extract batch number from filename like 'batch_001.jsonl'.
+
+    Args:
+        filename: Batch filename.
+
+    Returns:
+        Batch number as integer.
+    """
+    # batch_001.jsonl -> 001 -> 1
+    stem = filename.replace(".jsonl", "")
+    num_str = stem.split("_")[1]
+    return int(num_str)
+
+
+# -----------------------------------------------------------------------------
+# Dry run
+# -----------------------------------------------------------------------------
+
+
+def dry_run(batch_files: list[Path], state: dict) -> None:
+    """
+    Validate batch files and estimate costs without making API calls.
+
+    Args:
+        batch_files: List of batch file paths.
+        state: Current state dict.
+    """
+    logger.info("DRY RUN MODE - No API calls will be made")
+    logger.info("=" * 60)
+
+    total_requests = 0
+    total_cost = 0.0
+    pending_files = []
+    skipped_files = []
+
+    for batch_file in batch_files:
+        filename = batch_file.name
+
+        if is_batch_submitted(state, filename):
+            skipped_files.append(filename)
+            continue
+
+        # Validate
+        is_valid, error = validate_batch_file(batch_file)
+        if not is_valid:
+            logger.error(f"Invalid batch file {filename}: {error}")
+            sys.exit(1)
+
+        # Count and estimate
+        request_count = count_requests(batch_file)
+        estimated_cost = estimate_batch_cost(request_count)
+
+        logger.info(
+            f"  {filename}: {request_count:,} requests, "
+            f"~${estimated_cost:.2f}"
+        )
+
+        total_requests += request_count
+        total_cost += estimated_cost
+        pending_files.append(filename)
+
+    logger.info("=" * 60)
+    logger.info("Summary")
+    logger.info("=" * 60)
+    logger.info(f"Already submitted:    {len(skipped_files)} batches")
+    logger.info(f"Pending submission:   {len(pending_files)} batches")
+    logger.info(f"Total requests:       {total_requests:,}")
+    logger.info(f"Estimated cost:       ${total_cost:.2f}")
+    logger.info("")
+    logger.info("Cost calculation assumptions:")
+    logger.info(f"  - Input tokens/request:  {AVG_INPUT_TOKENS}")
+    logger.info(f"  - Output tokens/request: {MAX_TOKENS} (max)")
+    logger.info(f"  - Input cost:  ${INPUT_COST_PER_MTOK}/M tokens")
+    logger.info(f"  - Output cost: ${OUTPUT_COST_PER_MTOK}/M tokens")
+
+
+# -----------------------------------------------------------------------------
+# Submission
+# -----------------------------------------------------------------------------
+
+
+def submit_batches(
+    batch_files: list[Path],
+    state: dict,
+    state_path: Path,
+    max_batches: int | None = None,
+) -> None:
+    """
+    Submit batch files to the Anthropic API.
+
+    Args:
+        batch_files: List of batch file paths.
+        state: Current state dict (will be modified).
+        state_path: Path to save state file.
+        max_batches: Maximum number of batches to submit (None = all).
+    """
+    pending = [
+        f for f in batch_files if not is_batch_submitted(state, f.name)
+    ]
+
+    if not pending:
+        logger.info("No new batches to submit")
+        return
+
+    if max_batches is not None:
+        pending = pending[:max_batches]
+
+    logger.info(f"Submitting {len(pending)} batch(es)...")
+    logger.info("=" * 60)
+
+    for batch_file in pending:
+        filename = batch_file.name
+        batch_num = extract_batch_num(filename)
+        request_count = count_requests(batch_file)
+
+        logger.info(f"Submitting {filename} ({request_count:,} requests)...")
+
+        try:
+            result = submit_batch(batch_file)
+
+            # Add to state
+            batch_entry = {
+                "batch_num": batch_num,
+                "batch_id": result["batch_id"],
+                "request_file": filename,
+                "status": result["processing_status"],
+                "submitted_at": datetime.now(timezone.utc).isoformat(),
+                "ended_at": result["ended_at"],
+                "results_url": result["results_url"],
+                "request_counts": result["request_counts"],
+                "results_downloaded": False,
+            }
+            state["batches"].append(batch_entry)
+
+            # Save state immediately
+            save_state(state, state_path)
+
+            logger.info(
+                f"  -> batch_id: {result['batch_id']}, "
+                f"status: {result['processing_status']}"
+            )
+
+        except KeyboardInterrupt:
+            logger.warning("Interrupted! Saving state...")
+            save_state(state, state_path)
+            sys.exit(1)
+
+        except Exception as e:
+            logger.error(f"Failed to submit {filename}: {e}")
+            save_state(state, state_path)
+            raise
+
+    logger.info("=" * 60)
+    logger.info(f"Submitted {len(pending)} batch(es)")
+    logger.info(f"State saved to: {state_path}")
+
+
+# -----------------------------------------------------------------------------
+# CLI
+# -----------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Main entry point with CLI argument handling."""
+    load_dotenv()
+    batches_dir = get_batches_dir()
+    default_requests_dir = batches_dir / REQUESTS_SUBDIR
+
+    parser = argparse.ArgumentParser(
+        description="Submit batch files to Anthropic Batch API"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate files and estimate cost without making API calls",
+    )
+    parser.add_argument(
+        "--batches",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Submit only first N pending batches",
+    )
+    parser.add_argument(
+        "--requests-dir",
+        type=Path,
+        default=None,
+        help=f"Directory containing batch files (default: {default_requests_dir})",
+    )
+    args = parser.parse_args()
+
+    # Apply defaults
+    requests_dir = args.requests_dir or default_requests_dir
+    state_path = batches_dir / STATE_FILENAME
+
+    # Discover batch files
+    batch_files = discover_batch_files(requests_dir)
+
+    if not batch_files:
+        logger.error(f"No batch files found in {requests_dir}")
+        sys.exit(1)
+
+    logger.info("=" * 60)
+    logger.info("Submit Batches to Anthropic API")
+    logger.info("=" * 60)
+    logger.info(f"Requests dir: {requests_dir}")
+    logger.info(f"State file:   {state_path}")
+    logger.info(f"Found:        {len(batch_files)} batch file(s)")
+    logger.info("=" * 60)
+
+    # Load state
+    state = load_state(state_path)
+    submitted_count = len(state.get("batches", []))
+    if submitted_count > 0:
+        logger.info(f"Resuming: {submitted_count} batch(es) already submitted")
+
+    if args.dry_run:
+        dry_run(batch_files, state)
+    else:
+        submit_batches(batch_files, state, state_path, max_batches=args.batches)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add `scripts/submit_batches.py` to submit prepared batch files to the Anthropic Batch API with state tracking for resumability
- Add `scripts/collect_results.py` to poll for batch completion, download results, and produce the final `sentiment.parquet` file
- Add `scripts/run_batches.sh` orchestration script to run the full pipeline (prepare → submit → collect)
- Add `download_results()` function to `pipeline/batch.py` with defensive handling for all result types
- Fix array response handling in `parse_response()` for multi-player comments

## Test plan

- [x] Run `uv run python -m scripts.submit_batches --dry-run` to validate batch files and estimate costs
- [x] Run `uv run python -m scripts.submit_batches --batches 1` to submit a single test batch
- [x] Run `uv run python -m scripts.collect_results --no-wait` to check status and download completed batches
- [x] Verify `data/batches/state.json` tracks batch status correctly
- [x] Verify `data/processed/sentiment.parquet` is created after all batches complete
- [x] Verify `data/batches/failed_requests.jsonl` captures any API failures