### PR TITLE
feat(pipeline): export player_metadata as the Player dimension parquet

### DIFF
--- a/pipeline/aggregation.py
+++ b/pipeline/aggregation.py
@@ -13,6 +13,7 @@ import polars as pl
 
 from pipeline.schemas import (
     AGGREGATE_VIEW_SCHEMAS,
+    PLAYER_METADATA_SCHEMA,
     SCHEMA_VERSION,
     SENTIMENT_SCHEMA,
     validate_schema,
@@ -153,8 +154,9 @@ def aggregate_sentiment(input_path: Path) -> dict:
 
     Returns:
         Dict where player_overall, player_temporal, player_team, and
-        team_overall hold pl.DataFrames conforming to
-        AGGREGATE_VIEW_SCHEMAS; player_metadata and metadata are dicts.
+        team_overall hold pl.DataFrames conforming to AGGREGATE_VIEW_SCHEMAS;
+        player_metadata holds a pl.DataFrame conforming to
+        PLAYER_METADATA_SCHEMA (the Player dimension); metadata is a dict.
 
     Raises:
         ValueError: If the input parquet does not match SENTIMENT_SCHEMA,
@@ -286,16 +288,24 @@ def aggregate_sentiment(input_path: Path) -> dict:
         "generated_at": datetime.now(timezone.utc).isoformat(),
     }
 
-    # Filter player metadata to only players in player_overall
-    # and enrich with team logo_url
+    # Build the Player dimension: one row per attributed player, enriched with
+    # the roster team's logo. Built in players.yaml order filtered to attributed
+    # players — matching the prior dict's key order so the reconstructed
+    # aggregates.json stays byte-shape identical (see player_metadata_to_dict).
     attributed_players = set(player_overall.get_column("attributed_player").to_list())
-    filtered_player_metadata = {}
-    for player, meta in player_metadata.items():
-        if player in attributed_players:
-            enriched = dict(meta)
-            team_info = team_config.get(enriched.get("team", ""), {})
-            enriched["logo_url"] = team_info.get("logo_url")
-            filtered_player_metadata[player] = enriched
+    metadata_rows = [
+        {
+            "attributed_player": player,
+            "team": meta.get("team"),
+            "conference": meta.get("conference"),
+            "player_id": meta.get("player_id"),
+            "headshot_url": meta.get("headshot_url"),
+            "logo_url": team_config.get(meta.get("team") or "", {}).get("logo_url"),
+        }
+        for player, meta in player_metadata.items()
+        if player in attributed_players
+    ]
+    player_metadata_df = pl.DataFrame(metadata_rows, schema=PLAYER_METADATA_SCHEMA)
 
     logger.info(
         f"Aggregation complete: {unique_players} players, "
@@ -310,11 +320,40 @@ def aggregate_sentiment(input_path: Path) -> dict:
     }
     for view_name, schema in AGGREGATE_VIEW_SCHEMAS.items():
         validate_schema(views[view_name], schema, view_name)
+    validate_schema(player_metadata_df, PLAYER_METADATA_SCHEMA, "player_metadata")
 
     return {
         **views,
-        "player_metadata": filtered_player_metadata,
+        "player_metadata": player_metadata_df,
         "metadata": metadata,
+    }
+
+
+def player_metadata_to_dict(df: pl.DataFrame) -> dict[str, dict]:
+    """
+    Reconstruct the nested aggregates.json metadata dict from the frame.
+
+    Inverse of the Player-dimension frame built in aggregate_sentiment(): keys
+    the dict by player name and drops attributed_player from the value (it is
+    the key). Row order is preserved so the serialized aggregates.json stays
+    byte-shape identical to the pre-#39 dict output.
+
+    Args:
+        df: Player dimension frame conforming to PLAYER_METADATA_SCHEMA.
+
+    Returns:
+        Dict mapping player name to {team, conference, player_id,
+        headshot_url, logo_url}, in frame-row order.
+    """
+    return {
+        row["attributed_player"]: {
+            "team": row["team"],
+            "conference": row["conference"],
+            "player_id": row["player_id"],
+            "headshot_url": row["headshot_url"],
+            "logo_url": row["logo_url"],
+        }
+        for row in df.iter_rows(named=True)
     }
 
 

