### PR TITLE
fix(pipeline): retry transient API errors and resume downloads from file

### DIFF
--- a/pipeline/arctic_shift.py
+++ b/pipeline/arctic_shift.py
@@ -23,13 +23,37 @@ import requests
 from utils.constants import (
     ARCTIC_SHIFT_BASE_URL,
     ARCTIC_SHIFT_COMMENTS_ENDPOINT,
+    ARCTIC_SHIFT_MAX_ATTEMPTS,
     ARCTIC_SHIFT_PAGE_SIZE,
     ARCTIC_SHIFT_POSTS_ENDPOINT,
     ARCTIC_SHIFT_RATE_LIMIT_BUFFER,
     ARCTIC_SHIFT_REQUEST_DELAY,
+    ARCTIC_SHIFT_RETRY_BACKOFF,
+    ARCTIC_SHIFT_RETRYABLE_STATUSES,
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _is_retryable(error: requests.RequestException) -> bool:
+    """
+    Check whether a request error is worth retrying.
+
+    Connection errors and timeouts are always transient. HTTP errors are
+    retryable only for statuses in ARCTIC_SHIFT_RETRYABLE_STATUSES; other
+    client errors (e.g. 404) indicate a real problem with the request.
+
+    Args:
+        error: The exception raised by the request.
+
+    Returns:
+        True if the request should be retried.
+    """
+    if isinstance(error, requests.HTTPError):
+        if error.response is None:
+            return False
+        return error.response.status_code in ARCTIC_SHIFT_RETRYABLE_STATUSES
+    return isinstance(error, (requests.ConnectionError, requests.Timeout))
 
 
 class ArcticShiftClient:
@@ -44,6 +68,8 @@ class ArcticShiftClient:
         delay: Seconds to wait between requests. Defaults to 0.5s.
         page_size: Max items per request. Defaults to 100.
         rate_limit_buffer: Sleep when remaining requests fall below this. Defaults to 10.
+        max_attempts: Total attempts per page request (1 initial + retries). Defaults to 4.
+        retry_backoff: Base seconds for exponential backoff between retries. Defaults to 2.0.
 
     Example:
         with ArcticShiftClient() as client:
@@ -57,12 +83,16 @@ class ArcticShiftClient:
         delay: float = ARCTIC_SHIFT_REQUEST_DELAY,
         page_size: int = ARCTIC_SHIFT_PAGE_SIZE,
         rate_limit_buffer: int = ARCTIC_SHIFT_RATE_LIMIT_BUFFER,
+        max_attempts: int = ARCTIC_SHIFT_MAX_ATTEMPTS,
+        retry_backoff: float = ARCTIC_SHIFT_RETRY_BACKOFF,
     ) -> None:
         """Initialize the client with configuration."""
         self.base_url = base_url
         self.delay = delay
         self.page_size = page_size
         self.rate_limit_buffer = rate_limit_buffer
+        self.max_attempts = max_attempts
+        self.retry_backoff = retry_backoff
         self.session = requests.Session()
 
     def __enter__(self) -> "ArcticShiftClient":
@@ -197,7 +227,12 @@ class ArcticShiftClient:
         before: int,
     ) -> tuple[list[dict], dict[str, str]]:
         """
-        Fetch a single page from the API.
+        Fetch a single page from the API, retrying transient failures.
+
+        Connection errors, timeouts, 5xx responses, and 422 responses (which
+        this API intermittently returns for requests that succeed on replay)
+        are retried with exponential backoff up to max_attempts. Other HTTP
+        errors raise immediately.
 
         Args:
             endpoint: API endpoint path.
@@ -209,7 +244,9 @@ class ArcticShiftClient:
             Tuple of (list of item dicts, response headers).
 
         Raises:
-            requests.HTTPError: If API returns an error status.
+            requests.HTTPError: If API returns a non-transient error status,
+                or a transient one on every attempt.
+            requests.ConnectionError: If connection fails on every attempt.
         """
         url = f"{self.base_url}{endpoint}"
 
@@ -221,13 +258,27 @@ class ArcticShiftClient:
             "limit": self.page_size,
         }
 
