### PR TITLE
chore(config): update claude rules for v2 conventions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -9,18 +9,20 @@
 
 ```
 scripts/          → CLI entry points (download, filter, batch, aggregate)
-pipeline/         → Data processing (ArcticShiftClient, CommentPipeline, batch, aggregation)
+pipeline/         → Data processing (ArcticShiftClient, batch, aggregation)
 utils/            → Stateless helpers (constants, formatting, paths, player_config, team_config)
-config/           → YAML configs (players.yaml v1.2, teams.yaml)
+config/           → YAML configs (season.yaml, 2024-25/players.yaml, teams.yaml)
 app/              → Streamlit dashboard
 tests/            → pytest (unit/, conftest.py)
 notebooks/        → EDA and exploration (01-06)
 data/             → Not committed
-  ├── raw/        → Arctic Shift downloads
-  ├── filtered/   → Cleaned + player-mention filtered
-  ├── batches/    → Batch API requests/responses
-  ├── processed/  → sentiment.parquet (1.93M rows)
-  └── dashboard/  → aggregates.json (precomputed views)
+  ├── 2024-25/    → V1 season data
+  │   ├── raw/        → Arctic Shift downloads
+  │   ├── filtered/   → Player-mention filtered JSONL
+  │   ├── batches/    → Batch API requests/responses
+  │   ├── processed/  → sentiment.parquet
+  │   └── dashboard/  → aggregates.json + per-table Parquet files
+  └── 2025-26/    → V2 season data (same structure)
 ```
 
 ## Commands
@@ -47,7 +49,7 @@ uv run streamlit run app/streamlit_app.py  # Local dev
 
 ## Code Patterns
 
-- **Imports:** Relative within packages, absolute cross-package
+- **Imports:** Absolute throughout
 - **Scripts:** Thin wrappers that call pipeline/ modules. Use `if __name__ == "__main__":`
 - **Error handling:** Specific exceptions with context, preserve chains with `from e`
 - **Type hints:** Required on all function signatures
@@ -56,14 +58,26 @@ uv run streamlit run app/streamlit_app.py  # Local dev
 ## Data Files
 
 **Never read directly (large files):**
-- `data/raw/*.jsonl` (12+ GB)
-- `data/filtered/*.jsonl` (2+ GB)
-- `data/processed/sentiment.parquet` (1.93M rows)
-- `data/batches/requests/*.jsonl`
-- `data/batches/responses/*.jsonl`
+- `data/2024-25/raw/*.jsonl` (12+ GB)
+- `data/2024-25/filtered/*.jsonl` (2+ GB)
+- `data/2024-25/processed/sentiment.parquet` (1.93M rows)
+- `data/2024-25/batches/requests/*.jsonl`
+- `data/2024-25/batches/responses/*.jsonl`
 
 **Dashboard input:**
-- `data/dashboard/aggregates.json` — precomputed views, ~2MB, safe to load
+- `data/2024-25/dashboard/aggregates.json` — precomputed views, ~2MB, safe to load
+
+## DuckDB CLI
+
+For ad-hoc queries on Parquet files. Read-only — never use to query `data/*/raw/` or `data/*/processed/sentiment.parquet`.
+
+```bash
+duckdb                                                                   # Interactive shell
+SET access_mode = 'read_only';                                           # Enforce read-only (set globally via .duckdbrc)
+SELECT * FROM 'data/2024-25/dashboard/player_overall.parquet' LIMIT 10;
+```
+
+A `.duckdbrc` at project root sets read-only mode globally.
 
 ## Rules
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -72,12 +72,16 @@ uv run streamlit run app/streamlit_app.py  # Local dev
 For ad-hoc queries on Parquet files. Read-only — never use to query `data/*/raw/` or `data/*/processed/sentiment.parquet`.
 
 ```bash
-duckdb                                                                   # Interactive shell
-SET access_mode = 'read_only';                                           # Enforce read-only (set globally via .duckdbrc)
+# Non-interactive (preferred in Claude Code)
+duckdb -c "SELECT player, neg_rate FROM 'data/2024-25/dashboard/player_overall.parquet' ORDER BY neg_rate DESC LIMIT 10"
+
+# Interactive shell
+duckdb
+SET access_mode = 'read_only';
 SELECT * FROM 'data/2024-25/dashboard/player_overall.parquet' LIMIT 10;
 ```
 
-A `.duckdbrc` at project root sets read-only mode globally.
+A `.duckdbrc` at project root sets read-only mode globally. Always use aggregations or filters — never `SELECT *` without `LIMIT` (the `body` column on raw data will flood output).
 
 ## Rules
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -11,7 +11,7 @@
 scripts/          → CLI entry points (download, filter, batch, aggregate)
 pipeline/         → Data processing (ArcticShiftClient, batch, aggregation)
 utils/            → Stateless helpers (constants, formatting, paths, player_config, team_config)