--- a/pipeline/schemas.py
+++ b/pipeline/schemas.py
@@ -119,15 +119,43 @@ TEAM_OVERALL_SCHEMA = pl.Schema(
     }
 )
 
-# View name -> schema, shared by aggregate_sentiment()'s validation loop
-# and the aggregation script's parquet write loop. Keys match the
-# aggregate_sentiment() return-dict keys and the parquet filenames
-# (<view>.parquet).
+# View name -> schema for the four aggregate *views* (fact-table rollups).
+# Keys match aggregate_sentiment() return-dict keys and parquet filenames.
+# Deliberately fact-only: the aggregation script keys its JSON record-shaping
+# predicate ("is this a list of records?") off this mapping, so the Player
+# dimension below must NOT live here — it serializes to a nested dict.
 AGGREGATE_VIEW_SCHEMAS: dict[str, pl.Schema] = {
     "player_overall": PLAYER_OVERALL_SCHEMA,
     "player_temporal": PLAYER_TEMPORAL_SCHEMA,
     "player_team": PLAYER_TEAM_SCHEMA,
     "team_overall": TEAM_OVERALL_SCHEMA,
+}
+
+# --- Player dimension (enforced in pipeline/aggregation.py) ------------------
+# One row per attributed player — the Player dimension the views' attributed_player
+# FK references. Materialized as player_metadata.parquet; also re-serialized to a
+# nested {player: {...}} dict in aggregates.json. A dimension, not an aggregate
+# view, so it is kept out of AGGREGATE_VIEW_SCHEMAS (see note above).
+# NOTE: `team` here is the *roster* team (who the player plays for) — distinct
+# from the *fanbase* `team` in player_team/team_overall. See docs/data-model.md §2.
+PLAYER_METADATA_SCHEMA = pl.Schema(
+    {
+        "attributed_player": pl.String,
+        "team": pl.String,
+        "conference": pl.String,
+        "player_id": pl.Int64,
+        "headshot_url": pl.String,
+        "logo_url": pl.String,
+    }
+)
+
+# Every parquet the aggregation script writes -> its schema. Single source for
+# the write + validation loops; supersets AGGREGATE_VIEW_SCHEMAS with the Player
+# dimension. Use this for "what gets written as parquet"; use
+# AGGREGATE_VIEW_SCHEMAS for "what is a record-shaped view" (JSON serialization).
+PARQUET_SCHEMAS: dict[str, pl.Schema] = {
+    **AGGREGATE_VIEW_SCHEMAS,
+    "player_metadata": PLAYER_METADATA_SCHEMA,
 }
 
 

--- a/scripts/aggregate_sentiment.py
+++ b/scripts/aggregate_sentiment.py
@@ -18,8 +18,8 @@ import logging
 import sys
 from pathlib import Path
 
-from pipeline.aggregation import aggregate_sentiment
-from pipeline.schemas import AGGREGATE_VIEW_SCHEMAS
+from pipeline.aggregation import aggregate_sentiment, player_metadata_to_dict
+from pipeline.schemas import AGGREGATE_VIEW_SCHEMAS, PARQUET_SCHEMAS
 from utils.paths import get_dashboard_dir, get_processed_dir
 
 # -----------------------------------------------------------------------------