-        response = self.session.get(url, params=params, timeout=60)
-        response.raise_for_status()
+        last_error: requests.RequestException | None = None
 
-        data = response.json()
-        items = data.get("data", [])
+        for attempt in range(1, self.max_attempts + 1):
+            try:
+                response = self.session.get(url, params=params, timeout=60)
+                response.raise_for_status()
+                data = response.json()
+                return data.get("data", []), dict(response.headers)
+            except requests.RequestException as e:
+                if not _is_retryable(e):
+                    raise
+                last_error = e
+                if attempt < self.max_attempts:
+                    wait = self.retry_backoff * (2 ** (attempt - 1))
+                    logger.warning(
+                        f"Transient API error (attempt {attempt}/{self.max_attempts}), "
+                        f"retrying in {wait:.0f}s: {e}"
+                    )
+                    time.sleep(wait)
 
-        return items, dict(response.headers)
+        raise last_error  # type: ignore[misc]  # loop always sets it before exiting
 
     def _check_rate_limit(self, headers: dict[str, str]) -> None:
         """

--- a/pipeline/arctic_shift.py
+++ b/pipeline/arctic_shift.py
@@ -229,10 +229,10 @@ class ArcticShiftClient:
         """
         Fetch a single page from the API, retrying transient failures.
 
-        Connection errors, timeouts, 5xx responses, and 422 responses (which
-        this API intermittently returns for requests that succeed on replay)
-        are retried with exponential backoff up to max_attempts. Other HTTP
-        errors raise immediately.
+        Connection errors, timeouts, and transient HTTP statuses (5xx, 429,
+        and 422 — which this API intermittently returns for requests that
+        succeed on replay) are retried with exponential backoff up to
+        max_attempts. Other HTTP errors raise immediately.
 
         Args:
             endpoint: API endpoint path.

--- a/pipeline/processors.py
+++ b/pipeline/processors.py
@@ -230,9 +230,11 @@ def read_last_created_utc(path: Path, tail_bytes: int = 65536) -> int | None:
         f.seek(max(0, file_size - tail_bytes))
         tail = f.read().decode("utf-8", errors="replace")
 
-    # The window's first line may be partial (seek landed mid-line); walking
-    # backward also naturally skips it.
-    for line in reversed(tail.splitlines()):
+    # split("\n"), not splitlines(): the latter also breaks on Unicode
+    # separators (FS, LSEP, ...), which would misparse lines if the
+    # writer ever emits them unescaped. The window's first line may be
+    # partial (seek landed mid-line); walking backward naturally skips it.
+    for line in reversed(tail.split("\n")):
         if not line.strip():
             continue
         try:
@@ -244,3 +246,67 @@ def read_last_created_utc(path: Path, tail_bytes: int = 65536) -> int | None:
             return int(created)
 
     return None
+
+
+def resume_after(path: Path, tail_bytes: int = 65536) -> int | None:
+    """
+    Resolve the resume cursor for a download output file.
+
+    Fresh-start vs resume is decided by the file's actual state, not by
+    whether a timestamp happened to parse: a non-empty file that yields no
+    resume point raises instead of signaling a fresh start, which would
+    let the caller truncate previously downloaded data.
+
+    Args:
+        path: JSONL output file of a previous download run.
+        tail_bytes: Tail window passed to read_last_created_utc().
+
+    Returns:
+        The `after` cursor to resume from (last created_utc + 1, matching
+        the pagination cursor's advance semantics), or None if the file is
+        missing or empty (fresh start).
+
+    Raises:
+        ValueError: If the file has content but no parseable resume point
+            in the tail window.
+    """
+    if not path.exists() or path.stat().st_size == 0:
+        return None
+
+    last_ts = read_last_created_utc(path, tail_bytes)
+    if last_ts is None:
+        raise ValueError(
+            f"{path} has data but no parseable resume point in its last "
+            f"{tail_bytes} bytes; refusing to overwrite it. Inspect the "
+            "file, or rerun with --force to start fresh."
+        )
+
+    return last_ts + 1
+
+
+def ensure_trailing_newline(path: Path) -> bool:
+    """
+    Ensure a file ends with a newline before records are appended to it.
+
+    A crash can leave a truncated final line with no trailing newline;
+    appending directly would fuse the next record onto it, corrupting
+    both. The orphaned partial line is rejected downstream as malformed
+    JSON instead.
+
+    Args:
+        path: File about to be appended to.
+
+    Returns:
+        True if a newline was appended, False if none was needed.
+    """
+    if not path.exists() or path.stat().st_size == 0:
+        return False
+
+    with open(path, "rb") as f:
+        f.seek(-1, 2)
+        if f.read(1) == b"\n":
+            return False
+
+    with open(path, "a") as f:
+        f.write("\n")
+    return True