-config/           → YAML configs (season.yaml, 2024-25/players.yaml, teams.yaml)
+config/           → YAML configs (2024-25/players.yaml, teams.yaml; season.yaml planned)
 app/              → Streamlit dashboard
 tests/            → pytest (unit/, conftest.py)
 notebooks/        → EDA and exploration (01-06)
@@ -75,9 +75,8 @@ For ad-hoc queries on Parquet files. Read-only — never use to query `data/*/ra
 # Non-interactive (preferred in Claude Code)
 duckdb -c "SELECT player, neg_rate FROM 'data/2024-25/dashboard/player_overall.parquet' ORDER BY neg_rate DESC LIMIT 10"
 
-# Interactive shell
+# Interactive shell (.duckdbrc sets read-only automatically)
 duckdb
-SET access_mode = 'read_only';
 SELECT * FROM 'data/2024-25/dashboard/player_overall.parquet' LIMIT 10;
 ```
 

--- a/.claude/rules/git.md
+++ b/.claude/rules/git.md
@@ -26,7 +26,7 @@
 
 | Scope | Use For |
 |-------|---------|
-| `pipeline` | ArcticShiftClient, processors, batch jobs |
+| `pipeline` | data processing, batch jobs |
 | `data` | Data processing, schemas, Polars transforms |
 | `sentiment` | Classification logic, prompts |
 | `api` | Anthropic Batch API integration |
@@ -44,7 +44,7 @@
 
 Prefixes: `feature/`, `fix/`, `refactor/`, `docs/`, `chore/`, `test/`
 
-Examples: `feature/arctic-shift-client`, `fix/rate-limit-handling`, `refactor/comment-pipeline`
+Examples: `feature/arctic-shift-client`, `fix/rate-limit-handling`, `refactor/season-config`
 
 ## PR Titles
 

--- a/.claude/rules/python.md
+++ b/.claude/rules/python.md
@@ -139,7 +139,7 @@ if __name__ == "__main__":
 class ArcticShiftClient:
     """Handles all Arctic Shift API interactions."""
     
-    def __init__(self, base_url: str = ARCTIC_SHIFT_URL, delay: float = 0.5):
+    def __init__(self, base_url: str = ARCTIC_SHIFT_BASE_URL, delay: float = 0.5):
         self.base_url = base_url
         self.delay = delay
         self.session = requests.Session()
@@ -193,7 +193,7 @@ System constants (field schemas, API config) live in `utils/constants.py`. Domai
 
 ```python
 # Good
-from utils.constants import REQUIRED_FIELDS, ARCTIC_SHIFT_URL
+from utils.constants import REQUIRED_FIELDS, ARCTIC_SHIFT_BASE_URL
 
 # Avoid
 fields = ["id", "body", "author", "subreddit"]  # Magic list in random file
@@ -201,14 +201,15 @@ fields = ["id", "body", "author", "subreddit"]  # Magic list in random file
 
 ## Paths
 
-Use `pathlib.Path`, not string concatenation.
+Use `utils/paths.py` functions — never construct data paths with hardcoded strings.
 
 ```python
-from pathlib import Path
+from utils.paths import get_filtered_dir
 
 # Good
-output_path = Path("data/filtered") / "cleaned.jsonl"
+output_path = get_filtered_dir() / "cleaned.jsonl"
 
 # Avoid
+output_path = Path("data/filtered") / "cleaned.jsonl"  # Bypasses DATA_DIR env var
 output_path = "data/filtered/" + "cleaned.jsonl"
 ```

--- a/.claude/rules/python.md
+++ b/.claude/rules/python.md
@@ -10,14 +10,11 @@ paths:
 
 **Order:** Standard library → Third-party → Local (ruff enforces this)
 
-**Relative vs absolute:**
-- Within a package: use relative (`from .arctic_shift import ArcticShiftClient`)
-- Cross-package: use absolute (`from utils.formatting import format_duration`)
+Always use absolute imports.
 
 ```python
-# In pipeline/processors.py
-from .arctic_shift import ArcticShiftClient  # Same package: relative
-from utils.constants import FIELDS_TO_KEEP   # Different package: absolute
+from pipeline.arctic_shift import ArcticShiftClient
+from utils.constants import REQUIRED_FIELDS
 ```
 
 ## Type Hints
@@ -136,7 +133,7 @@ if __name__ == "__main__":
     main()
 ```
 
-**Pipeline classes own their domain:**
+**Classes for stateful components (API clients), functions for stateless transforms:**
 ```python
 # pipeline/arctic_shift.py
 class ArcticShiftClient:
@@ -192,11 +189,11 @@ Prefer `@dataclass` over plain classes when the primary purpose is holding data.
 
 ## Constants
 
-Centralize in `utils/constants.py`. No magic strings in code.
+System constants (field schemas, API config) live in `utils/constants.py`. Domain config (dates, thresholds, player lists) lives in YAML under `config/`. No magic strings in code.
 
 ```python
 # Good
