### PR TITLE
feat(config): add --season override so scripts target a non-active season

### DIFF
--- a/scripts/aggregate_sentiment.py
+++ b/scripts/aggregate_sentiment.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from pipeline.aggregation import aggregate_sentiment
 from pipeline.schemas import AGGREGATE_VIEW_SCHEMAS
 from utils.paths import get_dashboard_dir, get_processed_dir
+from utils.season_config import set_season_override
 
 # -----------------------------------------------------------------------------
 # Logging setup
@@ -49,9 +50,6 @@ DEFAULT_OUTPUT_FILENAME = "aggregates.json"
 
 def main() -> None:
     """Main entry point for sentiment aggregation."""
-    default_input = get_processed_dir() / DEFAULT_INPUT_FILENAME
-    default_output = get_dashboard_dir() / DEFAULT_OUTPUT_FILENAME
-
     parser = argparse.ArgumentParser(
         description="Aggregate sentiment data into dashboard-ready JSON"
     )
@@ -59,19 +57,32 @@ def main() -> None:
         "--input",
         type=Path,
         default=None,
-        help=f"Path to sentiment parquet file (default: {default_input})",
+        help="Path to sentiment parquet file "
+        f"(default: data/<season>/processed/{DEFAULT_INPUT_FILENAME})",
     )
     parser.add_argument(
         "--output",
         type=Path,
         default=None,
-        help=f"Path to write aggregates JSON (default: {default_output})",
+        help="Path to write aggregates JSON "
+        f"(default: data/<season>/dashboard/{DEFAULT_OUTPUT_FILENAME})",
+    )
+    parser.add_argument(
+        "--season",
+        default=None,
+        metavar="YYYY-YY",
+        help='Override the active season (e.g. "2024-25"); data paths and '
+        "player config resolve to it for this run",
     )
     args = parser.parse_args()
 
-    # Apply defaults after parsing
-    input_path = args.input or default_input
-    output_path = args.output or default_output
+    if args.season:
+        set_season_override(args.season)
+
+    # Defaults resolve after the season override so they land in the
+    # right season directory
+    input_path = args.input or get_processed_dir() / DEFAULT_INPUT_FILENAME
+    output_path = args.output or get_dashboard_dir() / DEFAULT_OUTPUT_FILENAME
 
     # Validate input exists
     if not input_path.exists():

--- a/scripts/collect_results.py
+++ b/scripts/collect_results.py
@@ -39,6 +39,7 @@ from pipeline.batch import (
 )
 from pipeline.results import build_sentiment_dataframe
 from utils.paths import get_batches_dir, get_filtered_dir, get_processed_dir
+from utils.season_config import set_season_override
 
 # -----------------------------------------------------------------------------
 # Logging setup
@@ -263,7 +264,17 @@ def main() -> None:
         action="store_true",
         help="Check once, download completed batches, and exit",
     )
+    parser.add_argument(
+        "--season",
+        default=None,
+        metavar="YYYY-YY",
+        help='Override the active season (e.g. "2024-25"); data paths and '
+        "player config resolve to it for this run",
+    )
     args = parser.parse_args()
+
+    if args.season:
+        set_season_override(args.season)
 
     # Setup paths
     batches_dir = get_batches_dir()

--- a/scripts/prepare_batches.py
+++ b/scripts/prepare_batches.py
@@ -30,6 +30,7 @@ from tqdm import tqdm
 from pipeline.batch import format_batch_request, REQUESTS_PER_BATCH
 from utils.formatting import format_duration
 from utils.paths import get_batches_dir, get_filtered_dir
+from utils.season_config import set_season_override
 
 # -----------------------------------------------------------------------------
 # Logging setup
@@ -177,12 +178,6 @@ def process_file(
 
 def main() -> None:
     """Main entry point with CLI argument handling."""
-    # Resolve default paths at runtime
-    filtered_dir = get_filtered_dir()
-    batches_dir = get_batches_dir()
-    default_input = filtered_dir / DEFAULT_INPUT_FILENAME
-    default_output = batches_dir / REQUESTS_SUBDIR
-
     parser = argparse.ArgumentParser(
         description="Prepare batch request files for Anthropic Batch API"
     )
@@ -190,13 +185,15 @@ def main() -> None:
         "--input",
         type=Path,
         default=None,
-        help=f"Path to input JSONL file (default: {default_input})",
+        help="Path to input JSONL file "
+        f"(default: data/<season>/filtered/{DEFAULT_INPUT_FILENAME})",
     )
     parser.add_argument(
         "--output",
         type=Path,
         default=None,
-        help=f"Directory to write batch files (default: {default_output})",
+        help="Directory to write batch files "
+        f"(default: data/<season>/batches/{REQUESTS_SUBDIR})",
     )
     parser.add_argument(
         "--limit",
@@ -209,13 +206,24 @@ def main() -> None:
         action="store_true",
         help="Skip counting lines (faster start, but no progress percentage)",
     )
