### PR TITLE
feat(pipeline): add bar race CSV export for Flourish

### DIFF
--- a/pipeline/aggregation.py
+++ b/pipeline/aggregation.py
@@ -445,6 +445,9 @@ def pivot_bar_race_wide(
     week_cols = sorted(
         [c for c in wide.columns if c not in {"attributed_player", "Label", "Category", "Image"}]
     )
+    wide = wide.with_columns(
+        [(pl.col(c) * 100).round(2) for c in week_cols]
+    )
     wide = wide.select(["Label", "Category", "Image"] + week_cols)
 
     return wide

--- a/scripts/export_bar_race.py
+++ b/scripts/export_bar_race.py
@@ -7,7 +7,7 @@ Flourish's bar chart race template expects.
 
 Usage:
     uv run python -m scripts.export_bar_race
-    uv run python -m scripts.export_bar_race --top-n 20 --min-comments 3000
+    uv run python -m scripts.export_bar_race --top-n 20 --min-ranking-comments 3000 --min-entry-comments 500
     uv run python -m scripts.export_bar_race --input data/dashboard/aggregates.json --output data/dashboard/bar_race.csv
 """
 
@@ -75,10 +75,16 @@ def main() -> None:
         help="Number of top players to include (default: 15)",
     )
     parser.add_argument(
-        "--min-comments",
+        "--min-ranking-comments",
         type=int,
         default=5000,
-        help="Minimum cumulative comments to show a player in a given week (default: 5000)",
+        help="Minimum cumulative comments to qualify for top-N ranking (default: 5000)",
+    )
+    parser.add_argument(
+        "--min-entry-comments",
+        type=int,
+        default=1000,
+        help="Minimum cumulative comments for a player's bar to appear (default: 1000)",
     )
     args = parser.parse_args()
 
@@ -98,7 +104,8 @@ def main() -> None:
     logger.info(f"Input:  {input_path}")
     logger.info(f"Output: {output_path}")
     logger.info(f"Top N:  {args.top_n}")
-    logger.info(f"Min comments: {args.min_comments}")
+    logger.info(f"Min ranking comments: {args.min_ranking_comments}")
+    logger.info(f"Min entry comments:   {args.min_entry_comments}")
     logger.info("=" * 60)
 
     # Load aggregates
@@ -114,7 +121,9 @@ def main() -> None:
 
     wide = pivot_bar_race_wide(
         cumulative, data["player_metadata"],
-        top_n=args.top_n, min_comments=args.min_comments,
+        top_n=args.top_n,
+        min_ranking_comments=args.min_ranking_comments,
+        min_entry_comments=args.min_entry_comments,
     )
 
     # Ensure output directory exists

--- a/scripts/export_bar_race.py
+++ b/scripts/export_bar_race.py
@@ -1,0 +1,137 @@
+"""
+Export bar race CSV for Flourish from aggregates.json.
+
+Reads precomputed weekly sentiment aggregates, computes cumulative
+negative-sentiment rates, and pivots into the wide CSV format that
+Flourish's bar chart race template expects.
+
+Usage:
+    uv run python -m scripts.export_bar_race
+    uv run python -m scripts.export_bar_race --top-n 20 --min-comments 3000
+    uv run python -m scripts.export_bar_race --input data/dashboard/aggregates.json --output data/dashboard/bar_race.csv
+"""
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+from pipeline.aggregation import (
+    compute_cumulative_metrics,
+    pivot_bar_race_wide,
+)
+from utils.paths import get_dashboard_dir
+
+# -----------------------------------------------------------------------------
+# Logging setup
+# -----------------------------------------------------------------------------
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s | %(levelname)-8s | %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+
+# -----------------------------------------------------------------------------
+# Default filenames (directories come from utils/paths)
+# -----------------------------------------------------------------------------
+
+DEFAULT_INPUT_FILENAME = "aggregates.json"
+DEFAULT_OUTPUT_FILENAME = "bar_race.csv"
+
+
+# -----------------------------------------------------------------------------
+# CLI
+# -----------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Main entry point for bar race CSV export."""
+    default_input = get_dashboard_dir() / DEFAULT_INPUT_FILENAME
+    default_output = get_dashboard_dir() / DEFAULT_OUTPUT_FILENAME
+
+    parser = argparse.ArgumentParser(
+        description="Export bar race CSV for Flourish from aggregates.json"
+    )
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=None,
+        help=f"Path to aggregates JSON file (default: {default_input})",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help=f"Path to write bar race CSV (default: {default_output})",
+    )
+    parser.add_argument(
+        "--top-n",
+        type=int,
+        default=15,
+        help="Number of top players to include (default: 15)",
+    )
+    parser.add_argument(
+        "--min-comments",
+        type=int,
+        default=5000,
+        help="Minimum cumulative comments to show a player in a given week (default: 5000)",
+    )
+    args = parser.parse_args()
+
+    # Apply defaults after parsing
+    input_path = args.input or default_input
+    output_path = args.output or default_output
+
+    # Validate input exists
+    if not input_path.exists():
+        logger.error(f"Input file not found: {input_path}")
+        sys.exit(1)
+
+    # Log configuration
+    logger.info("=" * 60)
+    logger.info("Bar Race CSV Export")
+    logger.info("=" * 60)
+    logger.info(f"Input:  {input_path}")
+    logger.info(f"Output: {output_path}")
+    logger.info(f"Top N:  {args.top_n}")
+    logger.info(f"Min comments: {args.min_comments}")
+    logger.info("=" * 60)
+
+    # Load aggregates
+    with open(input_path) as f:
+        data = json.load(f)
+
+    # Transform
+    cumulative = compute_cumulative_metrics(data["player_temporal"])
+    logger.info(
+        f"Computed cumulative metrics: {cumulative['attributed_player'].n_unique()} "
+        f"players x {cumulative['week'].n_unique()} weeks"
+    )
+
+    wide = pivot_bar_race_wide(
+        cumulative, data["player_metadata"],
+        top_n=args.top_n, min_comments=args.min_comments,
+    )
+
+    # Ensure output directory exists
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Write CSV
+    wide.write_csv(output_path)
+
+    # Summary
+    week_cols = [c for c in wide.columns if c not in {"Label", "Category", "Image"}]
+    logger.info("=" * 60)
+    logger.info("Summary")
+    logger.info("=" * 60)
+    logger.info(f"Players: {wide.height}")
+    logger.info(f"Weeks:   {len(week_cols)}")
+    logger.info(f"Output:  {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -9,8 +9,11 @@ import polars as pl
 
 from pipeline.aggregation import (
     aggregate_sentiment,
+    compute_cumulative_metrics,
     compute_metrics,
     extract_team_from_flair,
+    mask_below_threshold,
+    pivot_bar_race_wide,
     resolve_player,
 )
 
@@ -312,3 +315,271 @@ class TestAggregateTeamConference:
 
         assert team_by_name["Los Angeles Lakers"]["conference"] == "West"
         assert team_by_name["Boston Celtics"]["conference"] == "East"
+
+
+# ---------------------------------------------------------------------------
+# Bar race export tests
+# ---------------------------------------------------------------------------
+
+
+def _make_temporal_records(
+    players_weeks: dict[str, list[tuple[str, int, int]]],
+) -> list[dict]:
+    """Build player_temporal-shaped dicts for testing.
+
+    Args:
+        players_weeks: Mapping of player name to list of
+            (week_str, neg_count, comment_count) tuples.
+
+    Returns:
+        List of dicts matching the player_temporal schema.
+    """
+    records = []
+    for player, weeks in players_weeks.items():
+        for week_str, neg, total in weeks:
+            records.append({
+                "attributed_player": player,
+                "week": week_str,
+                "neg_count": neg,
+                "pos_count": total - neg,
+                "neu_count": 0,
+                "comment_count": total,
+                "neg_rate": round(neg / total, 4) if total else 0,
+                "pos_rate": round((total - neg) / total, 4) if total else 0,
+                "net_sentiment": 0.0,
+                "polarization": 0.0,
+            })
+    return records
+
+
+class TestComputeCumulativeMetrics:
+    """Tests for compute_cumulative_metrics function."""
+
+    def test_excludes_stub_week(self):
+        """The maximum week (stub) is excluded from the output."""
+        records = _make_temporal_records({
+            "Player A": [
+                ("2024-10-07 00:00:00", 5, 50),
+                ("2024-10-14 00:00:00", 10, 100),
+                ("2024-10-21 00:00:00", 2, 10),  # stub (max week)
+            ],
+        })
+        result = compute_cumulative_metrics(records)
+        weeks = result["week"].to_list()
+        from datetime import date
+        assert date(2024, 10, 21) not in weeks
+        assert len(weeks) == 2
+
+    def test_cumulative_sums_correct(self):
+        """Running neg and total counts accumulate across weeks."""
+        records = _make_temporal_records({
+            "Player A": [
+                ("2024-10-07 00:00:00", 5, 50),
+                ("2024-10-14 00:00:00", 10, 100),
+                ("2024-10-21 00:00:00", 1, 10),  # stub
+            ],
+        })
+        result = compute_cumulative_metrics(records)
+        rows = result.sort("week").to_dicts()
+
+        assert rows[0]["cum_neg"] == 5
+        assert rows[0]["cum_total"] == 50
+        assert rows[1]["cum_neg"] == 15
+        assert rows[1]["cum_total"] == 150
+
+    def test_fills_missing_weeks(self):
+        """A player missing from a week gets zero new counts, cumulative carries forward."""
+        records = _make_temporal_records({
+            "Player A": [
+                ("2024-10-07 00:00:00", 5, 50),
+                # gap at 2024-10-14
+                ("2024-10-21 00:00:00", 10, 100),
+                ("2024-10-28 00:00:00", 1, 10),  # stub
+            ],
+            "Player B": [
+                ("2024-10-07 00:00:00", 3, 30),
+                ("2024-10-14 00:00:00", 7, 70),
+                ("2024-10-21 00:00:00", 2, 20),
+                ("2024-10-28 00:00:00", 1, 10),  # stub
+            ],
+        })
+        result = compute_cumulative_metrics(records)
+        a_rows = result.filter(
+            pl.col("attributed_player") == "Player A"
+        ).sort("week").to_dicts()
+
+        # Player A has 3 rows (all non-stub weeks)
+        assert len(a_rows) == 3
+        # Week 2 (gap): cumulative should equal week 1 values
+        assert a_rows[1]["cum_neg"] == 5
+        assert a_rows[1]["cum_total"] == 50
+        # Week 3: adds actual data
+        assert a_rows[2]["cum_neg"] == 15
+        assert a_rows[2]["cum_total"] == 150
+
+    def test_cum_neg_rate_rounded(self):
+        """Cumulative neg_rate is rounded to 4 decimal places."""
+        records = _make_temporal_records({
+            "Player A": [
+                ("2024-10-07 00:00:00", 1, 3),
+                ("2024-10-14 00:00:00", 1, 1),  # stub
+            ],
+        })
+        result = compute_cumulative_metrics(records)
+        rate = result["cum_neg_rate"][0]
+        assert rate == 0.3333
+
+    def test_single_player_single_week(self):
+        """Minimal input: one player, two weeks (one real + one stub)."""
+        records = _make_temporal_records({
+            "Solo": [
+                ("2024-10-07 00:00:00", 4, 10),
+                ("2024-10-14 00:00:00", 1, 5),  # stub
+            ],
+        })
+        result = compute_cumulative_metrics(records)
+        assert result.height == 1
+        row = result.to_dicts()[0]
+        assert row["attributed_player"] == "Solo"
+        assert row["cum_neg"] == 4
+        assert row["cum_total"] == 10
+        assert row["cum_neg_rate"] == 0.4
+
+
+class TestMaskBelowThreshold:
+    """Tests for mask_below_threshold function."""
+
+    def test_below_threshold_is_null(self):
+        """Rows with cum_total below threshold get null cum_neg_rate."""
+        records = _make_temporal_records({
+            "Player A": [
+                ("2024-10-07 00:00:00", 50, 500),
+                ("2024-10-14 00:00:00", 60, 600),
+                ("2024-10-21 00:00:00", 1, 10),  # stub
+            ],
+        })
+        cumulative = compute_cumulative_metrics(records)
+        # cum_total after week 1: 500, week 2: 1100
+        masked = mask_below_threshold(cumulative, min_comments=1000)
+        rows = masked.sort("week").to_dicts()
+
+        assert rows[0]["cum_neg_rate"] is None  # 500 < 1000
+        assert rows[1]["cum_neg_rate"] is not None  # 1100 >= 1000
+
+    def test_above_threshold_preserved(self):
+        """Rows at or above threshold retain their cum_neg_rate."""
+        records = _make_temporal_records({
+            "Player A": [
+                ("2024-10-07 00:00:00", 100, 1000),
+                ("2024-10-14 00:00:00", 1, 10),  # stub
+            ],
+        })
+        cumulative = compute_cumulative_metrics(records)
+        masked = mask_below_threshold(cumulative, min_comments=1000)
+        row = masked.to_dicts()[0]
+        assert row["cum_neg_rate"] == 0.1
+
+    def test_custom_threshold(self):
+        """Custom min_comments threshold is respected."""
+        records = _make_temporal_records({
+            "Player A": [
+                ("2024-10-07 00:00:00", 25, 250),
+                ("2024-10-14 00:00:00", 30, 300),
+                ("2024-10-21 00:00:00", 1, 10),  # stub
+            ],
+        })
+        cumulative = compute_cumulative_metrics(records)
+        # cum_total: 250, 550
+        masked = mask_below_threshold(cumulative, min_comments=500)
+        rows = masked.sort("week").to_dicts()
+
+        assert rows[0]["cum_neg_rate"] is None  # 250 < 500
+        assert rows[1]["cum_neg_rate"] is not None  # 550 >= 500
+
+
+class TestPivotBarRaceWide:
+    """Tests for pivot_bar_race_wide function."""
+
+    def _build_test_data(self):
+        """Build test temporal records and metadata for pivot tests."""
+        records = _make_temporal_records({
+            "Player A": [
+                ("2024-10-07 00:00:00", 100, 1000),
+                ("2024-10-14 00:00:00", 150, 1500),
+                ("2024-10-21 00:00:00", 1, 10),  # stub
+            ],
+            "Player B": [
+                ("2024-10-07 00:00:00", 200, 1000),
+                ("2024-10-14 00:00:00", 250, 1500),
+                ("2024-10-21 00:00:00", 1, 10),  # stub
+            ],
+            "Player C": [
+                ("2024-10-07 00:00:00", 50, 1000),
+                ("2024-10-14 00:00:00", 80, 1500),
+                ("2024-10-21 00:00:00", 1, 10),  # stub
+            ],
+        })
+        metadata = {
+            "Player A": {
+                "team": "Team Alpha",
+                "headshot_url": "https://cdn.example.com/a.png",
+            },
+            "Player B": {
+                "team": "Team Beta",
+                "headshot_url": "https://cdn.example.com/b.png",
+            },
+            "Player C": {
+                "team": "Team Gamma",
+                "headshot_url": "https://cdn.example.com/c.png",
+            },
+        }
+        return records, metadata
+
+    def test_output_columns_structure(self):
+        """Output has Label, Category, Image, then date columns."""
+        records, metadata = self._build_test_data()
+        cumulative = compute_cumulative_metrics(records)
+        wide = pivot_bar_race_wide(cumulative, metadata, top_n=3, min_comments=0)
+
+        cols = wide.columns
+        assert cols[0] == "Label"
+        assert cols[1] == "Category"
+        assert cols[2] == "Image"
+        assert len(cols) == 5  # 3 meta + 2 weeks
+
+    def test_respects_top_n(self):
+        """Only top_n players appear in output."""
+        records, metadata = self._build_test_data()
+        cumulative = compute_cumulative_metrics(records)
+        wide = pivot_bar_race_wide(cumulative, metadata, top_n=2, min_comments=0)
+
+        assert wide.height == 2
+        labels = wide["Label"].to_list()
+        # Player B has highest final neg_rate, then Player A
+        assert "Player B" in labels
+        assert "Player A" in labels
+        assert "Player C" not in labels
+
+    def test_week_columns_are_iso_dates(self):
+        """Week column headers match YYYY-MM-DD format."""
+        import re
+
+        records, metadata = self._build_test_data()
+        cumulative = compute_cumulative_metrics(records)
+        wide = pivot_bar_race_wide(cumulative, metadata, top_n=2, min_comments=0)
+
+        date_cols = [c for c in wide.columns if c not in {"Label", "Category", "Image"}]
+        for col in date_cols:
+            assert re.match(r"\d{4}-\d{2}-\d{2}", col), f"Bad date format: {col}"
+
+    def test_masked_cells_are_null(self):
+        """Cells masked below threshold appear as null in wide format."""
+        records, metadata = self._build_test_data()
+        cumulative = compute_cumulative_metrics(records)
+        # Threshold so week 1 (cum_total=1000) is below, week 2 (cum_total=2500) is above
+        wide = pivot_bar_race_wide(cumulative, metadata, top_n=2, min_comments=1500)
+
+        # First week column should have null values
+        first_week_col = wide.columns[3]
+        vals = wide[first_week_col].to_list()
+        assert all(v is None for v in vals)

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -539,7 +539,10 @@ class TestPivotBarRaceWide:
         """Output has Label, Category, Image, then date columns."""
         records, metadata = self._build_test_data()
         cumulative = compute_cumulative_metrics(records)
-        wide = pivot_bar_race_wide(cumulative, metadata, top_n=3, min_comments=0)
+        wide = pivot_bar_race_wide(
+            cumulative, metadata, top_n=3,
+            min_ranking_comments=0, min_entry_comments=0,
+        )
 
         cols = wide.columns
         assert cols[0] == "Label"
@@ -551,7 +554,10 @@ class TestPivotBarRaceWide:
         """Only top_n players appear in output."""
         records, metadata = self._build_test_data()
         cumulative = compute_cumulative_metrics(records)
-        wide = pivot_bar_race_wide(cumulative, metadata, top_n=2, min_comments=0)
+        wide = pivot_bar_race_wide(
+            cumulative, metadata, top_n=2,
+            min_ranking_comments=0, min_entry_comments=0,
+        )
 
         assert wide.height == 2
         labels = wide["Label"].to_list()
@@ -566,7 +572,10 @@ class TestPivotBarRaceWide:
 
         records, metadata = self._build_test_data()
         cumulative = compute_cumulative_metrics(records)
-        wide = pivot_bar_race_wide(cumulative, metadata, top_n=2, min_comments=0)
+        wide = pivot_bar_race_wide(
+            cumulative, metadata, top_n=2,
+            min_ranking_comments=0, min_entry_comments=0,
+        )
 
         date_cols = [c for c in wide.columns if c not in {"Label", "Category", "Image"}]
         for col in date_cols:
@@ -576,8 +585,12 @@ class TestPivotBarRaceWide:
         """Cells masked below threshold appear as null in wide format."""
         records, metadata = self._build_test_data()
         cumulative = compute_cumulative_metrics(records)
-        # Threshold so week 1 (cum_total=1000) is below, week 2 (cum_total=2500) is above
-        wide = pivot_bar_race_wide(cumulative, metadata, top_n=2, min_comments=1500)
+        # Ranking threshold 0 lets all players qualify; entry threshold 1500
+        # means week 1 (cum_total=1000) is below, week 2 (cum_total=2500) is above
+        wide = pivot_bar_race_wide(
+            cumulative, metadata, top_n=2,
+            min_ranking_comments=0, min_entry_comments=1500,
+        )
 
         # First week column should have null values
         first_week_col = wide.columns[3]


### PR DESCRIPTION
## Summary
- Add `compute_cumulative_metrics()`, `mask_below_threshold()`, and `pivot_bar_race_wide()` to `pipeline/aggregation.py` — transforms weekly `player_temporal` snapshots into cumulative neg_rate rankings in Flourish's wide CSV format
- Add `scripts/export_bar_race.py` CLI with `--top-n`, `--min-ranking-comments`, and `--min-entry-comments` flags
- Two independent thresholds: `min_ranking_comments` (default 5000) controls which players qualify for top-N selection, `min_entry_comments` (default 1000) controls when a player's bar first appears in the animation

## Test plan
- [x] `uv run pytest tests/unit/test_aggregation.py -v` — 36 tests pass (12 new: 5 cumulative metrics, 3 masking, 4 pivot)
- [x] `uv run ruff check .` — no lint errors
- [x] `uv run python -m scripts.export_bar_race` — produces `data/dashboard/bar_race.csv` with 15 players x 39 weeks, Draymond Green at top
- [x] Upload CSV to Flourish bar chart race template — bars animate, players enter as they cross 1,000 comments