--- a/pipeline/processors.py
+++ b/pipeline/processors.py
@@ -6,6 +6,7 @@ import json
 import logging
 import re
 from dataclasses import dataclass
+from pathlib import Path
 
 from utils.constants import INVALID_BODY_VALUES, REQUIRED_FIELDS
 from utils.player_config import load_player_config
@@ -197,3 +198,49 @@ def process_line(line: str, stats: ProcessingStats) -> dict | None:
 
     stats.accepted_comments += 1
     return result
+
+
+def read_last_created_utc(path: Path, tail_bytes: int = 65536) -> int | None:
+    """
+    Read the most recent created_utc from the tail of a raw JSONL file.
+
+    Used to resume an interrupted download from where it stopped: the output
+    file itself is the source of truth, so this survives any crash mode. Only
+    the last tail_bytes are read (raw files are multi-GB), and lines are
+    walked backward so a final line truncated by a mid-write kill is skipped
+    in favor of the last complete one.
+
+    Args:
+        path: JSONL file of raw comments (one JSON object per line).
+        tail_bytes: Bytes to read from the end of the file. Must comfortably
+            exceed the longest expected line (~64x a typical comment).
+
+    Returns:
+        created_utc of the last parseable line, or None if the file is
+        missing, empty, or has no parseable line in the tail window.
+    """
+    if not path.exists():
+        return None
+
+    file_size = path.stat().st_size
+    if file_size == 0:
+        return None
+
+    with open(path, "rb") as f:
+        f.seek(max(0, file_size - tail_bytes))
+        tail = f.read().decode("utf-8", errors="replace")
+
+    # The window's first line may be partial (seek landed mid-line); walking
+    # backward also naturally skips it.
+    for line in reversed(tail.splitlines()):
+        if not line.strip():
+            continue
+        try:
+            comment = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        created = comment.get("created_utc")
+        if isinstance(created, (int, float)):
+            return int(created)
+
+    return None

--- a/scripts/download_comments.py
+++ b/scripts/download_comments.py
@@ -20,7 +20,8 @@ Usage:
 Design decisions:
     - Sequential downloads (one subreddit at a time) to respect the free API
     - Pagination via created_utc ascending - simple and reliable
-    - Progress saved after each subreddit completes (resumable)
+    - Completed subreddits tracked in progress.json; mid-download resume reads
+      the last written comment from the output file itself (survives crashes)
     - Rate limit headers checked to avoid hitting limits
     - Configurable delay between requests (default 0.5s)
 
@@ -42,6 +43,7 @@ from pathlib import Path
 from typing import Any
 
 from pipeline.arctic_shift import ArcticShiftClient
+from pipeline.processors import read_last_created_utc
 from utils.constants import ARCTIC_SHIFT_PAGE_SIZE, PROGRESS_FILENAME
 from utils.formatting import format_duration
 from utils.paths import get_raw_dir
@@ -82,18 +84,18 @@ def load_progress(progress_path: Path) -> dict[str, Any]:
 
     Structure:
         {
-            "completed": ["subreddit1", "subreddit2"],
-            "in_progress": {
-                "subreddit3": {"last_timestamp": 1234567890, "count": 50000}
-            }
+            "completed": ["subreddit1", "subreddit2"]
         }
