### PR TITLE
feat(pipeline): add schemas.py for produced data file contracts

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -67,6 +67,9 @@ uv run streamlit run app/streamlit_app.py  # Local dev
 **Dashboard input:**
 - `data/2024-25/dashboard/aggregates.json` — precomputed views, ~2MB, safe to load
 
+**Schema contracts:**
+- `pipeline/schemas.py` — single source of truth for produced-file schemas (`sentiment.parquet` + aggregate views); `SCHEMA_VERSION` is stamped into `aggregates.json` metadata. Don't duplicate column lists elsewhere.
+
 ## DuckDB CLI
 
 For ad-hoc queries on Parquet files. Read-only — never use to query `data/*/raw/` or `data/*/processed/sentiment.parquet`.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -103,11 +103,18 @@ def test_format_duration(seconds: int, expected: str):
     assert format_duration(seconds) == expected
 ```
 
-Prefer this over multiple similar test functions.
+Prefer this over multiple similar test functions — but only **within a single behavior** (same act-and-assert shape, different data). Distinct behaviors with distinct assertions (e.g., missing column vs. dtype mismatch) get separate named tests. If the test body needs `if`/`else` keyed on a parameter, you've parametrized across behaviors — split it.
 
 ## Fixtures
 
-Define in `conftest.py` for shared fixtures:
+**Reuse before defining.** Check `tests/conftest.py` for an existing fixture before writing a new one — compose existing fixtures (e.g., build a batch from `valid_nba_comment`) rather than redefining near-duplicates in test modules.
+
+Placement:
+- Used by multiple test files → `conftest.py`
+- Used by one test file → define locally in that module
+- Promote to `conftest.py` on the second consumer, not in anticipation of one
+
+Shared fixtures live in `conftest.py`:
 
 ```python
 # tests/conftest.py

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -15,6 +15,7 @@ from .batch import (
     submit_batch,
 )
 from .processors import ProcessingStats, extract_fields, has_valid_body, process_line