@@ -92,19 +92,25 @@ def main() -> None:
     # Ensure output directory exists
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Write JSON output: frame views -> records, key order preserved;
-    # default=str keeps week datetimes serialized exactly as before.
-    serializable = {
-        key: (value.to_dicts() if key in AGGREGATE_VIEW_SCHEMAS else value)
-        for key, value in result.items()
-    }
+    # Write JSON output: the four record-shaped views -> lists of dicts; the
+    # Player dimension -> its nested {player: {...}} dict (byte-shape identical
+    # to pre-#39); the metadata scalar passes through. default=str keeps week
+    # datetimes serialized exactly as before.
+    serializable = {}
+    for key, value in result.items():
+        if key in AGGREGATE_VIEW_SCHEMAS:
+            serializable[key] = value.to_dicts()
+        elif key == "player_metadata":
+            serializable[key] = player_metadata_to_dict(value)
+        else:
+            serializable[key] = value
     with open(output_path, "w") as f:
         json.dump(serializable, f, indent=2, default=str)
 
     logger.info(f"Wrote aggregates to {output_path}")
 
-    # Write one parquet per tabular view next to the JSON
-    for view_name in AGGREGATE_VIEW_SCHEMAS:
+    # Write one parquet per produced table (four views + the Player dimension)
+    for view_name in PARQUET_SCHEMAS:
         parquet_path = output_path.parent / f"{view_name}.parquet"
         result[view_name].write_parquet(parquet_path)
         logger.info(f"Wrote {parquet_path}")

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -15,9 +15,15 @@ from pipeline.aggregation import (
     extract_team_from_flair,
     mask_below_threshold,
     pivot_bar_race_wide,
+    player_metadata_to_dict,
     resolve_player,
 )
-from pipeline.schemas import AGGREGATE_VIEW_SCHEMAS, SCHEMA_VERSION, SENTIMENT_SCHEMA
+from pipeline.schemas import (
+    AGGREGATE_VIEW_SCHEMAS,
+    PLAYER_METADATA_SCHEMA,
+    SCHEMA_VERSION,
+    SENTIMENT_SCHEMA,
+)
 
 
 class TestResolvePlayer:
@@ -201,62 +207,51 @@ def _make_test_parquet(tmp_path, rows):
     return path
 
 
+def _lebron_parquet(tmp_path):
+    """Two LeBron comments (one Lakers, one Celtics flair) — LeBron the only
+    attributed player. Shared by the Player-dimension tests."""
+    return _make_test_parquet(tmp_path, {
+        "comment_id": ["c1", "c2"],
+        "body": ["LeBron is great", "LeBron is washed"],
+        "author": ["u1", "u2"],
+        "author_flair_text": [":lal-1: Lakers", ":bos-1: Celtics"],
+        "author_flair_css_class": ["lakers", "celtics"],
+        "created_utc": [1704067200, 1704153600],
+        "score": [10, 5],
+        "mentioned_players": [["LeBron James"], ["LeBron James"]],
+        "sentiment": ["pos", "neg"],
+        "confidence": [0.9, 0.8],
+        "sentiment_player": ["LeBron James", "LeBron James"],
+        "input_tokens": [100, 100],
+        "output_tokens": [20, 20],
+    })
+
+
 class TestAggregatePlayerMetadata:
-    """Tests for player_metadata key in aggregate output."""
+    """Tests for the player_metadata Player-dimension frame in aggregate output."""
 
-    def test_player_metadata_key_exists(self, tmp_path):
-        """Output contains player_metadata top-level key."""
-        path = _make_test_parquet(tmp_path, {
-            "comment_id": ["c1", "c2"],
-            "body": ["LeBron is great", "LeBron is washed"],
-            "author": ["u1", "u2"],
-            "author_flair_text": [":lal-1: Lakers", ":bos-1: Celtics"],
-            "author_flair_css_class": ["lakers", "celtics"],
-            "created_utc": [1704067200, 1704153600],
-            "score": [10, 5],
-            "mentioned_players": [["LeBron James"], ["LeBron James"]],
-            "sentiment": ["pos", "neg"],
-            "confidence": [0.9, 0.8],
-            "sentiment_player": ["LeBron James", "LeBron James"],
-            "input_tokens": [100, 100],
-            "output_tokens": [20, 20],
-        })
+    def test_player_metadata_is_frame_conforming_to_schema(self, tmp_path):
+        """player_metadata is returned as a frame matching PLAYER_METADATA_SCHEMA."""
+        result = aggregate_sentiment(_lebron_parquet(tmp_path))
 