+
+    Only subreddit-level completion is tracked here; mid-download resume
+    reads the last written comment from the output file itself.
 
     Returns empty structure if file doesn't exist (fresh start).
     """
     if progress_path.exists():
         with open(progress_path, "r") as f:
             return json.load(f)
-    return {"completed": [], "in_progress": {}}
+    return {"completed": []}
 
 
 def save_progress(progress_path: Path, progress: dict[str, Any]) -> None:
@@ -143,7 +145,18 @@ def download_subreddit(
     # Open in append mode if resuming, write mode if fresh
     mode = "a" if resume_from else "w"
 
+    # A crash can leave a truncated final line with no trailing newline;
+    # start on a fresh line so appended records don't fuse with it (the
+    # orphaned partial line is rejected downstream as malformed JSON)
+    needs_newline = False
+    if mode == "a" and output_path.exists() and output_path.stat().st_size > 0:
+        with open(output_path, "rb") as check:
+            check.seek(-1, 2)
+            needs_newline = check.read(1) != b"\n"
+
     with open(output_path, mode) as f:
+        if needs_newline:
+            f.write("\n")
         for comment in client.fetch_comments(
             subreddit=subreddit,
             after=after_timestamp,
@@ -206,7 +219,7 @@ def main() -> None:
 
     # Load or reset progress
     if args.force:
-        progress = {"completed": [], "in_progress": {}}
+        progress = {"completed": []}
         logger.info("Force mode: ignoring previous progress")
     else:
         progress = load_progress(progress_path)
@@ -255,16 +268,20 @@ def main() -> None:
 
             output_path = raw_dir / f"r_{subreddit}_comments.jsonl"
 
-            # Check if we're resuming mid-download
+            # Resume mid-download from the output file itself — the file is
+            # the source of truth, so this survives any crash mode
             resume_from = None
-            if subreddit in progress.get("in_progress", {}):
-                resume_info = progress["in_progress"][subreddit]
-                resume_from = resume_info.get("last_timestamp")
-                logger.info(
-                    f"Resuming {subreddit} from {resume_from} "
-                    f"({resume_info.get('count', 0):,} comments so far)"
-                )
-            else:
+            if not args.force:
+                last_ts = read_last_created_utc(output_path)
+                if last_ts is not None:
+                    # +1 mirrors the pagination cursor's advance semantics
+                    resume_from = last_ts + 1
+                    logger.info(
+                        f"Resuming {subreddit} after "
+                        f"{datetime.fromtimestamp(last_ts)} "
+                        f"(appending to {output_path.name})"
+                    )
+            if resume_from is None:
                 logger.info(f"Starting {subreddit}...")
 
             # Download!
@@ -284,8 +301,6 @@ def main() -> None:
 
                 # Mark as complete
                 progress["completed"].append(subreddit)
-                if subreddit in progress.get("in_progress", {}):
-                    del progress["in_progress"][subreddit]
 
                 session_stats[subreddit] = {"count": count, "duration": sub_elapsed}
 
@@ -297,17 +312,17 @@ def main() -> None:
                 )
 
             except KeyboardInterrupt:
-                logger.warning("\nInterrupted! Saving progress...")
-                # Save partial progress
-                if subreddit not in progress.get("in_progress", {}):
-                    progress["in_progress"] = progress.get("in_progress", {})
-                # Note: We could track last_timestamp here for better resume
+                logger.warning(
+                    "\nInterrupted! Partial output is on disk; "
+                    "rerun to resume from the last written comment."
+                )
                 save_progress(progress_path, progress)
                 sys.exit(1)
 
             except Exception as e:
                 logger.error(f"Failed on {subreddit}: {e}")
-                # Save progress so we can resume
+                # Completed list persists; mid-download state resumes from
+                # the output file on rerun
                 save_progress(progress_path, progress)
                 raise
 

--- a/scripts/download_comments.py
+++ b/scripts/download_comments.py
@@ -43,7 +43,7 @@ from pathlib import Path
 from typing import Any
 
 from pipeline.arctic_shift import ArcticShiftClient
-from pipeline.processors import read_last_created_utc
+from pipeline.processors import ensure_trailing_newline, resume_after
 from utils.constants import ARCTIC_SHIFT_PAGE_SIZE, PROGRESS_FILENAME
 from utils.formatting import format_duration
 from utils.paths import get_raw_dir
@@ -145,18 +145,11 @@ def download_subreddit(
     # Open in append mode if resuming, write mode if fresh
     mode = "a" if resume_from else "w"
 
-    # A crash can leave a truncated final line with no trailing newline;
-    # start on a fresh line so appended records don't fuse with it (the
-    # orphaned partial line is rejected downstream as malformed JSON)
-    needs_newline = False
-    if mode == "a" and output_path.exists() and output_path.stat().st_size > 0:
-        with open(output_path, "rb") as check:
-            check.seek(-1, 2)
-            needs_newline = check.read(1) != b"\n"
+    # Crash-truncated final lines must not fuse with appended records
+    if mode == "a":
+        ensure_trailing_newline(output_path)
 
     with open(output_path, mode) as f:
-        if needs_newline:
-            f.write("\n")
         for comment in client.fetch_comments(
             subreddit=subreddit,
             after=after_timestamp,
@@ -269,19 +262,19 @@ def main() -> None:
             output_path = raw_dir / f"r_{subreddit}_comments.jsonl"
 
             # Resume mid-download from the output file itself — the file is
-            # the source of truth, so this survives any crash mode
+            # the source of truth, so this survives any crash mode. A file
+            # with data but no parseable resume point raises rather than
+            # silently starting fresh (which would truncate it).
             resume_from = None
             if not args.force:
-                last_ts = read_last_created_utc(output_path)
-                if last_ts is not None:
-                    # +1 mirrors the pagination cursor's advance semantics
-                    resume_from = last_ts + 1
-                    logger.info(
-                        f"Resuming {subreddit} after "
-                        f"{datetime.fromtimestamp(last_ts)} "
-                        f"(appending to {output_path.name})"
-                    )
-            if resume_from is None:
+                resume_from = resume_after(output_path)
+            if resume_from is not None:
+                logger.info(
+                    f"Resuming {subreddit} from "
+                    f"{datetime.fromtimestamp(resume_from)} "
+                    f"(appending to {output_path.name})"
+                )
+            else:
                 logger.info(f"Starting {subreddit}...")
 
             # Download!

--- a/tests/unit/test_arctic_shift.py
+++ b/tests/unit/test_arctic_shift.py
@@ -276,7 +276,7 @@ class TestErrorHandling:
                 list(client.fetch_comments("nba", after=0, before=200))
 
 
-def _error_response(status: int):
+def _error_response(status: int) -> Mock:
     """Build a mock response whose raise_for_status raises an HTTPError with a status."""
     response = Mock()
     response.status_code = status

--- a/tests/unit/test_arctic_shift.py
+++ b/tests/unit/test_arctic_shift.py
@@ -2,7 +2,7 @@
 
 import time
 import pytest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import requests
 
@@ -264,8 +264,8 @@ class TestErrorHandling:
                 list(client.fetch_comments("nba", after=0, before=200))
 
     def test_connection_error_raises_exception(self):
-        """Verify connection errors propagate."""
-        client = ArcticShiftClient()
+        """Verify persistent connection errors propagate after retries are exhausted."""
+        client = ArcticShiftClient(retry_backoff=0)
 
         with patch.object(
             client.session,
@@ -274,6 +274,93 @@ class TestErrorHandling:
         ):
             with pytest.raises(requests.ConnectionError):
                 list(client.fetch_comments("nba", after=0, before=200))
+
+
+def _error_response(status: int):
+    """Build a mock response whose raise_for_status raises an HTTPError with a status."""
+    response = Mock()
+    response.status_code = status
+    response.raise_for_status.side_effect = requests.HTTPError(
+        f"{status} error", response=response
+    )
+    return response
+
+
+class TestRetry:
+    """Tests for transient-error retry in _fetch_page."""
+
+    def test_retries_transient_422_then_succeeds(
+        self, mock_comments_page, mock_empty_response
+    ):
+        """Verify a transient 422 is retried and the download continues."""
+        client = ArcticShiftClient(retry_backoff=0, delay=0)
+        page = mock_comments_page(start_id=1, count=2)
+
+        with patch.object(
+            client.session,
+            "get",
+            side_effect=[_error_response(422), page, mock_empty_response],
+        ) as mock_get:
+            results = list(client.fetch_comments("nba", after=0, before=200))
+
+        assert len(results) == 2
+        assert mock_get.call_count == 3
+
+    def test_retries_connection_error_then_succeeds(
+        self, mock_comments_page, mock_empty_response
+    ):
+        """Verify a transient connection error is retried."""
+        client = ArcticShiftClient(retry_backoff=0, delay=0)
+        page = mock_comments_page(start_id=1, count=1)
+
+        with patch.object(
+            client.session,
+            "get",
+            side_effect=[
+                requests.ConnectionError("reset"),
+                page,
+                mock_empty_response,
+            ],
+        ) as mock_get:
+            results = list(client.fetch_comments("nba", after=0, before=200))
+
+        assert len(results) == 1
+        assert mock_get.call_count == 3
+
+    def test_raises_after_exhausting_attempts(self):
+        """Verify a persistent transient error raises after max_attempts."""
+        client = ArcticShiftClient(retry_backoff=0, max_attempts=3)
+
+        with patch.object(
+            client.session, "get", return_value=_error_response(503)
+        ) as mock_get:
+            with pytest.raises(requests.HTTPError):
+                list(client.fetch_comments("nba", after=0, before=200))
+
+        assert mock_get.call_count == 3
+
+    def test_non_transient_client_error_not_retried(self):
+        """Verify a 404 raises immediately with no retry."""
+        client = ArcticShiftClient(retry_backoff=0)
+
+        with patch.object(
+            client.session, "get", return_value=_error_response(404)
+        ) as mock_get:
+            with pytest.raises(requests.HTTPError):
+                list(client.fetch_comments("nba", after=0, before=200))
+
+        assert mock_get.call_count == 1
+
+    def test_backoff_grows_exponentially(self):
+        """Verify retry waits follow the exponential backoff schedule."""
+        client = ArcticShiftClient(retry_backoff=2.0, max_attempts=4)
+
+        with patch.object(client.session, "get", return_value=_error_response(503)):
+            with patch("pipeline.arctic_shift.time.sleep") as mock_sleep:
+                with pytest.raises(requests.HTTPError):
+                    list(client.fetch_comments("nba", after=0, before=200))
+
+        assert [c.args[0] for c in mock_sleep.call_args_list] == [2.0, 4.0, 8.0]
 
 
 class TestSessionManagement:

--- a/tests/unit/test_processors.py
+++ b/tests/unit/test_processors.py
@@ -1,11 +1,13 @@
 """Unit tests for pipeline.processors module."""
 
+import json
 import logging
 
 from pipeline.processors import (
     ProcessingStats,
     extract_fields,
     has_valid_body,
+    read_last_created_utc,
 )
 from utils.constants import REQUIRED_FIELDS
 
@@ -126,3 +128,58 @@ class TestProcessingStats:
 
         assert "Total processed:" in caplog.text
         assert "Acceptance rate:" in caplog.text
+
+
+class TestReadLastCreatedUtc:
+    """Tests for the read_last_created_utc download-resume helper."""
+
+    def test_returns_last_line_timestamp(self, tmp_path):
+        """Last valid line's created_utc should be returned."""
+        path = tmp_path / "comments.jsonl"
+        lines = [json.dumps({"id": str(i), "created_utc": 1000 + i}) for i in range(3)]
+        path.write_text("\n".join(lines) + "\n")
+
+        assert read_last_created_utc(path) == 1002
+
+    def test_missing_file_returns_none(self, tmp_path):
+        """Nonexistent file should return None (fresh start)."""
+        assert read_last_created_utc(tmp_path / "missing.jsonl") is None
+
+    def test_empty_file_returns_none(self, tmp_path):
+        """Empty file should return None (fresh start)."""
+        path = tmp_path / "empty.jsonl"
+        path.touch()
+
+        assert read_last_created_utc(path) is None
+
+    def test_skips_truncated_final_line(self, tmp_path):
+        """A mid-write truncated last line should fall back to the previous valid one."""
+        path = tmp_path / "comments.jsonl"
+        good = json.dumps({"id": "1", "created_utc": 1500})
+        truncated = '{"id": "2", "created_utc": 16'
+        path.write_text(good + "\n" + truncated)
+
+        assert read_last_created_utc(path) == 1500
+
+    def test_no_parseable_line_returns_none(self, tmp_path):
+        """File with no valid JSON lines should return None."""
+        path = tmp_path / "garbage.jsonl"
+        path.write_text("not json\nalso not json\n")
+
+        assert read_last_created_utc(path) is None
+
+    def test_reads_only_tail_window(self, tmp_path):
+        """Only the tail window is read; a partial first line in the window is skipped."""
+        path = tmp_path / "comments.jsonl"
+        filler = json.dumps({"id": "x", "created_utc": 1}) + "\n"
+        last = json.dumps({"id": "last", "created_utc": 9999}) + "\n"
+        path.write_text(filler * 5000 + last)
+
+        assert read_last_created_utc(path, tail_bytes=1024) == 9999
+
+    def test_float_created_utc_coerced_to_int(self, tmp_path):
+        """Reddit sometimes serializes created_utc as a float; it should coerce to int."""
+        path = tmp_path / "comments.jsonl"
+        path.write_text(json.dumps({"id": "1", "created_utc": 1500.0}) + "\n")
+
+        assert read_last_created_utc(path) == 1500