-from utils.constants import FIELDS_TO_KEEP, ARCTIC_SHIFT_URL
+from utils.constants import REQUIRED_FIELDS, ARCTIC_SHIFT_URL
 
 # Avoid
 fields = ["id", "body", "author", "subreddit"]  # Magic list in random file

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -51,20 +51,22 @@ Mirror the source structure:
 
 ## Naming
 
+Group tests by subject using classes:
+
 ```python
-# Test files
-test_<module>.py
+class TestFilterByLength:
+    def test_rejects_short_comments(self):
+        ...
 
-# Test functions: test_<function>_<scenario>
-def test_filter_by_length_rejects_short_comments():
-    ...
+    def test_accepts_long_comments(self):
+        ...
 
-def test_filter_by_length_accepts_long_comments():
-    ...
-
-def test_fetch_comments_handles_rate_limit():
-    ...
+class TestFetchComments:
+    def test_handles_rate_limit(self):
+        ...
 ```
+
+File names: `test_<module>.py`. Method names: `test_<scenario>` (no need to repeat the class subject).
 
 ## Test Structure
 
@@ -113,14 +115,18 @@ import pytest
 
 @pytest.fixture
 def sample_comment() -> dict:
-    """Standard comment for testing processors."""
+    """Standard comment for testing processors. Fields match REQUIRED_FIELDS."""
     return {
         "id": "abc123",
         "body": "LeBron is the GOAT",
         "author": "user123",
         "author_flair_text": "Lakers",
+        "author_flair_css_class": "lakers",
         "subreddit": "nba",
         "created_utc": 1709251200,
+        "score": 10,
+        "controversiality": 0,
+        "parent_id": "t3_post123",
         "link_id": "t3_post123",
     }
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -42,7 +42,7 @@ tests/
 │   ├── test_formatting.py
 │   └── test_arctic_shift.py
 └── integration/         # End-to-end, may touch files/network
-    └── test_pipeline.py
+    └── test_pipeline.py  # TODO: v2 integration tests (currently empty)
 ```
 
 Mirror the source structure:
@@ -169,7 +169,7 @@ def test_fetch_comments_paginates():
 |-----------|------------|
 | `pipeline/` | Core logic, edge cases, error handling |
 | `utils/` | Pure functions with various inputs |
-| `scripts/` | Skip (thin wrappers, tested via integration) |
+| `scripts/` | Skip (thin CLI wrappers) |
 
 ## When Tests Are Optional
 
@@ -181,8 +181,8 @@ Not everything needs unit tests. Skip tests for:
 
 Focus testing effort on:
 
-- **Reusable pipeline components** — `ArcticShiftClient`, `CommentPipeline`
-- **Pure utility functions** — `format_duration`, `filter_by_length`
+- **Reusable pipeline components** — `ArcticShiftClient`, processors
+- **Pure utility functions** — `format_duration`, `extract_fields`
 - **Complex logic** — Anything with branching, edge cases, or error handling
 
 ## Running Tests


### PR DESCRIPTION
## Description

The `.claude/` rules were written during early v1 and never updated as the codebase evolved. Several conventions described stale class names, wrong constant names, or conflicted with actual practice. These need to be correct before v2 implementation so Claude Code generates code that matches current conventions.

## Changes

- Remove `CommentPipeline` references (being deleted in v2)
- Update `config/` layout to season-scoped structure (`2024-25/players.yaml`); mark `season.yaml` as planned
- Update `data/` architecture map to season-scoped dirs (`data/2024-25/`, `data/2025-26/`)
- Standardize on absolute imports throughout (relative imports were never used in practice)
- Fix `ARCTIC_SHIFT_URL` → `ARCTIC_SHIFT_BASE_URL` (would have caused ImportError)
- Fix `FIELDS_TO_KEEP` → `REQUIRED_FIELDS` (stale constant name)
- Split constants guidance: system constants in `utils/constants.py`, domain config in YAML
- Update Paths section to use `utils/paths.py` functions (not raw `Path("data/...")` strings)
- Add missing fields to `sample_comment` fixture to match `REQUIRED_FIELDS`
- Add class-based test grouping convention (`TestXxx`) to match actual test files
- Add DuckDB CLI section: non-interactive pattern, read-only note, `SELECT *` footgun warning
- Update `pipeline` scope description and branch naming example in git.md

## Testing

- [x] All tests pass (`uv run pytest`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Added tests for new functionality (if applicable) — docs only, N/A
- [x] Manually verified changes work as expected