+from .results import build_sentiment_dataframe
 from .schemas import (
     PLAYER_OVERALL_SCHEMA,
     PLAYER_TEAM_SCHEMA,
@@ -36,6 +37,7 @@ __all__ = [
     "ProcessingStats",
     "aggregate_sentiment",
     "build_prompt",
+    "build_sentiment_dataframe",
     "calculate_cost",
     "download_results",
     "extract_fields",

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -27,14 +27,14 @@ from .schemas import (
 )
 
 __all__ = [
+    "ArcticShiftClient",
     "PLAYER_OVERALL_SCHEMA",
     "PLAYER_TEAM_SCHEMA",
     "PLAYER_TEMPORAL_SCHEMA",
+    "ProcessingStats",
     "SCHEMA_VERSION",
     "SENTIMENT_SCHEMA",
     "TEAM_OVERALL_SCHEMA",
-    "ArcticShiftClient",
-    "ProcessingStats",
     "aggregate_sentiment",
     "build_prompt",
     "build_sentiment_dataframe",

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -15,8 +15,23 @@ from .batch import (
     submit_batch,
 )
 from .processors import ProcessingStats, extract_fields, has_valid_body, process_line
+from .schemas import (
+    PLAYER_OVERALL_SCHEMA,
+    PLAYER_TEAM_SCHEMA,
+    PLAYER_TEMPORAL_SCHEMA,
+    SCHEMA_VERSION,
+    SENTIMENT_SCHEMA,
+    TEAM_OVERALL_SCHEMA,
+    validate_schema,
+)
 
 __all__ = [
+    "PLAYER_OVERALL_SCHEMA",
+    "PLAYER_TEAM_SCHEMA",
+    "PLAYER_TEMPORAL_SCHEMA",
+    "SCHEMA_VERSION",
+    "SENTIMENT_SCHEMA",
+    "TEAM_OVERALL_SCHEMA",
     "ArcticShiftClient",
     "ProcessingStats",
     "aggregate_sentiment",
@@ -33,4 +48,5 @@ __all__ = [
     "process_line",
     "save_state",
     "submit_batch",
+    "validate_schema",
 ]

--- a/pipeline/aggregation.py
+++ b/pipeline/aggregation.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import polars as pl
 
+from pipeline.schemas import SCHEMA_VERSION
 from utils.player_config import build_alias_to_player_map, load_player_metadata
 from utils.season_config import get_active_season
 from utils.team_config import build_alias_to_team_map, load_team_config
@@ -244,6 +245,7 @@ def aggregate_sentiment(input_path: Path) -> dict:
     unique_weeks = df["week"].n_unique()
 
     metadata = {
+        "schema_version": SCHEMA_VERSION,
         "total_comments": total_rows,
         "usable_comments": usable_rows,
         "excluded_comments": excluded_rows,

--- a/pipeline/results.py
+++ b/pipeline/results.py
@@ -1,0 +1,120 @@
+"""
+Assemble batch classification results into the sentiment DataFrame.
+
+Joins parsed Batch API results with filtered comment metadata and
+enforces SENTIMENT_SCHEMA at the sentiment.parquet write boundary.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+import polars as pl
+
+from pipeline.batch import calculate_cost, parse_response
+from pipeline.schemas import (
+    COMMENT_INPUT_SCHEMA,
+    RESULTS_SCHEMA,
+    SENTIMENT_SCHEMA,
+    validate_schema,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def build_sentiment_dataframe(
+    responses_dir: Path, filtered_path: Path, state: dict
+) -> tuple[pl.DataFrame, list[dict]]:
+    """
+    Build sentiment DataFrame by joining results with comment metadata.
+
+    Args:
+        responses_dir: Directory containing batch_NNN_results.jsonl files.
+        filtered_path: Path to filtered comments JSONL file.
+        state: State dict to update with token totals.
+
+    Returns:
+        Tuple of (sentiment DataFrame, list of failed requests).
+
+    Raises:
+        FileNotFoundError: If no results files exist in responses_dir.
+        ValueError: If the assembled frame does not match SENTIMENT_SCHEMA.
+    """
+    # Load all results
+    results_files = sorted(responses_dir.glob("batch_*_results.jsonl"))
+    if not results_files:
+        raise FileNotFoundError(f"No results files found in {responses_dir}")
+
+    logger.info(f"Loading results from {len(results_files)} files...")
+
+    all_results = []
+    failed_requests = []
+    total_input_tokens = 0
+    total_output_tokens = 0
+
+    for results_file in results_files:
+        with open(results_file) as f:
+            for line in f:
+                if not line.strip():
+                    continue
+                result = json.loads(line)
+
+                if result["result_type"] == "succeeded":
+                    parsed = parse_response(result["content"])
+                    all_results.append(
+                        {
+                            "id": result["custom_id"],
+                            "sentiment": parsed["s"],
+                            "confidence": parsed["c"],
+                            "sentiment_player": parsed.get("p"),
+                            "input_tokens": result["input_tokens"],
+                            "output_tokens": result["output_tokens"],
+                        }
+                    )
+                    total_input_tokens += result["input_tokens"]
+                    total_output_tokens += result["output_tokens"]
+                else:
+                    failed_requests.append(result)
+
+    logger.info(f"Loaded {len(all_results)} successful results")
+    if failed_requests:
+        logger.warning(f"Found {len(failed_requests)} failed requests")
+
+    # Update state with token totals
+    state["total_input_tokens"] = total_input_tokens
+    state["total_output_tokens"] = total_output_tokens
+    state["estimated_cost_usd"] = calculate_cost(
+        total_input_tokens, total_output_tokens
+    )
+
+    # Create results DataFrame with pinned dtypes (correct even when empty)
+    results_df = pl.DataFrame(all_results, schema=RESULTS_SCHEMA)
+
+    # Load comments lazily; the schema pins dtypes and projects away extra keys
+    logger.info(f"Loading comments from {filtered_path}...")
+    comments_df = pl.scan_ndjson(filtered_path, schema=COMMENT_INPUT_SCHEMA)
+
+    # Join results with comments
+    logger.info("Joining results with comments...")
+    results_count = len(all_results)
+    joined_df = (
+        comments_df.join(results_df.lazy(), on="id", how="inner")
+        .rename({"id": "comment_id"})
+        .select(SENTIMENT_SCHEMA.names())
+        .collect()
+    )
+
+    # Validate join didn't drop rows
+    joined_count = len(joined_df)
+    if joined_count < results_count:
+        dropped = results_count - joined_count
+        logger.warning(
+            f"Join dropped {dropped} results "
+            f"({dropped / results_count * 100:.1f}% - comments may be missing from filtered file)"
+        )
+
+    logger.info(f"Final DataFrame: {joined_count} rows")
+
+    validate_schema(joined_df, SENTIMENT_SCHEMA, "sentiment.parquet")
+
+    return joined_df, failed_requests

--- a/pipeline/results.py
+++ b/pipeline/results.py
@@ -38,7 +38,8 @@ def build_sentiment_dataframe(
 
     Raises:
         FileNotFoundError: If no results files exist in responses_dir.
-        ValueError: If the assembled frame does not match SENTIMENT_SCHEMA.
+        ValueError: If a results file contains malformed JSON, or the
+            assembled frame does not match SENTIMENT_SCHEMA.
     """
     # Load all results
     results_files = sorted(responses_dir.glob("batch_*_results.jsonl"))
@@ -57,7 +58,12 @@ def build_sentiment_dataframe(
             for line in f:
                 if not line.strip():
                     continue
-                result = json.loads(line)
+                try:
+                    result = json.loads(line)
+                except json.JSONDecodeError as e:
+                    raise ValueError(
+                        f"Malformed JSON in {results_file.name}: {e}"
+                    ) from e
 
                 if result["result_type"] == "succeeded":
                     parsed = parse_response(result["content"])

--- a/pipeline/schemas.py
+++ b/pipeline/schemas.py
@@ -1,0 +1,162 @@
+"""
+Schema contracts for produced data files.
+
+Single source of truth for column names and dtypes of every file the
+pipeline produces. Data dictionary first, enforcement second:
+
+- SENTIMENT_SCHEMA is enforced at the sentiment.parquet write boundary
+  (pipeline/results.py).
+- The four aggregate-view schemas document the tabular sections of
+  aggregates.json in their parquet-ready shape; enforcement arrives with
+  their parquet write boundary (issue #28). Note: team_overall's
+  enrichment columns (abbreviation, conference, logo_url) are currently
+  added dict-level after aggregation — the schema records the target
+  shape #28 must produce.
+
+This module must not import from other pipeline modules (it is imported
+by them).
+"""
+
+import polars as pl
+
+# Bump on any breaking change to a produced-file contract.
+SCHEMA_VERSION = 1
+
+# data/<season>/processed/sentiment.parquet — one row per classified comment.
+SENTIMENT_SCHEMA = pl.Schema(
+    {
+        "comment_id": pl.String,
+        "body": pl.String,
+        "author": pl.String,
+        "author_flair_text": pl.String,  # nullable
+        "author_flair_css_class": pl.String,  # nullable
+        "created_utc": pl.Int64,  # epoch seconds
+        "score": pl.Int64,
+        "mentioned_players": pl.List(pl.String),
+        "sentiment": pl.String,  # "pos" | "neg" | "neu" | "error"
+        "confidence": pl.Float64,
+        "sentiment_player": pl.String,  # nullable
+        "input_tokens": pl.Int64,
+        "output_tokens": pl.Int64,
+    }
+)
+
+# --- Construction-side schemas, derived from SENTIMENT_SCHEMA ---------------
+# The joined frame is assembled from two inputs. Deriving their schemas from
+# SENTIMENT_SCHEMA means a dtype change happens in exactly one place and the
+# strict boundary check can never drift from construction.
+
+_COMMENT_SIDE_COLUMNS = [
+    "comment_id",
+    "body",
+    "author",
+    "author_flair_text",
+    "author_flair_css_class",
+    "created_utc",
+    "score",
+    "mentioned_players",
+]
+_RESULTS_SIDE_COLUMNS = [
+    "sentiment",
+    "confidence",
+    "sentiment_player",
+    "input_tokens",
+    "output_tokens",
+]
+
+# Filtered-comments NDJSON: comment-side columns, id column named "id"
+# pre-rename. Doubles as a projection — extra input keys are dropped.
+COMMENT_INPUT_SCHEMA = pl.Schema(
+    {
+        ("id" if col == "comment_id" else col): SENTIMENT_SCHEMA[col]
+        for col in _COMMENT_SIDE_COLUMNS
+    }
+)
+
+# Parsed batch results, keyed by custom_id ("id" pre-rename).
+RESULTS_SCHEMA = pl.Schema(
+    {
+        "id": SENTIMENT_SCHEMA["comment_id"],
+        **{col: SENTIMENT_SCHEMA[col] for col in _RESULTS_SIDE_COLUMNS},
+    }
+)
+
+# --- Aggregate views (tabular sections of aggregates.json; enforced in #28) -
+# Column order mirrors compute_metrics output: group cols, counts, rates.
+
+_METRIC_COLUMNS: dict[str, pl.DataType] = {
+    "neg_count": pl.Int64,  # UInt32 from .len(), cast in compute_metrics
+    "pos_count": pl.Int64,
+    "neu_count": pl.Int64,
+    "comment_count": pl.Int64,
+    "neg_rate": pl.Float64,
+    "pos_rate": pl.Float64,
+    "net_sentiment": pl.Float64,
+    "polarization": pl.Float64,
+}
+
+PLAYER_OVERALL_SCHEMA = pl.Schema({"attributed_player": pl.String, **_METRIC_COLUMNS})
+
+PLAYER_TEMPORAL_SCHEMA = pl.Schema(
+    {
+        "attributed_player": pl.String,
+        "week": pl.Datetime("us"),  # pl.from_epoch(...).dt.truncate("1w"), no tz
+        **_METRIC_COLUMNS,
+    }
+)
+
+PLAYER_TEAM_SCHEMA = pl.Schema(
+    {"attributed_player": pl.String, "team": pl.String, **_METRIC_COLUMNS}
+)
+
+TEAM_OVERALL_SCHEMA = pl.Schema(
+    {
+        "team": pl.String,
+        **_METRIC_COLUMNS,
+        "abbreviation": pl.String,  # enrichment from config/teams.yaml
+        "conference": pl.String,
+        "logo_url": pl.String,
+    }
+)
+
+
+def validate_schema(df: pl.DataFrame, expected: pl.Schema, name: str) -> None:
+    """
+    Validate a DataFrame against an expected schema, failing fast.
+
+    Strict equality: column names, dtypes, and order must all match.
+
+    Args:
+        df: DataFrame to validate.
+        expected: Expected schema contract.
+        name: Human-readable target name for error messages
+            (e.g. "sentiment.parquet").
+
+    Raises:
+        ValueError: If the schema does not match. The message names the
+            target and enumerates missing columns, extra columns, and
+            dtype mismatches (or a column-order mismatch).
+    """
+    actual = df.schema
+    if actual == expected:
+        return
+
+    problems: list[str] = []
+    missing = [col for col in expected if col not in actual]
+    extra = [col for col in actual if col not in expected]
+    mismatched = [
+        f"{col}: expected {expected[col]}, got {actual[col]}"
+        for col in expected
+        if col in actual and actual[col] != expected[col]
+    ]
+    if missing:
+        problems.append(f"missing columns: {missing}")
+    if extra:
+        problems.append(f"extra columns: {extra}")
+    if mismatched:
+        problems.append(f"dtype mismatches: [{'; '.join(mismatched)}]")
+    if not problems:  # same names and dtypes, different order
+        problems.append(
+            f"column order mismatch: expected {expected.names()}, got {actual.names()}"
+        )
+    raise ValueError(f"Schema validation failed for {name!r}: " + "; ".join(problems))

--- a/pipeline/schemas.py
+++ b/pipeline/schemas.py
@@ -64,8 +64,9 @@ _RESULTS_SIDE_COLUMNS = [
     "output_tokens",
 ]
 
-# Filtered-comments NDJSON: comment-side columns, id column named "id"
-# pre-rename. Doubles as a projection — extra input keys are dropped.
+# Filtered-comments NDJSON: comment-side columns. The key column is "id"
+# here because the rename to "comment_id" happens after the join in
+# pipeline/results.py. Doubles as a projection — extra input keys dropped.
 COMMENT_INPUT_SCHEMA = pl.Schema(
     {
         ("id" if col == "comment_id" else col): SENTIMENT_SCHEMA[col]
@@ -73,7 +74,8 @@ COMMENT_INPUT_SCHEMA = pl.Schema(
     }
 )
 
-# Parsed batch results, keyed by custom_id ("id" pre-rename).
+# Parsed batch results. The key column is "id" (the request custom_id);
+# same rename-after-join story as COMMENT_INPUT_SCHEMA above.
 RESULTS_SCHEMA = pl.Schema(
     {
         "id": SENTIMENT_SCHEMA["comment_id"],
@@ -136,6 +138,11 @@ def validate_schema(df: pl.DataFrame, expected: pl.Schema, name: str) -> None:
         ValueError: If the schema does not match. The message names the
             target and enumerates missing columns, extra columns, and
             dtype mismatches (or a column-order mismatch).
+
+    Note:
+        Nullable columns must be pinned with schema= at construction —
+        an all-null column built without one infers as Null dtype and
+        will be reported here as a dtype mismatch.
     """
     actual = df.schema
     if actual == expected:

--- a/scripts/collect_results.py
+++ b/scripts/collect_results.py
@@ -28,18 +28,16 @@ import sys
 import time
 from pathlib import Path
 
-import polars as pl
 from dotenv import load_dotenv
 
 from pipeline.batch import (
     STATE_FILENAME,
-    calculate_cost,
     download_results,
     get_batch_status,
     load_state,
-    parse_response,
     save_state,
 )
+from pipeline.results import build_sentiment_dataframe
 from utils.paths import get_batches_dir, get_filtered_dir, get_processed_dir
 
 # -----------------------------------------------------------------------------
@@ -61,24 +59,6 @@ RESPONSES_SUBDIR = "responses"
 FILTERED_FILENAME = "r_nba_player_mentions.jsonl"
 OUTPUT_FILENAME = "sentiment.parquet"
 FAILED_FILENAME = "failed_requests.jsonl"
-
-# Output columns for sentiment.parquet
-OUTPUT_COLUMNS = [
-    "comment_id",
-    "body",
-    "author",
-    "author_flair_text",
-    "author_flair_css_class",
-    "created_utc",
-    "score",
-    "mentioned_players",
-    "sentiment",
-    "confidence",
-    "sentiment_player",
-    "input_tokens",
-    "output_tokens",
-]
-
 
 # -----------------------------------------------------------------------------
 # Helper functions
@@ -250,109 +230,6 @@ def poll_until_complete(
             f"({len(pending)} batches pending, {remaining:.0f}s remaining)"
         )
         time.sleep(wait_time)
-
-
-def build_sentiment_dataframe(
-    responses_dir: Path, filtered_path: Path, state: dict
-) -> tuple[pl.DataFrame, list[dict]]:
-    """
-    Build sentiment DataFrame by joining results with comment metadata.
-
-    Args:
-        responses_dir: Directory containing batch_NNN_results.jsonl files.
-        filtered_path: Path to filtered comments JSONL file.
-        state: State dict to update with token totals.
-
-    Returns:
-        Tuple of (sentiment DataFrame, list of failed requests).
-    """
-    # Load all results
-    results_files = sorted(responses_dir.glob("batch_*_results.jsonl"))
-    if not results_files:
-        raise FileNotFoundError(f"No results files found in {responses_dir}")
-
-    logger.info(f"Loading results from {len(results_files)} files...")
-
-    all_results = []
-    failed_requests = []
-    total_input_tokens = 0
-    total_output_tokens = 0
-
-    for results_file in results_files:
-        with open(results_file) as f:
-            for line in f:
-                if not line.strip():
-                    continue
-                result = json.loads(line)
-
-                if result["result_type"] == "succeeded":
-                    parsed = parse_response(result["content"])
-                    all_results.append(
-                        {
-                            "id": result["custom_id"],
-                            "sentiment": parsed["s"],
-                            "confidence": parsed["c"],
-                            "sentiment_player": parsed.get("p"),
-                            "input_tokens": result["input_tokens"],
-                            "output_tokens": result["output_tokens"],
-                        }
-                    )
-                    total_input_tokens += result["input_tokens"]
-                    total_output_tokens += result["output_tokens"]
-                else:
-                    failed_requests.append(result)
-
-    logger.info(f"Loaded {len(all_results)} successful results")
-    if failed_requests:
-        logger.warning(f"Found {len(failed_requests)} failed requests")
-
-    # Update state with token totals
-    state["total_input_tokens"] = total_input_tokens
-    state["total_output_tokens"] = total_output_tokens
-    state["estimated_cost_usd"] = calculate_cost(
-        total_input_tokens, total_output_tokens
-    )
-
-    # Create results DataFrame
-    results_df = pl.DataFrame(all_results)
-
-    # Load comments with lazy evaluation
-    logger.info(f"Loading comments from {filtered_path}...")
-    comments_df = pl.scan_ndjson(filtered_path).select(
-        [
-            pl.col("id"),
-            pl.col("body"),
-            pl.col("author"),
-            pl.col("author_flair_text"),
-            pl.col("author_flair_css_class"),
-            pl.col("created_utc"),
-            pl.col("score"),
-            pl.col("mentioned_players"),
-        ]
-    )
-
-    # Join results with comments
-    logger.info("Joining results with comments...")
-    results_count = len(all_results)
-    joined_df = (
-        comments_df.join(results_df.lazy(), on="id", how="inner")
-        .rename({"id": "comment_id"})
-        .select(OUTPUT_COLUMNS)
-        .collect()
-    )
-
-    # Validate join didn't drop rows
-    joined_count = len(joined_df)
-    if joined_count < results_count:
-        dropped = results_count - joined_count
-        logger.warning(
-            f"Join dropped {dropped} results "
-            f"({dropped / results_count * 100:.1f}% - comments may be missing from filtered file)"
-        )
-
-    logger.info(f"Final DataFrame: {joined_count} rows")
-
-    return joined_df, failed_requests
 
 
 # -----------------------------------------------------------------------------

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -16,6 +16,7 @@ from pipeline.aggregation import (
     pivot_bar_race_wide,
     resolve_player,
 )
+from pipeline.schemas import SCHEMA_VERSION
 
 
 class TestResolvePlayer:
@@ -647,3 +648,29 @@ class TestPivotBarRaceWide:
         first_week_col = wide.columns[3]
         vals = wide[first_week_col].to_list()
         assert all(v is None for v in vals)
+
+
+class TestAggregateMetadata:
+    """Tests for the metadata key in aggregate output."""
+
+    def test_metadata_includes_schema_version(self, tmp_path):
+        """metadata carries the SCHEMA_VERSION from pipeline/schemas.py."""
+        path = _make_test_parquet(tmp_path, {
+            "comment_id": ["c1", "c2"],
+            "body": ["LeBron is great", "LeBron is washed"],
+            "author": ["u1", "u2"],
+            "author_flair_text": [":lal-1: Lakers", ":bos-1: Celtics"],
+            "author_flair_css_class": ["lakers", "celtics"],
+            "created_utc": [1704067200, 1704153600],
+            "score": [10, 5],
+            "mentioned_players": [["LeBron James"], ["LeBron James"]],
+            "sentiment": ["pos", "neg"],
+            "confidence": [0.9, 0.8],
+            "sentiment_player": ["LeBron James", "LeBron James"],
+            "input_tokens": [100, 100],
+            "output_tokens": [20, 20],
+        })
+
+        result = aggregate_sentiment(path)
+
+        assert result["metadata"]["schema_version"] == SCHEMA_VERSION

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -1,0 +1,179 @@
+"""Tests for pipeline/results.py sentiment frame assembly."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from pipeline.batch import init_state
+from pipeline.results import build_sentiment_dataframe
+from pipeline.schemas import SENTIMENT_SCHEMA
+
+
+def _succeeded(
+    custom_id: str, content: str, input_tokens: int = 100, output_tokens: int = 20
+) -> dict:
+    """Build a succeeded entry shaped like download_results output."""
+    return {
+        "custom_id": custom_id,
+        "result_type": "succeeded",
+        "content": content,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+    }
+
+
+def _errored(custom_id: str) -> dict:
+    """Build an errored entry shaped like download_results output."""
+    return {
+        "custom_id": custom_id,
+        "result_type": "errored",
+        "error": "api_error: Overloaded",
+    }
+
+
+def _write_results_file(responses_dir: Path, entries: list[dict]) -> None:
+    """Write entries as a batch results JSONL file."""
+    responses_dir.mkdir(exist_ok=True)
+    path = responses_dir / "batch_001_results.jsonl"
+    path.write_text("\n".join(json.dumps(entry) for entry in entries) + "\n")
+
+
+@pytest.fixture
+def filtered_comments_file(
+    tmp_path, valid_nba_comment, valid_team_subreddit_comment
+) -> Path:
+    """
+    Two filtered comments as JSONL (ids abc123 and def456).
+
+    Composes the conftest raw-comment fixtures with mentioned_players,
+    the field the filter stage appends before classification.
+    """
+    comments = [
+        {**valid_nba_comment, "mentioned_players": ["LeBron James"]},
+        {**valid_team_subreddit_comment, "mentioned_players": ["Jayson Tatum"]},
+    ]
+    path = tmp_path / "filtered.jsonl"
+    path.write_text("\n".join(json.dumps(comment) for comment in comments) + "\n")
+    return path
+
+
+@pytest.fixture
+def responses_dir(tmp_path, valid_sentiment_responses) -> Path:
+    """
+    Responses dir with one results file where both comments succeeded.
+
+    Reuses raw response strings from the conftest sentiment fixture;
+    custom_ids match the filtered_comments_file comment ids.
+    """
+    raw_responses = [raw for raw, _ in valid_sentiment_responses]
+    directory = tmp_path / "responses"
+    _write_results_file(
+        directory,
+        [
+            _succeeded("abc123", raw_responses[0]),  # pos, 0.95, LeBron James
+            _succeeded("def456", raw_responses[2], 80, 15),  # neu, 0.6, null
+        ],
+    )
+    return directory
+
+
+class TestBuildSentimentDataframe:
+    """Tests for joining batch results with filtered comments."""
+
+    def test_assembled_frame_matches_sentiment_schema(
+        self, responses_dir, filtered_comments_file
+    ):
+        """Verify the assembled frame conforms to SENTIMENT_SCHEMA."""
+        # Act
+        df, _ = build_sentiment_dataframe(
+            responses_dir, filtered_comments_file, init_state()
+        )
+
+        # Assert
+        assert df.schema == SENTIMENT_SCHEMA
+        assert df.height == 2
+
+    def test_joined_values_match_inputs(self, responses_dir, filtered_comments_file):
+        """Verify joined row values carry through from both inputs."""
+        # Act
+        df, _ = build_sentiment_dataframe(
+            responses_dir, filtered_comments_file, init_state()
+        )
+
+        # Assert
+        row = df.filter(df["comment_id"] == "abc123").to_dicts()[0]
+        assert row["body"] == "LeBron is washed, can't believe we traded for him"
+        assert row["sentiment"] == "pos"
+        assert row["confidence"] == 0.95
+        assert row["sentiment_player"] == "LeBron James"
+        assert row["input_tokens"] == 100
+        assert row["output_tokens"] == 20
+
+    def test_empty_results_yield_empty_conformant_frame(
+        self, tmp_path, filtered_comments_file
+    ):
+        """Verify an all-errored batch produces a 0-row frame with the full schema."""
+        # Arrange
+        directory = tmp_path / "responses"
+        _write_results_file(directory, [_errored("abc123"), _errored("def456")])
+
+        # Act
+        df, failed = build_sentiment_dataframe(
+            directory, filtered_comments_file, init_state()
+        )
+
+        # Assert
+        assert df.height == 0
+        assert df.schema == SENTIMENT_SCHEMA
+        assert len(failed) == 2
+
+    def test_failed_requests_separated_from_results(
+        self, tmp_path, filtered_comments_file, valid_sentiment_responses
+    ):
+        """Verify errored entries land in failed_requests, not the frame."""
+        # Arrange
+        raw_responses = [raw for raw, _ in valid_sentiment_responses]
+        directory = tmp_path / "responses"
+        _write_results_file(
+            directory,
+            [_succeeded("abc123", raw_responses[0]), _errored("def456")],
+        )
+
+        # Act
+        df, failed = build_sentiment_dataframe(
+            directory, filtered_comments_file, init_state()
+        )
+
+        # Assert
+        assert df.height == 1
+        assert df["comment_id"].to_list() == ["abc123"]
+        assert len(failed) == 1
+        assert failed[0]["custom_id"] == "def456"
+
+    def test_missing_results_files_raise_file_not_found(
+        self, tmp_path, filtered_comments_file
+    ):
+        """Verify an empty responses dir fails fast."""
+        # Arrange
+        directory = tmp_path / "responses"
+        directory.mkdir()
+
+        # Act / Assert
+        with pytest.raises(FileNotFoundError, match="No results files"):
+            build_sentiment_dataframe(directory, filtered_comments_file, init_state())
+
+    def test_state_updated_with_token_totals(
+        self, responses_dir, filtered_comments_file
+    ):
+        """Verify token totals and cost are written into the state dict."""
+        # Arrange
+        state = init_state()
+
+        # Act
+        build_sentiment_dataframe(responses_dir, filtered_comments_file, state)
+
+        # Assert
+        assert state["total_input_tokens"] == 180
+        assert state["total_output_tokens"] == 35
+        assert state["estimated_cost_usd"] > 0

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -3,11 +3,12 @@
 import json
 from pathlib import Path
 
+import polars as pl
 import pytest
 
 from pipeline.batch import init_state
 from pipeline.results import build_sentiment_dataframe
-from pipeline.schemas import SENTIMENT_SCHEMA
+from pipeline.schemas import COMMENT_INPUT_SCHEMA, SENTIMENT_SCHEMA
 
 
 def _succeeded(
@@ -177,3 +178,41 @@ class TestBuildSentimentDataframe:
         assert state["total_input_tokens"] == 180
         assert state["total_output_tokens"] == 35
         assert state["estimated_cost_usd"] > 0
+
+    def test_malformed_results_json_raises_with_filename(
+        self, tmp_path, filtered_comments_file
+    ):
+        """Verify a corrupted results file fails fast naming the file."""
+        # Arrange
+        directory = tmp_path / "responses"
+        directory.mkdir()
+        (directory / "batch_001_results.jsonl").write_text("{not valid json\n")
+
+        # Act / Assert
+        with pytest.raises(ValueError, match="batch_001_results.jsonl"):
+            build_sentiment_dataframe(directory, filtered_comments_file, init_state())
+
+    def test_construction_drift_raises_at_boundary(
+        self, monkeypatch, responses_dir, filtered_comments_file
+    ):
+        """Verify the write-boundary guard fires if construction drifts.
+
+        Simulates a future edit that changes a construction-side schema
+        without updating SENTIMENT_SCHEMA — the strict boundary check
+        must catch the divergence rather than write a drifted parquet.
+        """
+        # Arrange
+        drifted = pl.Schema(
+            {
+                name: (pl.Int32 if name == "score" else dtype)
+                for name, dtype in COMMENT_INPUT_SCHEMA.items()
+            }
+        )
+        monkeypatch.setattr("pipeline.results.COMMENT_INPUT_SCHEMA", drifted)
+
+        # Act / Assert
+        with pytest.raises(ValueError, match="sentiment.parquet") as exc:
+            build_sentiment_dataframe(
+                responses_dir, filtered_comments_file, init_state()
+            )
+        assert "score" in str(exc.value)

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -1,0 +1,85 @@
+"""Tests for pipeline/schemas.py schema validation."""
+
+import polars as pl
+import pytest
+
+from pipeline.schemas import SENTIMENT_SCHEMA, validate_schema
+
+
+@pytest.fixture
+def sentiment_frame() -> pl.DataFrame:
+    """One-row DataFrame conforming exactly to SENTIMENT_SCHEMA."""
+    return pl.DataFrame(
+        [
+            {
+                "comment_id": "abc123",
+                "body": "LeBron is washed",
+                "author": "user123",
+                "author_flair_text": "Lakers",
+                "author_flair_css_class": "lakers",
+                "created_utc": 1709251200,
+                "score": 10,
+                "mentioned_players": ["LeBron James"],
+                "sentiment": "neg",
+                "confidence": 0.95,
+                "sentiment_player": "LeBron James",
+                "input_tokens": 100,
+                "output_tokens": 20,
+            }
+        ],
+        schema=SENTIMENT_SCHEMA,
+    )
+
+
+class TestValidateSchema:
+    """Tests for validate_schema fail-fast behavior and diagnostics."""
+
+    def test_conforming_frame_passes(self, sentiment_frame):
+        """Verify a frame matching the schema validates without raising."""
+        # Arrange / Act / Assert — no exception is the assertion
+        validate_schema(sentiment_frame, SENTIMENT_SCHEMA, "sentiment.parquet")
+
+    def test_missing_column_raises(self, sentiment_frame):
+        """Verify a dropped column is reported by name."""
+        # Arrange
+        df = sentiment_frame.drop("score")
+
+        # Act / Assert
+        with pytest.raises(ValueError, match="sentiment.parquet") as exc:
+            validate_schema(df, SENTIMENT_SCHEMA, "sentiment.parquet")
+        assert "missing columns" in str(exc.value)
+        assert "score" in str(exc.value)
+
+    def test_extra_column_raises(self, sentiment_frame):
+        """Verify an unexpected column is reported by name."""
+        # Arrange
+        df = sentiment_frame.with_columns(pl.lit(1).alias("bonus"))
+
+        # Act / Assert
+        with pytest.raises(ValueError, match="sentiment.parquet") as exc:
+            validate_schema(df, SENTIMENT_SCHEMA, "sentiment.parquet")
+        assert "extra columns" in str(exc.value)
+        assert "bonus" in str(exc.value)
+
+    def test_dtype_mismatch_raises(self, sentiment_frame):
+        """Verify a wrong dtype is reported with expected and actual types."""
+        # Arrange
+        df = sentiment_frame.with_columns(pl.col("score").cast(pl.Int32))
+
+        # Act / Assert
+        with pytest.raises(ValueError, match="sentiment.parquet") as exc:
+            validate_schema(df, SENTIMENT_SCHEMA, "sentiment.parquet")
+        message = str(exc.value)
+        assert "score" in message
+        assert "Int64" in message
+        assert "Int32" in message
+
+    def test_column_order_mismatch_raises(self, sentiment_frame):
+        """Verify reordered columns fail with an order-specific diagnostic."""
+        # Arrange
+        df = sentiment_frame.select(list(reversed(SENTIMENT_SCHEMA.names())))
+
+        # Act / Assert
+        with pytest.raises(ValueError, match="sentiment.parquet") as exc:
+            validate_schema(df, SENTIMENT_SCHEMA, "sentiment.parquet")
+        assert "column order" in str(exc.value)


### PR DESCRIPTION
## Summary

Closes #27.

- **`pipeline/schemas.py`** — single source of truth for produced-file contracts: `SENTIMENT_SCHEMA` (13-column `sentiment.parquet`), four aggregate-view schemas (parquet-ready target shape for #28), `SCHEMA_VERSION`, and a `validate_schema()` helper that fails fast with the schema name and every missing/extra/mismatched column.
- **Write-boundary enforcement** — `build_sentiment_dataframe` moved from `scripts/collect_results.py` to `pipeline/results.py` (thin-scripts convention). Dtypes are pinned at both construction sites (`scan_ndjson(schema=...)`, `pl.DataFrame(..., schema=RESULTS_SCHEMA)`) and the assembled frame is strictly validated against `SENTIMENT_SCHEMA` before write. No casts anywhere — a cast would only hide a construction bug. `OUTPUT_COLUMNS` (names-only) retired.
- **Latent bug fixed** — an all-errored batch previously produced a 0-column frame that would crash the join; `schema=RESULTS_SCHEMA` makes the empty case construct correctly (locked by test).
- **`SCHEMA_VERSION` stamped into `aggregates.json` metadata** for cross-season drift detection.
- **Testing rules** updated: fixture reuse-before-defining, promote-on-second-consumer, parametrize-within-a-behavior.
- Docs now point at `pipeline/schemas.py` instead of duplicating column lists.

Per discussion: aggregate-view enforcement is deliberately deferred to #28, where the views get a real write boundary (parquet export).

## Verification

- 238 tests passing (12 new), ruff clean
- Contract vs reality: `pl.read_parquet_schema` footer of the real v1 `sentiment.parquet` (1.93M rows) equals `SENTIMENT_SCHEMA` exactly