--- a/tests/unit/test_processors.py
+++ b/tests/unit/test_processors.py
@@ -3,11 +3,15 @@
 import json
 import logging
 
+import pytest
+
 from pipeline.processors import (
     ProcessingStats,
+    ensure_trailing_newline,
     extract_fields,
     has_valid_body,
     read_last_created_utc,
+    resume_after,
 )
 from utils.constants import REQUIRED_FIELDS
 
@@ -183,3 +187,73 @@ class TestReadLastCreatedUtc:
         path.write_text(json.dumps({"id": "1", "created_utc": 1500.0}) + "\n")
 
         assert read_last_created_utc(path) == 1500
+
+
+class TestResumeAfter:
+    """Tests for the resume_after cursor resolver."""
+
+    def test_missing_file_returns_none(self, tmp_path):
+        """Nonexistent file should mean a fresh start."""
+        assert resume_after(tmp_path / "missing.jsonl") is None
+
+    def test_empty_file_returns_none(self, tmp_path):
+        """Empty file should mean a fresh start."""
+        path = tmp_path / "empty.jsonl"
+        path.touch()
+
+        assert resume_after(path) is None
+
+    def test_returns_last_timestamp_plus_one(self, tmp_path):
+        """Cursor should be last created_utc + 1, matching pagination semantics."""
+        path = tmp_path / "comments.jsonl"
+        path.write_text(json.dumps({"id": "1", "created_utc": 1500}) + "\n")
+
+        assert resume_after(path) == 1501
+
+    def test_unparseable_content_raises(self, tmp_path):
+        """A file with data but no parseable resume point must raise, never signal fresh start."""
+        path = tmp_path / "comments.jsonl"
+        path.write_text("not json at all\n")
+
+        with pytest.raises(ValueError, match="refusing to overwrite"):
+            resume_after(path)
+
+    def test_single_line_larger_than_tail_window_raises(self, tmp_path):
+        """A line exceeding the tail window should raise, not signal fresh start."""
+        path = tmp_path / "comments.jsonl"
+        big = json.dumps({"id": "1", "created_utc": 1500, "body": "x" * 2048}) + "\n"
+        path.write_text(big)
+
+        with pytest.raises(ValueError, match="refusing to overwrite"):
+            resume_after(path, tail_bytes=1024)
+
+
+class TestEnsureTrailingNewline:
+    """Tests for the ensure_trailing_newline append guard."""
+
+    def test_appends_newline_when_missing(self, tmp_path):
+        """File ending mid-line should gain a trailing newline."""
+        path = tmp_path / "comments.jsonl"
+        path.write_text('{"id": "1", "created_utc": 15')
+
+        assert ensure_trailing_newline(path) is True
+        assert path.read_text().endswith("\n")
+
+    def test_noop_when_newline_present(self, tmp_path):
+        """File already ending in a newline should be untouched."""
+        path = tmp_path / "comments.jsonl"
+        content = json.dumps({"id": "1", "created_utc": 1500}) + "\n"
+        path.write_text(content)
+
+        assert ensure_trailing_newline(path) is False
+        assert path.read_text() == content
+
+    def test_noop_on_missing_or_empty_file(self, tmp_path):
+        """Missing and empty files need no guard, and a missing file must not be created."""
+        missing = tmp_path / "missing.jsonl"
+        assert ensure_trailing_newline(missing) is False
+        assert not missing.exists()
+
+        empty = tmp_path / "empty.jsonl"
+        empty.touch()
+        assert ensure_trailing_newline(empty) is False

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -66,8 +66,10 @@ ARCTIC_SHIFT_RETRY_BACKOFF = 2.0
 
 # HTTP statuses treated as transient. 422 is included deliberately: the API
 # intermittently surfaces backend hiccups as 422 on requests that succeed
