### PR TITLE
chore(config): ignore docs/internal for local reference docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,8 @@ data/2024-25/*
 docs/notion.md
 .claude/settings.local.json
 
+# Local reference docs — frozen research / working notes (internal working dir)
+docs/internal/
+
 # uv
 .python-version


### PR DESCRIPTION
Adds a `docs/internal/` ignore rule as the home for frozen, season-scoped research and working notes that shouldn't ship in the public repo (v1 feedback synthesis, data analysis, and the local planning docs).

No code or behavior impact — gitignore only.