+    parser.add_argument(
+        "--season",
+        default=None,
+        metavar="YYYY-YY",
+        help='Override the active season (e.g. "2024-25"); data paths and '
+        "player config resolve to it for this run",
+    )
     args = parser.parse_args()
 
-    # Apply defaults after parsing
+    if args.season:
+        set_season_override(args.season)
+
+    # Defaults resolve after the season override so they land in the
+    # right season directory
     if args.input is None:
-        args.input = default_input
+        args.input = get_filtered_dir() / DEFAULT_INPUT_FILENAME
     if args.output is None:
-        args.output = default_output
+        args.output = get_batches_dir() / REQUESTS_SUBDIR
 
     # Validate input exists
     if not args.input.exists():

--- a/scripts/process_comments.py
+++ b/scripts/process_comments.py
@@ -31,6 +31,7 @@ from tqdm import tqdm
 from pipeline.processors import ProcessingStats, process_line
 from utils.formatting import format_duration, format_size
 from utils.paths import get_filtered_dir, get_raw_dir
+from utils.season_config import set_season_override
 
 logging.basicConfig(
     level=logging.INFO,
@@ -115,9 +116,6 @@ def process_file(
 
 def main() -> None:
     """Main entry point with CLI argument handling."""
-    default_input = get_raw_dir() / DEFAULT_INPUT_FILENAME
-    default_output = get_filtered_dir() / DEFAULT_OUTPUT_FILENAME
-
     parser = argparse.ArgumentParser(
         description="Process raw comments: validate, extract fields, filter to player mentions",
     )
@@ -126,14 +124,16 @@ def main() -> None:
         type=Path,
         nargs="?",
         default=None,
-        help=f"Path to raw JSONL file (default: {default_input})",
+        help="Path to raw JSONL file "
+        f"(default: data/<season>/raw/{DEFAULT_INPUT_FILENAME})",
     )
     parser.add_argument(
         "output",
         type=Path,
         nargs="?",
         default=None,
-        help=f"Path to write filtered JSONL output (default: {default_output})",
+        help="Path to write filtered JSONL output "
+        f"(default: data/<season>/filtered/{DEFAULT_OUTPUT_FILENAME})",
     )
     parser.add_argument(
         "--limit",
@@ -146,12 +146,24 @@ def main() -> None:
         action="store_true",
         help="Skip counting lines (faster start, but no progress percentage)",
     )
+    parser.add_argument(
+        "--season",
+        default=None,
+        metavar="YYYY-YY",
+        help='Override the active season (e.g. "2024-25"); data paths and '
+        "player config resolve to it for this run",
+    )
     args = parser.parse_args()
 
+    if args.season:
+        set_season_override(args.season)
+
+    # Defaults resolve after the season override so they land in the
+    # right season directory
     if args.input is None:
-        args.input = default_input
+        args.input = get_raw_dir() / DEFAULT_INPUT_FILENAME
     if args.output is None:
-        args.output = default_output
+        args.output = get_filtered_dir() / DEFAULT_OUTPUT_FILENAME
 
     if not args.input.exists():
         logger.error("Input file not found: %s", args.input)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -525,6 +525,7 @@ def season_override() -> Callable[[str], None]:
     the override. Teardown clears both the override and the caches so
     later tests see the on-disk active season again.
     """
+    import pipeline.processors
     from utils.player_config import (
         build_alias_to_player_map,
         load_player_config,
@@ -539,6 +540,10 @@ def season_override() -> Callable[[str], None]:
             load_player_metadata,
         ):
             fn.cache_clear()
+        # cache_clear() is a side door the override's warm-cache guard
+        # never sees, so the compiled-pattern global it normally subsumes
+        # must be reset by hand or it keeps the wrong season's patterns
+        pipeline.processors._player_patterns = None
 
     def _set(season: str) -> None:
         _clear_caches()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -507,3 +507,44 @@ def team_alias_map() -> dict[str, str]:
         "cha": "Charlotte Hornets",
         "hornets": "Charlotte Hornets",
     }
+
+
+# ---------------------------------------------------------------------------
+# Season override (issue #51)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def season_override() -> Callable[[str], None]:
+    """
+    Set a process-level season override with cold caches; restores after.
+
+    Yields a callable — season_override("2024-25") — that clears the
+    season-derived player-config caches (the override's warm-cache guard
+    would otherwise trip on caches populated by earlier tests) and sets
+    the override. Teardown clears both the override and the caches so
+    later tests see the on-disk active season again.
+    """
+    from utils.player_config import (
+        build_alias_to_player_map,
+        load_player_config,
+        load_player_metadata,
+    )
+    from utils.season_config import clear_season_override, set_season_override
+
+    def _clear_caches() -> None:
+        for fn in (
+            load_player_config,
+            build_alias_to_player_map,
+            load_player_metadata,
+        ):
+            fn.cache_clear()
+
+    def _set(season: str) -> None:
+        _clear_caches()
+        clear_season_override()
+        set_season_override(season)
+
+    yield _set
+    clear_season_override()
+    _clear_caches()

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -810,3 +810,32 @@ class TestAggregateMetadata:
         result = aggregate_sentiment(path)
 
         assert result["metadata"]["schema_version"] == SCHEMA_VERSION
+
+    def test_metadata_season_honors_override(self, tmp_path, season_override):
+        """metadata.season reflects a --season override (#51).
+
+        Pins that aggregation stamps the season via the override-aware
+        get_active_season(), so a future direct load_season_config()
+        read can't silently mislabel a backfill.
+        """
+        season_override("2024-25")
+        path = _make_test_parquet(tmp_path, {
+            "comment_id": ["c1", "c2"],
+            "body": ["LeBron is great", "LeBron is washed"],
+            "author": ["u1", "u2"],
+            "author_flair_text": [":lal-1: Lakers", ":bos-1: Celtics"],
+            "author_flair_css_class": ["lakers", "celtics"],
+            "created_utc": [1704067200, 1704153600],
+            "score": [10, 5],
+            "link_id": ["t3_post123", "t3_post456"],
+            "mentioned_players": [["LeBron James"], ["LeBron James"]],
+            "sentiment": ["pos", "neg"],
+            "confidence": [0.9, 0.8],
+            "sentiment_player": ["LeBron James", "LeBron James"],
+            "input_tokens": [100, 100],
+            "output_tokens": [20, 20],
+        })
+
+        result = aggregate_sentiment(path)
+
+        assert result["metadata"]["season"] == "2024-25"

--- a/tests/unit/test_season_config.py
+++ b/tests/unit/test_season_config.py
@@ -7,7 +7,26 @@ accessors, and caching behavior.
 
 import re
 
-from utils.season_config import get_active_season, load_season_config
+import pytest
+
+from utils.paths import get_data_dir
+from utils.player_config import (
+    build_alias_to_player_map,
+    load_player_config,
+    load_player_metadata,
+)
+from utils.season_config import (
+    clear_season_override,
+    get_active_season,
+    load_season_config,
+    set_season_override,
+)
+
+
+def _clear_player_caches() -> None:
+    """Clear the season-derived player-config caches."""
+    for fn in (load_player_config, build_alias_to_player_map, load_player_metadata):
+        fn.cache_clear()
 
 
 class TestLoadSeasonConfig:
@@ -86,3 +105,61 @@ class TestGetActiveSeason:
     def test_matches_season_format(self):
         """Active season is a YYYY-YY identifier."""
         assert re.fullmatch(r"\d{4}-\d{2}", get_active_season())
+
+
+class TestSeasonOverride:
+    """Tests for the process-level --season override (#51)."""
+
+    @pytest.fixture(autouse=True)
+    def clean_override_state(self):
+        """Cold season-derived caches and no override, before and after."""
+        _clear_player_caches()
+        clear_season_override()
+        yield
+        clear_season_override()
+        _clear_player_caches()
+
+    def test_override_changes_active_season(self):
+        """get_active_season returns the override when set."""
+        set_season_override("2024-25")
+        assert get_active_season() == "2024-25"
+
+    def test_no_override_uses_config_file(self):
+        """Without an override, the on-disk config value is returned."""
+        assert get_active_season() == load_season_config()["season"]
+
+    def test_clear_restores_config_value(self):
+        """Clearing the override restores the on-disk config value."""
+        set_season_override("2024-25")
+        clear_season_override()
+        assert get_active_season() == load_season_config()["season"]
+
+    def test_override_reaches_paths(self):
+        """Path resolution honors the override with no parameter threading."""
+        set_season_override("2024-25")
+        assert get_data_dir().name == "2024-25"
+
+    def test_override_reaches_player_config(self):
+        """The player-config loader resolves the override season's file.
+
+        Pins the 2024-25 config's player count — safe because that
+        season is over and its config is frozen.
+        """
+        set_season_override("2024-25")
+        players, _ = load_player_config()
+        assert len(players) == 111
+
+    def test_invalid_format_raises(self):
+        """A malformed season identifier is rejected up front."""
+        with pytest.raises(ValueError, match="YYYY-YY"):
+            set_season_override("2024-2025")
+
+    def test_raises_if_caches_already_warm(self):
+        """Setting the override after config loading fails loud.
+
+        A silent cache clear could mask early code having already acted
+        on the wrong season, so the guard raises instead.
+        """
+        load_player_config()
+        with pytest.raises(RuntimeError, match="script entry"):
+            set_season_override("2024-25")

--- a/tests/unit/test_season_config.py
+++ b/tests/unit/test_season_config.py
@@ -9,6 +9,7 @@ import re
 
 import pytest
 
+import pipeline.processors
 from utils.paths import get_data_dir
 from utils.player_config import (
     build_alias_to_player_map,
@@ -24,9 +25,15 @@ from utils.season_config import (
 
 
 def _clear_player_caches() -> None:
-    """Clear the season-derived player-config caches."""
+    """Clear the season-derived player-config caches.
+
+    Also resets the compiled-pattern global in pipeline.processors:
+    cache_clear() bypasses the override's warm-cache guard, which
+    normally subsumes that global via load_player_config().
+    """
     for fn in (load_player_config, build_alias_to_player_map, load_player_metadata):
         fn.cache_clear()
+    pipeline.processors._player_patterns = None
 
 
 class TestLoadSeasonConfig:

--- a/utils/player_config.py
+++ b/utils/player_config.py
@@ -5,7 +5,10 @@ This module provides cached access to player aliases and short alias lists
 from config/{season}/players.yaml for player mention detection.
 
 Note: Config is cached per process invocation via @lru_cache. One season
-per process — call cache_clear() if switching seasons within a single run.
+per process — the season is resolved through get_active_season() at first
+load, honoring a set_season_override() made at script entry (the --season
+flag). The override's guard raises if these caches are already warm, so
+set it before anything triggers a load.
 """
 
 from functools import lru_cache

--- a/utils/season_config.py
+++ b/utils/season_config.py
@@ -4,11 +4,16 @@ Season configuration loading from YAML.
 This module provides cached access to the active season identifier,
 date boundaries, and target subreddits from config/season.yaml.
 
-Note: Config is cached per process invocation. If a future script needs
-to process multiple seasons in one run, call load_season_config.cache_clear()
-before switching.
+The active season can be overridden per process via set_season_override()
+(the scripts' --season flag), which must be called at script entry before
+any season-derived config is loaded — one season per process still holds.
+The override redirects only the season identifier (paths, players.yaml);
+load_season_config()'s other fields (start_date, end_date, subreddits)
+deliberately keep their on-disk values, so scripts that consume those
+(download_comments) must not use the override.
 """
 
+import re
 from functools import lru_cache
 from pathlib import Path
 
@@ -18,6 +23,10 @@ import yaml
 CONFIG_PATH = Path(__file__).parent.parent / "config" / "season.yaml"
 
 REQUIRED_KEYS = {"season", "start_date", "end_date", "subreddits"}
+
+SEASON_FORMAT = re.compile(r"\d{4}-\d{2}")
+
+_season_override: str | None = None
 
 
 @lru_cache(maxsize=1)
@@ -51,9 +60,80 @@ def load_season_config() -> dict:
 
 def get_active_season() -> str:
     """
-    Get the active season identifier from config.
+    Get the active season identifier.
+
+    Returns the process-level override when one is set (see
+    set_season_override), otherwise the value from config/season.yaml.
 
     Returns:
         Season string, e.g. "2024-25".
     """
+    if _season_override is not None:
+        return _season_override
     return load_season_config()["season"]
+
+
+def set_season_override(season: str) -> None:
+    """
+    Override the active season for the rest of this process.
+
+    Call once at script entry (the --season flag), before any
+    season-derived config is loaded. Everything that resolves through
+    get_active_season() — data paths, the players.yaml loaders, the
+    aggregates.json season stamp — follows the override; the remaining
+    load_season_config() fields (start_date, end_date, subreddits) keep
+    their on-disk values.
+
+    Args:
+        season: Season identifier, e.g. "2024-25".
+
+    Raises:
+        ValueError: If season is not in YYYY-YY format.
+        RuntimeError: If season-derived caches are already warm — data
+            was already loaded for another season, and clearing it
+            silently could mask work that acted on the wrong season.
+    """
+    if not SEASON_FORMAT.fullmatch(season):
+        raise ValueError(
+            f"Invalid season identifier: {season!r} (expected YYYY-YY, "
+            'e.g. "2024-25")'
+        )
+    _ensure_season_caches_cold()
+    global _season_override
+    _season_override = season
+
+
+def clear_season_override() -> None:
+    """Clear the season override, restoring config/season.yaml resolution."""
+    global _season_override
+    _season_override = None
+
+
+def _ensure_season_caches_cold() -> None:
+    """
+    Fail fast if season-derived caches were populated before the override.
+
+    Checks the player-config loaders' lru_caches; these subsume the
+    compiled-pattern cache in pipeline/processors.py, which is only ever
+    populated through load_player_config().
+
+    Raises:
+        RuntimeError: Naming the warm caches, if any.
+    """
+    from utils.player_config import (
+        build_alias_to_player_map,
+        load_player_config,
+        load_player_metadata,
+    )
+
+    warm = [
+        fn.__name__
+        for fn in (load_player_config, build_alias_to_player_map, load_player_metadata)
+        if fn.cache_info().currsize > 0
+    ]
+    if warm:
+        raise RuntimeError(
+            f"set_season_override() called after season-derived caches were "
+            f"populated: {warm}. Set the override at script entry, before "
+            "any config loading."
+        )

--- a/utils/season_config.py
+++ b/utils/season_config.py
@@ -11,6 +11,9 @@ The override redirects only the season identifier (paths, players.yaml);
 load_season_config()'s other fields (start_date, end_date, subreddits)
 deliberately keep their on-disk values, so scripts that consume those
 (download_comments) must not use the override.
+
+The override is process-local module state: spawn-based worker processes
+(multiprocessing) would not inherit it and must set it themselves.
 """
 
 import re


### PR DESCRIPTION
Closes #51

## What

`--season YYYY-YY` flag on `collect_results`, `aggregate_sentiment`, `process_comments`, and `prepare_batches`, backed by a process-level override on `get_active_season()`:

- `season_config.set_season_override()` — called once at script entry; validates format, then everything downstream (all five path leaf functions, the three player-config loaders, the `aggregates.json` season stamp) follows the override with **zero parameter threading**, because it all already resolves through `get_active_season()`.
- `clear_season_override()` for test hygiene; `season_override` conftest fixture manages the global state + cache clearing for tests.

## The ordering guard (the real work in #51)

`set_season_override()` **raises** if the season-derived caches (`load_player_config`, `build_alias_to_player_map`, `load_player_metadata`) are already warm — failing loud instead of silently clearing, since a clear can mask early code having already acted on the wrong season. These three subsume the compiled-pattern cache in `pipeline/processors.py`, which only populates through `load_player_config()`.

Related fix the guard surfaced: three scripts resolved default paths *before* `parse_args()` (for help-text f-strings), which would have baked active-season paths in before the override landed. Default resolution now happens after the override; help text uses `data/<season>/…` placeholders.

## Deliberately excluded: `download_comments`

The override redirects the season *identifier* only; `load_season_config()`'s `start_date` / `end_date` / `subreddits` keep on-disk values (documented in both module docstrings). `download_comments` consumes those fields, so giving it the flag would let one season's directory be filled with another season's date window.

## Verification

- 286 tests pass, ruff clean.
- New tests: override identity/clear/default, format validation, paths reach-through, player-config reach-through (2024-25's frozen 111-player config), the warm-cache guard, and `metadata.season` honoring the override in `aggregate_sentiment` output (pins the AC from #51).
- End-to-end smoke with 2025-26 active on disk: override to `2024-25` → `data/2024-25/*` paths + 111-player config loaded.

#47 (v1 re-assembly) is now unblocked: `uv run python -m scripts.collect_results --season 2024-25 --no-wait` then `... aggregate_sentiment --season 2024-25`.