-        result = aggregate_sentiment(path)
-
-        assert "player_metadata" in result
-        assert isinstance(result["player_metadata"], dict)
+        assert isinstance(result["player_metadata"], pl.DataFrame)
+        assert result["player_metadata"].schema == PLAYER_METADATA_SCHEMA
 
     def test_metadata_contains_attributed_players(self, tmp_path):
-        """player_metadata includes metadata for attributed players."""
-        path = _make_test_parquet(tmp_path, {
-            "comment_id": ["c1", "c2"],
-            "body": ["LeBron is great", "LeBron is washed"],
-            "author": ["u1", "u2"],
-            "author_flair_text": [":lal-1: Lakers", ":bos-1: Celtics"],
-            "author_flair_css_class": ["lakers", "celtics"],
-            "created_utc": [1704067200, 1704153600],
-            "score": [10, 5],
-            "mentioned_players": [["LeBron James"], ["LeBron James"]],
-            "sentiment": ["pos", "neg"],
-            "confidence": [0.9, 0.8],
-            "sentiment_player": ["LeBron James", "LeBron James"],
-            "input_tokens": [100, 100],
-            "output_tokens": [20, 20],
-        })
+        """The frame has a row per attributed player, enriched with roster team."""
+        result = aggregate_sentiment(_lebron_parquet(tmp_path))
 
-        result = aggregate_sentiment(path)
-        meta = result["player_metadata"]
-
-        assert "LeBron James" in meta
-        assert meta["LeBron James"]["team"] == "Los Angeles Lakers"
-        assert meta["LeBron James"]["conference"] == "West"
-        assert meta["LeBron James"]["player_id"] == 2544
-        assert "logo_url" in meta["LeBron James"]
-        assert "cdn.nba.com/logos" in meta["LeBron James"]["logo_url"]
+        row = result["player_metadata"].row(
+            by_predicate=pl.col("attributed_player") == "LeBron James", named=True
+        )
+        assert row["team"] == "Los Angeles Lakers"
+        assert row["conference"] == "West"
+        assert row["player_id"] == 2544
+        assert row["headshot_url"] is not None
+        assert "cdn.nba.com/logos" in row["logo_url"]
 
     def test_metadata_excludes_non_attributed_players(self, tmp_path):
-        """player_metadata only includes players that appear in player_overall."""
+        """The frame only includes players that appear in player_overall."""
         path = _make_test_parquet(tmp_path, {
             "comment_id": ["c1"],
             "body": ["LeBron is great"],
@@ -274,11 +269,52 @@ class TestAggregatePlayerMetadata:
         })
 
         result = aggregate_sentiment(path)
-        meta = result["player_metadata"]
+        players = result["player_metadata"]["attributed_player"].to_list()
 