-# when replayed (observed 2026-07-02 on the v2 season download).
-ARCTIC_SHIFT_RETRYABLE_STATUSES = frozenset({422, 500, 502, 503, 504})
+# when replayed (observed 2026-07-02 on the v2 season download). 429 is
+# normally avoided via the rate-limit headers, but retrying covers the case
+# where those headers are absent.
+ARCTIC_SHIFT_RETRYABLE_STATUSES = frozenset({422, 429, 500, 502, 503, 504})
 
 
 

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -58,6 +58,17 @@ ARCTIC_SHIFT_REQUEST_DELAY = 0.5
 # Rate limit buffer - sleep when remaining requests drop below this
 ARCTIC_SHIFT_RATE_LIMIT_BUFFER = 10
 
+# Total attempts per page request (1 initial + retries)
+ARCTIC_SHIFT_MAX_ATTEMPTS = 4
+
+# Base seconds for exponential backoff between retries (2s -> 4s -> 8s)
+ARCTIC_SHIFT_RETRY_BACKOFF = 2.0
+
+# HTTP statuses treated as transient. 422 is included deliberately: the API
+# intermittently surfaces backend hiccups as 422 on requests that succeed
+# when replayed (observed 2026-07-02 on the v2 season download).
+ARCTIC_SHIFT_RETRYABLE_STATUSES = frozenset({422, 500, 502, 503, 504})
+
 
 
 # =============================================================================


