### PR TITLE
feat(pipeline): export per-table parquet alongside aggregates.json

### DIFF
--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -17,6 +17,7 @@ from .batch import (
 from .processors import ProcessingStats, extract_fields, has_valid_body, process_line
 from .results import build_sentiment_dataframe
 from .schemas import (
+    AGGREGATE_VIEW_SCHEMAS,
     PLAYER_OVERALL_SCHEMA,
     PLAYER_TEAM_SCHEMA,
     PLAYER_TEMPORAL_SCHEMA,
@@ -27,6 +28,7 @@ from .schemas import (
 )
 
 __all__ = [
+    "AGGREGATE_VIEW_SCHEMAS",
     "ArcticShiftClient",
     "PLAYER_OVERALL_SCHEMA",
     "PLAYER_TEAM_SCHEMA",

--- a/pipeline/aggregation.py
+++ b/pipeline/aggregation.py
@@ -11,7 +11,12 @@ from pathlib import Path
 
 import polars as pl
 
-from pipeline.schemas import SCHEMA_VERSION
+from pipeline.schemas import (
+    AGGREGATE_VIEW_SCHEMAS,
+    SCHEMA_VERSION,
+    SENTIMENT_SCHEMA,
+    validate_schema,
+)
 from utils.player_config import build_alias_to_player_map, load_player_metadata
 from utils.season_config import get_active_season
 from utils.team_config import build_alias_to_team_map, load_team_config
@@ -92,7 +97,7 @@ def extract_team_from_flair(
     return None
 
 
-def compute_metrics(df: pl.DataFrame, group_cols: list[str]) -> list[dict]:
+def compute_metrics(df: pl.DataFrame, group_cols: list[str]) -> pl.DataFrame:
     """
     Compute sentiment metrics grouped by specified columns.
 
@@ -104,7 +109,8 @@ def compute_metrics(df: pl.DataFrame, group_cols: list[str]) -> list[dict]:
         group_cols: Columns to group by.
 
     Returns:
-        List of dicts with group keys and computed metrics.
+        DataFrame with group columns first, then count and rate columns,
+        sorted by group_cols (group_by row order is nondeterministic).
     """
     grouped = (
         df.group_by(group_cols)
@@ -132,7 +138,7 @@ def compute_metrics(df: pl.DataFrame, group_cols: list[str]) -> list[dict]:
         )
     )
 
-    return grouped.to_dicts()
+    return grouped.sort(group_cols)
 
 
 def aggregate_sentiment(input_path: Path) -> dict:
@@ -146,11 +152,17 @@ def aggregate_sentiment(input_path: Path) -> dict:
         input_path: Path to sentiment.parquet file.
 
     Returns:
-        Dict with keys: player_overall, player_temporal, player_team,
-        team_overall, metadata.
+        Dict where player_overall, player_temporal, player_team, and
+        team_overall hold pl.DataFrames conforming to
+        AGGREGATE_VIEW_SCHEMAS; player_metadata and metadata are dicts.
+
+    Raises:
+        ValueError: If the input parquet does not match SENTIMENT_SCHEMA,
+            or a computed view does not match its schema contract.
     """
     logger.info(f"Loading sentiment data from {input_path}")
     df = pl.read_parquet(input_path)
+    validate_schema(df, SENTIMENT_SCHEMA, str(input_path))
     total_rows = len(df)
     logger.info(f"Loaded {total_rows:,} rows")
 
@@ -213,8 +225,9 @@ def aggregate_sentiment(input_path: Path) -> dict:
     # Player overall (attributed only)
     logger.info("Computing player_overall...")
     df_attributed = df.filter(pl.col("attributed_player").is_not_null())
-    player_overall = compute_metrics(df_attributed, ["attributed_player"])
-    player_overall.sort(key=lambda x: x["neg_rate"], reverse=True)
+    player_overall = compute_metrics(df_attributed, ["attributed_player"]).sort(
+        ["neg_rate", "attributed_player"], descending=[True, False]
+    )
 
     # Player temporal (attributed only)
     logger.info("Computing player_temporal...")
@@ -230,14 +243,30 @@ def aggregate_sentiment(input_path: Path) -> dict:
     # Team overall (team non-null)
     logger.info("Computing team_overall...")
     df_team = df.filter(pl.col("team").is_not_null())
-    team_overall = compute_metrics(df_team, ["team"])
 
-    # Add abbreviation, conference and logo_url to each team row
-    for row in team_overall:
-        team_info = team_config.get(row["team"], {})
-        row["abbreviation"] = team_info.get("abbreviation")
-        row["conference"] = team_info.get("conference")
-        row["logo_url"] = team_info.get("logo_url")
+    # Enrich with abbreviation, conference and logo_url from config/teams.yaml.
+    # Schema pin so an all-null column can't infer as Null dtype; left join
+    # appends the enrichment columns after the metrics, matching
+    # TEAM_OVERALL_SCHEMA order. Re-sort because joins don't preserve row order.
+    team_enrichment = pl.DataFrame(
+        {
+            "team": list(team_config),
+            "abbreviation": [info["abbreviation"] for info in team_config.values()],
+            "conference": [info["conference"] for info in team_config.values()],
+            "logo_url": [info["logo_url"] for info in team_config.values()],
+        },
+        schema={
+            "team": pl.String,
+            "abbreviation": pl.String,
+            "conference": pl.String,
+            "logo_url": pl.String,
+        },
+    )
+    team_overall = (
+        compute_metrics(df_team, ["team"])
+        .join(team_enrichment, on="team", how="left")
+        .sort("team")
+    )
 
     # Metadata
     unique_players = df_attributed["attributed_player"].n_unique()
@@ -259,7 +288,7 @@ def aggregate_sentiment(input_path: Path) -> dict:
 
     # Filter player metadata to only players in player_overall
     # and enrich with team logo_url
-    attributed_players = {row["attributed_player"] for row in player_overall}
+    attributed_players = set(player_overall.get_column("attributed_player").to_list())
     filtered_player_metadata = {}
     for player, meta in player_metadata.items():
         if player in attributed_players:
@@ -273,11 +302,17 @@ def aggregate_sentiment(input_path: Path) -> dict:
         f"{unique_teams} teams, {unique_weeks} weeks"
     )
 
-    return {
+    views = {
         "player_overall": player_overall,
         "player_temporal": player_temporal,
         "player_team": player_team,
         "team_overall": team_overall,
+    }
+    for view_name, schema in AGGREGATE_VIEW_SCHEMAS.items():
+        validate_schema(views[view_name], schema, view_name)
+
+    return {
+        **views,
         "player_metadata": filtered_player_metadata,
         "metadata": metadata,
     }

--- a/pipeline/aggregation.py
+++ b/pipeline/aggregation.py
@@ -333,7 +333,9 @@ def compute_cumulative_metrics(player_temporal: list[dict]) -> pl.DataFrame:
     keeping cumulative totals stable.
 
     Args:
-        player_temporal: List of weekly metric dicts from aggregates.json.
+        player_temporal: List of weekly metric dicts read back from
+            aggregates.json, with week as a serialized string — not the
+            in-memory DataFrame view returned by aggregate_sentiment().
             Each dict has: attributed_player, week, neg_count, comment_count.
 
     Returns:

--- a/pipeline/schemas.py
+++ b/pipeline/schemas.py
@@ -5,13 +5,11 @@ Single source of truth for column names and dtypes of every file the
 pipeline produces. Data dictionary first, enforcement second:
 
 - SENTIMENT_SCHEMA is enforced at the sentiment.parquet write boundary
-  (pipeline/results.py).
-- The four aggregate-view schemas document the tabular sections of
-  aggregates.json in their parquet-ready shape; enforcement arrives with
-  their parquet write boundary (issue #28). Note: team_overall's
-  enrichment columns (abbreviation, conference, logo_url) are currently
-  added dict-level after aggregation — the schema records the target
-  shape #28 must produce.
+  (pipeline/results.py) and again as a read-side guard in
+  pipeline/aggregation.py.
+- The four aggregate-view schemas describe the tabular sections of
+  aggregates.json in their parquet-ready shape; they are enforced in
+  aggregate_sentiment() before the views are returned for writing.
 
 This module must not import from other pipeline modules (it is imported
 by them).
@@ -83,7 +81,7 @@ RESULTS_SCHEMA = pl.Schema(
     }
 )
 
-# --- Aggregate views (tabular sections of aggregates.json; enforced in #28) -
+# --- Aggregate views (enforced in pipeline/aggregation.py) ------------------
 # Column order mirrors compute_metrics output: group cols, counts, rates.
 
 _METRIC_COLUMNS: dict[str, pl.DataType] = {
@@ -120,6 +118,17 @@ TEAM_OVERALL_SCHEMA = pl.Schema(
         "logo_url": pl.String,
     }
 )
+
+# View name -> schema, shared by aggregate_sentiment()'s validation loop
+# and the aggregation script's parquet write loop. Keys match the
+# aggregate_sentiment() return-dict keys and the parquet filenames
+# (<view>.parquet).
+AGGREGATE_VIEW_SCHEMAS: dict[str, pl.Schema] = {
+    "player_overall": PLAYER_OVERALL_SCHEMA,
+    "player_temporal": PLAYER_TEMPORAL_SCHEMA,
+    "player_team": PLAYER_TEAM_SCHEMA,
+    "team_overall": TEAM_OVERALL_SCHEMA,
+}
 
 
 def validate_schema(df: pl.DataFrame, expected: pl.Schema, name: str) -> None:

--- a/scripts/aggregate_sentiment.py
+++ b/scripts/aggregate_sentiment.py
@@ -1,9 +1,11 @@
 """
-Aggregate sentiment data into dashboard-ready JSON.
+Aggregate sentiment data into dashboard-ready outputs.
 
 Reads classified sentiment parquet, computes player rankings,
-flair segmentation, and temporal trends. Outputs precomputed
-aggregates for the Streamlit dashboard.
+flair segmentation, and temporal trends. Writes the nested
+aggregates.json for the Streamlit dashboard plus one parquet per
+tabular view (player_overall, player_temporal, player_team,
+team_overall) alongside it for ad-hoc DuckDB queries.
 
 Usage:
     uv run python -m scripts.aggregate_sentiment
@@ -17,6 +19,7 @@ import sys
 from pathlib import Path
 
 from pipeline.aggregation import aggregate_sentiment
+from pipeline.schemas import AGGREGATE_VIEW_SCHEMAS
 from utils.paths import get_dashboard_dir, get_processed_dir
 
 # -----------------------------------------------------------------------------
@@ -89,11 +92,22 @@ def main() -> None:
     # Ensure output directory exists
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Write JSON output
+    # Write JSON output: frame views -> records, key order preserved;
+    # default=str keeps week datetimes serialized exactly as before.
+    serializable = {
+        key: (value.to_dicts() if key in AGGREGATE_VIEW_SCHEMAS else value)
+        for key, value in result.items()
+    }
     with open(output_path, "w") as f:
-        json.dump(result, f, indent=2, default=str)
+        json.dump(serializable, f, indent=2, default=str)
 
     logger.info(f"Wrote aggregates to {output_path}")
+
+    # Write one parquet per tabular view next to the JSON
+    for view_name in AGGREGATE_VIEW_SCHEMAS:
+        parquet_path = output_path.parent / f"{view_name}.parquet"
+        result[view_name].write_parquet(parquet_path)
+        logger.info(f"Wrote {parquet_path}")
 
     # Log metadata summary
     meta = result["metadata"]

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -6,6 +6,7 @@ and compute_metrics from the aggregation pipeline.
 """
 
 import polars as pl
+import pytest
 
 from pipeline.aggregation import (
     aggregate_sentiment,
@@ -16,7 +17,7 @@ from pipeline.aggregation import (
     pivot_bar_race_wide,
     resolve_player,
 )
-from pipeline.schemas import SCHEMA_VERSION
+from pipeline.schemas import AGGREGATE_VIEW_SCHEMAS, SCHEMA_VERSION, SENTIMENT_SCHEMA
 
 
 class TestResolvePlayer:
@@ -135,11 +136,10 @@ class TestComputeMetrics:
             "sentiment": ["neg", "neg", "pos", "neu", "neu", "neg", "pos", "pos"],
         })
 
-        results = compute_metrics(df, ["player"])
-        results_by_player = {r["player"]: r for r in results}
+        result = compute_metrics(df, ["player"])
 
         # Player A: 2 neg, 1 pos, 2 neu = 5 total
-        a = results_by_player["A"]
+        a = result.row(by_predicate=pl.col("player") == "A", named=True)
         assert a["neg_count"] == 2
         assert a["pos_count"] == 1
         assert a["neu_count"] == 2
@@ -150,7 +150,7 @@ class TestComputeMetrics:
         assert a["polarization"] == 0.6
 
         # Player B: 1 neg, 2 pos, 0 neu = 3 total
-        b = results_by_player["B"]
+        b = result.row(by_predicate=pl.col("player") == "B", named=True)
         assert b["neg_count"] == 1
         assert b["pos_count"] == 2
         assert b["neu_count"] == 0
@@ -163,8 +163,8 @@ class TestComputeMetrics:
             "sentiment": ["neg", "pos", "pos"],
         })
 
-        results = compute_metrics(df, ["player"])
-        a = results[0]
+        result = compute_metrics(df, ["player"])
+        a = result.row(0, named=True)
 
         assert a["neg_rate"] == 0.3333
         assert a["pos_rate"] == 0.6667
@@ -177,13 +177,25 @@ class TestComputeMetrics:
             "sentiment": ["neg", "pos", "neu"],
         })
 
-        results = compute_metrics(df, ["player", "team"])
-        assert len(results) == 3
+        result = compute_metrics(df, ["player", "team"])
+        assert result.height == 3
+
+    def test_returns_frame_sorted_by_group_cols(self):
+        """Output is a DataFrame deterministically sorted by the group columns."""
+        df = pl.DataFrame({
+            "player": ["C", "A", "B"],
+            "sentiment": ["neg", "pos", "neu"],
+        })
+
+        result = compute_metrics(df, ["player"])
+
+        assert isinstance(result, pl.DataFrame)
+        assert result["player"].to_list() == ["A", "B", "C"]
 
 
 def _make_test_parquet(tmp_path, rows):
-    """Create a minimal sentiment parquet for testing aggregate_sentiment."""
-    df = pl.DataFrame(rows)
+    """Create a SENTIMENT_SCHEMA-conforming parquet for testing aggregate_sentiment."""
+    df = pl.DataFrame(rows, schema=SENTIMENT_SCHEMA)
     path = tmp_path / "test_sentiment.parquet"
     df.write_parquet(path)
     return path
@@ -292,7 +304,7 @@ class TestAggregateTeamConference:
 
         result = aggregate_sentiment(path)
 
-        for row in result["team_overall"]:
+        for row in result["team_overall"].to_dicts():
             assert "conference" in row, f"Missing conference for {row['team']}"
 
     def test_conference_values_correct(self, tmp_path):
@@ -314,7 +326,7 @@ class TestAggregateTeamConference:
         })
 
         result = aggregate_sentiment(path)
-        team_by_name = {r["team"]: r for r in result["team_overall"]}
+        team_by_name = {r["team"]: r for r in result["team_overall"].to_dicts()}
 
         assert team_by_name["Los Angeles Lakers"]["conference"] == "West"
         assert team_by_name["Boston Celtics"]["conference"] == "East"
@@ -338,7 +350,7 @@ class TestAggregateTeamConference:
         })
 
         result = aggregate_sentiment(path)
-        team_by_name = {r["team"]: r for r in result["team_overall"]}
+        team_by_name = {r["team"]: r for r in result["team_overall"].to_dicts()}
 
         assert team_by_name["Los Angeles Lakers"]["abbreviation"] == "LAL"
         assert team_by_name["Boston Celtics"]["abbreviation"] == "BOS"
@@ -363,10 +375,104 @@ class TestAggregateTeamConference:
 
         result = aggregate_sentiment(path)
 
-        for row in result["team_overall"]:
+        for row in result["team_overall"].to_dicts():
             assert "logo_url" in row, f"Missing logo_url for {row['team']}"
             assert row["logo_url"] is not None
             assert "cdn.nba.com/logos" in row["logo_url"]
+
+
+class TestAggregateViews:
+    """Tests for the four DataFrame views returned by aggregate_sentiment."""
+
+    @pytest.fixture
+    def views_parquet(self, tmp_path):
+        """Parquet with attributed players and team flairs so all views are non-empty.
+
+        neg_rates by player: Giannis 1.0, Kevin Durant 0.5, LeBron James 0.5
+        (tie with Durant), Stephen Curry 0.0 — exercises the player_overall
+        sort and its tiebreaker.
+        """
+        return _make_test_parquet(tmp_path, {
+            "comment_id": ["c1", "c2", "c3", "c4", "c5", "c6"],
+            "body": [
+                "Giannis traveled again",
+                "KD is a snake",
+                "KD is unstoppable",
+                "LeBron is washed",
+                "LeBron is the GOAT",
+                "Curry never misses",
+            ],
+            "author": ["u1", "u2", "u3", "u4", "u5", "u6"],
+            "author_flair_text": [
+                ":lal-1: Lakers",
+                ":bos-1: Celtics",
+                ":lal-1: Lakers",
+                ":bos-1: Celtics",
+                ":lal-1: Lakers",
+                ":bos-1: Celtics",
+            ],
+            "author_flair_css_class": [
+                "lakers", "celtics", "lakers", "celtics", "lakers", "celtics",
+            ],
+            "created_utc": [
+                1704067200, 1704067200, 1704067200,  # week of 2024-01-01
+                1704672000, 1704672000, 1704672000,  # week of 2024-01-08
+            ],
+            "score": [10, 5, 8, 3, 12, 7],
+            "mentioned_players": [
+                ["Giannis Antetokounmpo"],
+                ["Kevin Durant"],
+                ["Kevin Durant"],
+                ["LeBron James"],
+                ["LeBron James"],
+                ["Stephen Curry"],
+            ],
+            "sentiment": ["neg", "neg", "pos", "neg", "pos", "pos"],
+            "confidence": [0.9, 0.8, 0.9, 0.85, 0.95, 0.9],
+            "sentiment_player": [
+                "Giannis Antetokounmpo",
+                "Kevin Durant",
+                "Kevin Durant",
+                "LeBron James",
+                "LeBron James",
+                "Stephen Curry",
+            ],
+            "input_tokens": [100, 100, 100, 100, 100, 100],
+            "output_tokens": [20, 20, 20, 20, 20, 20],
+        })
+
+    @pytest.mark.parametrize(
+        "view_name,schema",
+        AGGREGATE_VIEW_SCHEMAS.items(),
+        ids=AGGREGATE_VIEW_SCHEMAS.keys(),
+    )
+    def test_views_conform_to_schemas(self, views_parquet, view_name, schema):
+        """Each returned view matches its schema contract exactly."""
+        result = aggregate_sentiment(views_parquet)
+
+        assert result[view_name].schema == schema
+
+    def test_player_overall_sorted_by_neg_rate_desc_then_player_asc(
+        self, views_parquet
+    ):
+        """player_overall sorts by neg_rate descending, player name on ties."""
+        result = aggregate_sentiment(views_parquet)
+
+        players = result["player_overall"]["attributed_player"].to_list()
+        assert players == [
+            "Giannis Antetokounmpo",  # 1.0
+            "Kevin Durant",  # 0.5 — tie, alphabetical before LeBron
+            "LeBron James",  # 0.5
+            "Stephen Curry",  # 0.0
+        ]
+
+    def test_rejects_nonconforming_input_parquet(self, tmp_path):
+        """Input parquet not matching SENTIMENT_SCHEMA fails fast."""
+        path = tmp_path / "bad.parquet"
+        pl.DataFrame({"comment_id": ["c1"], "body": ["hello"]}).write_parquet(path)
+
+        with pytest.raises(ValueError, match="Schema validation failed"):
+            aggregate_sentiment(path)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #28

## Summary

Promotes the four aggregate views (`player_overall`, `player_temporal`, `player_team`, `team_overall`) from list-of-dicts to Polars DataFrames end-to-end, validates them against the #27 schema contracts, and writes one parquet per view alongside `aggregates.json` for clean ad-hoc DuckDB queries.

- **`pipeline/schemas.py`** — `AGGREGATE_VIEW_SCHEMAS` mapping (view name → schema), shared by the validation loop and the script's write loop so the view list can't drift
- **`pipeline/aggregation.py`**
  - `compute_metrics()` returns a frame sorted by its group columns — fixes the nondeterministic `group_by` row order behind the ~74k-line cosmetic `aggregates.json` diffs (Session Log 2026-06-10 open question: deterministic sort, file stays tracked)
  - `player_overall` sorted `neg_rate` desc with `attributed_player` asc tiebreaker
  - `team_overall` enrichment is now a left join against a schema-pinned frame from `config/teams.yaml` — produces `TEAM_OVERALL_SCHEMA` shape by construction
  - Read-side guard: input parquet validated against `SENTIMENT_SCHEMA` immediately after read; all four views validated before return
- **`scripts/aggregate_sentiment.py`** — frames convert to records at JSON serialization (`default=str` keeps `week` byte-identical, Streamlit and bar-race export unaffected); parquet write loop keyed on `AGGREGATE_VIEW_SCHEMAS`, directory derived from `--output` so all five files travel together
- **Tests** — fixtures pin `SENTIMENT_SCHEMA` at construction (all-null/empty-list columns otherwise infer `Null` dtypes and trip the new guard); assertions migrated to frame-based access; new `TestAggregateViews` covers schema conformance (parametrized over the mapping), the sort + tiebreaker, and the foreign-input rejection

## Not in this PR (per ticket)

- No `.gitignore` change — the dashboard parquets are intentionally untracked local conveniences
- v1 parquet backfill + `schema_version: 1` stamp into the committed `aggregates.json` happens in the one-off post-merge re-aggregation (last noisy diff; deterministic from then on)

## Verification

- `uv run pytest` — 247 passed (7 new)
- `uv run ruff check .` — clean
- End-to-end smoke run on a synthetic `SENTIMENT_SCHEMA` parquet in a scratch dir: JSON keys/shape unchanged, `week` serialized identically, four parquets written, DuckDB `SELECT * FROM player_overall.parquet` returns correct rows