-        # Only LeBron attributed — Giannis should not be in metadata
-        assert "LeBron James" in meta
-        assert "Giannis Antetokounmpo" not in meta
+        assert "LeBron James" in players
+        assert "Giannis Antetokounmpo" not in players
+
+
+class TestPlayerMetadataToDict:
+    """Tests for player_metadata_to_dict (frame -> nested aggregates.json dict).
+
+    These guard the byte-shape contract: aggregates.json must stay a nested
+    {player: {...}} dict identical to the pre-#39 output.
+    """
+
+    def test_reconstructs_nested_dict_keyed_by_player(self, tmp_path):
+        """The helper keys the dict by player name with the enriched values."""
+        result = aggregate_sentiment(_lebron_parquet(tmp_path))
+
+        as_dict = player_metadata_to_dict(result["player_metadata"])
+
+        assert isinstance(as_dict, dict)
+        assert as_dict["LeBron James"]["team"] == "Los Angeles Lakers"
+        assert as_dict["LeBron James"]["conference"] == "West"
+        assert as_dict["LeBron James"]["player_id"] == 2544
+
+    def test_value_keys_match_json_contract(self, tmp_path):
+        """Each entry carries exactly the five metadata keys, in aggregates.json order."""
+        result = aggregate_sentiment(_lebron_parquet(tmp_path))
+
+        as_dict = player_metadata_to_dict(result["player_metadata"])
+
+        assert list(as_dict["LeBron James"].keys()) == [
+            "team",
+            "conference",
+            "player_id",
+            "headshot_url",
+            "logo_url",
+        ]
+
+    def test_preserves_row_order(self, tmp_path):
+        """Dict key order follows frame row order (byte-shape stability)."""
+        result = aggregate_sentiment(_lebron_parquet(tmp_path))
+        df = result["player_metadata"]
+
+        as_dict = player_metadata_to_dict(df)
+
+        assert list(as_dict.keys()) == df["attributed_player"].to_list()
 
 
 class TestAggregateTeamConference:


### PR DESCRIPTION
Closes #39.

Materializes the **Player dimension** as `player_metadata.parquet` so roster-level joins stop needing `unnest(json_keys(...))` gymnastics against `aggregates.json`. This is the model's only unmaterialized dimension — Team is already joinable via `teams.yaml`; Player is the exact analog.

## Changes
- **`PLAYER_METADATA_SCHEMA`** (`attributed_player, team, conference, player_id, headshot_url, logo_url`). **`headshot_url` included** — the ticket's column list undercounted it, but the JSON byte-shape and the dashboard (`app/utils/data.py`, Leaderboard / Player Detail / Flair View, `export_bar_race`) all consume it.
- **Option (b) for the mapping:** `AGGREGATE_VIEW_SCHEMAS` stays the four fact views (it drives the JSON record-shaping predicate); a new `PARQUET_SCHEMAS` superset feeds the write/validation loops. `player_metadata` is a *dimension*, not an aggregate *view*, so it stays out of the views mapping — the fact/dimension split from `docs/data-model.md`, now enforced in code rather than just documented.
- **`aggregate_sentiment()`** returns `player_metadata` as a validated frame, built in `players.yaml` order (filtered to attributed players) so the reconstructed dict preserves key order.
- **`player_metadata_to_dict()`** rebuilds the nested `{player: {...}}` dict at JSON serialization time, keeping `aggregates.json` byte-identical.
- Script writes `player_metadata.parquet` alongside the four view parquets.

## No `SCHEMA_VERSION` bump
Intentional: no existing produced-file contract changes, and a bump would alter `aggregates.json`'s `metadata.schema_version` and *break* byte-identity. (Contrast #43, which must bump it.)

## Verification (real re-aggregation, 1.93M rows)
- `aggregates.json` diff is **one line** — the `generated_at` timestamp. `player_metadata` (incl. key order), all four views, and `metadata` (sans timestamp) are byte-identical (confirmed by deep-equality check). Restored the committed JSON; v1 parquet backfill is out of scope (next re-aggregation, per #28's pattern).
- `player_metadata.parquet`: 111 rows, correct schema; `player_overall JOIN player_metadata USING (attributed_player)` resolves roster team cleanly (and surfaces the documented season-end/trade-fidelity caveat, e.g. Westbrook→Nuggets).
- `ruff` clean, **250 tests pass** (rewrote `TestAggregatePlayerMetadata` for the frame; added `TestPlayerMetadataToDict` for the byte-shape contract).

## Follow-ups (unchanged by this PR)
- `roster_team` / `fan_team` rename — separate focused ticket (can't coexist with this PR's byte-identical requirement).
- v1 `player_metadata.parquet` backfill — produced by the next full re-aggregation.