### PR TITLE
chore(config): activate 2025-26 season

### DIFF
--- a/config/season.yaml
+++ b/config/season.yaml
@@ -1,5 +1,5 @@
-season: "2024-25"
-start_date: "2024-10-01"
-end_date: "2025-06-30"
+season: "2025-26"
+start_date: "2025-10-01"
+end_date: "2026-06-30"
 subreddits:
   - nba

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 
+from utils.season_config import get_active_season
 from utils.paths import (
     get_batches_dir,
     get_dashboard_dir,
@@ -23,7 +24,7 @@ from utils.paths import (
 PINNED_SEASON = "2098-99"
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def pinned_season(monkeypatch) -> str:
     """Pin the active season so tests don't depend on config/season.yaml."""
     monkeypatch.setattr("utils.paths.get_active_season", lambda: PINNED_SEASON)
@@ -53,6 +54,14 @@ class TestGetDataDir:
         """Data dir ends with the season identifier."""
         result = get_data_dir()
         assert result.name == pinned_season
+
+    def test_real_config_wiring_unmocked(self):
+        """Smoke test: the real active season from season.yaml lands in the path.
+
+        Deliberately unmocked — the only test exercising the wiring between
+        utils.paths and the real config file end-to-end.
+        """
+        assert get_active_season() in str(get_data_dir())
 
 
 class TestLeafPathFunctions:

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -2,10 +2,14 @@
 Tests for season-aware data path construction.
 
 Tests verify that path functions return season-scoped directories
-and that get_data_dir accepts an explicit season override.
+and that get_data_dir accepts an explicit season override. The active
+season is pinned to a synthetic value so tests exercise the plumbing
+without depending on the real config/season.yaml.
 """
 
 from pathlib import Path
+
+import pytest
 
 from utils.paths import (
     get_batches_dir,
@@ -16,6 +20,15 @@ from utils.paths import (
     get_raw_dir,
 )
 
+PINNED_SEASON = "2098-99"
+
+
+@pytest.fixture(autouse=True)
+def pinned_season(monkeypatch) -> str:
+    """Pin the active season so tests don't depend on config/season.yaml."""
+    monkeypatch.setattr("utils.paths.get_active_season", lambda: PINNED_SEASON)
+    return PINNED_SEASON
+
 
 class TestGetDataDir:
     """Tests for get_data_dir function."""
@@ -25,51 +38,52 @@ class TestGetDataDir:
         result = get_data_dir()
         assert isinstance(result, Path)
 
-    def test_includes_active_season(self):
-        """Default data dir includes active season from season.yaml."""
+    def test_includes_active_season(self, pinned_season):
+        """Default data dir includes the active season."""
         result = get_data_dir()
-        assert "2024-25" in str(result)
+        assert pinned_season in str(result)
 
-    def test_explicit_season_override(self):
-        """Passing season explicitly overrides the default."""
-        result = get_data_dir(season="2025-26")
-        assert result.name == "2025-26"
+    def test_explicit_season_override(self, pinned_season):
+        """Passing season explicitly overrides the active-season default."""
+        result = get_data_dir(season="2024-25")
+        assert result.name == "2024-25"
+        assert pinned_season not in str(result)
 
-    def test_ends_with_season(self):
+    def test_ends_with_season(self, pinned_season):
         """Data dir ends with the season identifier."""
         result = get_data_dir()
-        assert result.name == "2024-25"
+        assert result.name == pinned_season
 
 
 class TestLeafPathFunctions:
     """Tests for subdirectory path functions."""
 
-    def test_raw_dir_is_season_scoped(self):
+    def test_raw_dir_is_season_scoped(self, pinned_season):
         """Raw dir is under the season directory."""
         result = get_raw_dir()
-        assert result.parent.name == "2024-25"
+        assert result.parent.name == pinned_season
         assert result.name == "raw"
 
-    def test_filtered_dir_is_season_scoped(self):
+    def test_filtered_dir_is_season_scoped(self, pinned_season):
         """Filtered dir is under the season directory."""
         result = get_filtered_dir()
-        assert result.parent.name == "2024-25"
+        assert result.parent.name == pinned_season
         assert result.name == "filtered"
 
-    def test_batches_dir_is_season_scoped(self):
+    def test_batches_dir_is_season_scoped(self, pinned_season):
         """Batches dir is under the season directory."""
         result = get_batches_dir()
-        assert result.parent.name == "2024-25"
+        assert result.parent.name == pinned_season
         assert result.name == "batches"
 
-    def test_processed_dir_is_season_scoped(self):
+    def test_processed_dir_is_season_scoped(self, pinned_season):
         """Processed dir is under the season directory."""
         result = get_processed_dir()
-        assert result.parent.name == "2024-25"
+        assert result.parent.name == pinned_season
         assert result.name == "processed"
 
-    def test_dashboard_dir_is_season_scoped(self):
+    def test_dashboard_dir_is_season_scoped(self, pinned_season):
         """Dashboard dir is under the season directory."""
         result = get_dashboard_dir()
-        assert result.parent.name == "2024-25"
+        assert result.parent.name == pinned_season
         assert result.name == "dashboard"

--- a/tests/unit/test_player_config.py
+++ b/tests/unit/test_player_config.py
@@ -54,8 +54,8 @@ class TestLoadPlayerConfig:
         """Short aliases includes known entries requiring word boundaries."""
         _, short_aliases = load_player_config()
 
-        # These require word boundary matching
-        expected = {"ad", "curry", "james", "green", "ja"}
+        # These require word boundary matching (stable across season configs)
+        expected = {"ad", "curry", "ja"}
         assert expected.issubset(short_aliases)
 
     def test_caching_returns_same_object(self):
@@ -71,7 +71,8 @@ class TestLoadPlayerConfig:
         players, _ = load_player_config()
 
         # Should have dozens of players, but not thousands
-        assert 30 < len(players) < 200
+        # (2024-25 tracked 111, 2025-26 tracks 219)
+        assert 30 < len(players) < 500
 
 
 class TestBuildAliasToPlayerMap:
@@ -163,13 +164,25 @@ class TestLoadPlayerMetadata:
             assert "headshot_url" in player_meta, f"{player_name} missing 'headshot_url'"
 
     def test_conference_values_valid(self):
-        """Conference is always 'East' or 'West'."""
+        """Conference is 'East' or 'West'; None only for teamless players.
+
+        Off-roster carry-overs are kept teamless by design (inclusion is
+        discourse-driven, not roster-gated), so team and conference are
+        None together.
+        """
         metadata = load_player_metadata()
 
         for player_name, player_meta in metadata.items():
-            assert player_meta["conference"] in {"East", "West"}, (
-                f"{player_name} has invalid conference: {player_meta['conference']}"
-            )
+            if player_meta["team"] is None:
+                assert player_meta["conference"] is None, (
+                    f"{player_name} is teamless but has conference: "
+                    f"{player_meta['conference']}"
+                )
+            else:
+                assert player_meta["conference"] in {"East", "West"}, (
+                    f"{player_name} has invalid conference: "
+                    f"{player_meta['conference']}"
+                )
 
     def test_lebron_metadata(self):
         """LeBron James has correct metadata."""

--- a/tests/unit/test_season_config.py
+++ b/tests/unit/test_season_config.py
@@ -58,6 +58,7 @@ class TestLoadSeasonConfig:
         config = load_season_config()
         assert re.fullmatch(r"\d{4}-\d{2}", config["season"])
         start_year = int(config["season"][:4])
+        assert config["season"][5:7] == str(start_year + 1)[-2:]
         assert config["start_date"].startswith(str(start_year))
         assert config["end_date"].startswith(str(start_year + 1))
         assert "nba" in config["subreddits"]

--- a/tests/unit/test_season_config.py
+++ b/tests/unit/test_season_config.py
@@ -5,6 +5,8 @@ Tests cover loading from YAML, required key validation, convenience
 accessors, and caching behavior.
 """
 
+import re
+
 from utils.season_config import get_active_season, load_season_config
 
 
@@ -46,12 +48,18 @@ class TestLoadSeasonConfig:
         for sub in subreddits:
             assert isinstance(sub, str)
 
-    def test_current_season_values(self):
-        """Current config has expected 2024-25 values."""
+    def test_season_and_dates_consistent(self):
+        """Season identifier and date range agree, whatever season is active.
+
+        Invariants instead of pinned values so a legitimate season flip
+        doesn't break the suite: season is YYYY-YY, start_date falls in
+        the first year, end_date in the second.
+        """
         config = load_season_config()
-        assert config["season"] == "2024-25"
-        assert config["start_date"] == "2024-10-01"
-        assert config["end_date"] == "2025-06-30"
+        assert re.fullmatch(r"\d{4}-\d{2}", config["season"])
+        start_year = int(config["season"][:4])
+        assert config["start_date"].startswith(str(start_year))
+        assert config["end_date"].startswith(str(start_year + 1))
         assert "nba" in config["subreddits"]
 
     def test_caching_returns_same_object(self):
@@ -74,6 +82,6 @@ class TestGetActiveSeason:
         config = load_season_config()
         assert get_active_season() == config["season"]
 
-    def test_current_value(self):
-        """Active season is currently 2024-25."""
-        assert get_active_season() == "2024-25"
+    def test_matches_season_format(self):
+        """Active season is a YYYY-YY identifier."""
+        assert re.fullmatch(r"\d{4}-\d{2}", get_active_season())


### PR DESCRIPTION
## What

Flips `config/season.yaml` to the 2025-26 season (2025-10-01 → 2026-06-30, subreddits unchanged) so all season-scoped paths resolve to `data/2025-26/` for the v2 run.

## Test unpinning (2 of the 3 commits)

The flip surfaced a class of tests coupled to the *active* season config's content — each blocked the pre-commit gate in turn:

- `test_paths.py` hardcoded `"2024-25"` while reading the real `season.yaml`; now pins a synthetic season via monkeypatch and tests the season-scoping plumbing.
- `test_season_config.py` pinned exact season/date strings; now asserts invariants (YYYY-YY format, start/end years consistent with the season identifier) so future flips don't break the suite.
- `test_player_config.py` sanity checks updated for current config decisions: 219 players tracked, `james`/`green` dropped from short_aliases in the 2025-26 rebuild, and teamless off-roster carry-overs (Ball/Simmons/Paul/Beverley) legitimately have `conference: None` — the test now enforces that team and conference are None *together*.

Full suite: 257 passed; ruff clean.