### PR DESCRIPTION
Closes #49.

The first v2 download died on a transient Arctic Shift 422 (the same request succeeds on replay), and rerunning would have truncated the partial output — the `in_progress` resume state was never actually written by anything.

## Changes

- **Retry with backoff in `_fetch_page`**: connection errors, timeouts, 5xx, and 422 (empirically transient on this API) retry up to 4 attempts with exponential backoff (2s → 4s → 8s); other 4xx raise immediately. Constants in the Arctic Shift section of `utils/constants.py`.
- **File-based resume**: `read_last_created_utc()` (new, `pipeline/processors.py`) reads the last valid line's timestamp from the output file's tail — the file is the source of truth, so resume survives any crash mode. `download_comments.py` resumes from it `+1` (matching the pagination cursor semantics) in append mode; the vestigial `in_progress` plumbing is deleted. `--force` still truncates.
- **Newline guard on resumed appends**: a crash can leave a truncated final line with no trailing newline; without the guard the first appended record fuses with it into one malformed line (found by exercising the crash path during verification). The orphaned partial line is rejected downstream as malformed JSON.

## Verification (live API + crash simulation)

- Fresh run against the real API — **a real transient 422 occurred mid-run and was retried successfully** (`attempt 1/4`), download continued
- Kill + rerun: resumed in append mode, 0 duplicate IDs, timestamps monotonic, file head untouched
- Simulated mid-write crash (truncated final line): resume isolates exactly 1 malformed line, all appended records parse
- Local-socket probes: persistent 422 → 3 retry warnings then raise; 404 → immediate raise, no retry
- The real partial file from the failed run resolves to resume point `1759349327` — exactly where the July 2 run died
- `pytest` 270 passed, `ruff check` clean

## Notes

- Same-second boundary skip (`+1` cursor) unchanged — documented v1 limitation
- Relaunching the season download after merge continues from the existing `data/2025-26/raw/r_nba_comments.jsonl` instead of starting over