### PR TITLE
fix(pipeline): retry Cloudflare 52x and widen backoff to cover outages

### DIFF
--- a/pipeline/arctic_shift.py
+++ b/pipeline/arctic_shift.py
@@ -68,7 +68,8 @@ class ArcticShiftClient:
         delay: Seconds to wait between requests. Defaults to 0.5s.
         page_size: Max items per request. Defaults to 100.
         rate_limit_buffer: Sleep when remaining requests fall below this. Defaults to 10.
-        max_attempts: Total attempts per page request (1 initial + retries). Defaults to 4.
+        max_attempts: Total attempts per page request (1 initial + retries).
+            Defaults to ARCTIC_SHIFT_MAX_ATTEMPTS.
         retry_backoff: Base seconds for exponential backoff between retries. Defaults to 2.0.
 
     Example:

--- a/tests/unit/test_arctic_shift.py
+++ b/tests/unit/test_arctic_shift.py
@@ -327,6 +327,47 @@ class TestRetry:
         assert len(results) == 1
         assert mock_get.call_count == 3
 
+    @pytest.mark.parametrize("status", [520, 521, 522, 523, 524])
+    def test_retries_cloudflare_52x_then_succeeds(
+        self, status, mock_comments_page, mock_empty_response
+    ):
+        """Verify Cloudflare origin-side errors are retried.
+
+        520 ("origin returned unknown response") killed the first v2
+        download attempt; the 52x family signals transient
+        Cloudflare-to-origin failures, not client errors.
+        """
+        client = ArcticShiftClient(retry_backoff=0, delay=0)
+        page = mock_comments_page(start_id=1, count=2)
+
+        with patch.object(
+            client.session,
+            "get",
+            side_effect=[_error_response(status), page, mock_empty_response],
+        ) as mock_get:
+            results = list(client.fetch_comments("nba", after=0, before=200))
+
+        assert len(results) == 2
+        assert mock_get.call_count == 3
+
+    def test_default_backoff_window_covers_short_outages(self):
+        """Verify the default schedule rides out a typical origin restart.
+
+        Correlated failure bursts (backend restarts) last 30-120s; the
+        default attempts/backoff must cover at least ~60s, not just
+        single-request blips.
+        """
+        client = ArcticShiftClient()
+
+        with patch.object(client.session, "get", return_value=_error_response(503)):
+            with patch("pipeline.arctic_shift.time.sleep") as mock_sleep:
+                with pytest.raises(requests.HTTPError):
+                    list(client.fetch_comments("nba", after=0, before=200))
+
+        waits = [c.args[0] for c in mock_sleep.call_args_list]
+        assert waits == [2.0, 4.0, 8.0, 16.0, 32.0]
+        assert sum(waits) >= 60
+
     def test_raises_after_exhausting_attempts(self):
         """Verify a persistent transient error raises after max_attempts."""
         client = ArcticShiftClient(retry_backoff=0, max_attempts=3)

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -58,18 +58,25 @@ ARCTIC_SHIFT_REQUEST_DELAY = 0.5
 # Rate limit buffer - sleep when remaining requests drop below this
 ARCTIC_SHIFT_RATE_LIMIT_BUFFER = 10
 
-# Total attempts per page request (1 initial + retries)
-ARCTIC_SHIFT_MAX_ATTEMPTS = 4
+# Total attempts per page request (1 initial + retries). The window must
+# ride out correlated failure bursts (origin restarts run 30-120s), not
+# just single-request blips: 6 attempts -> 2+4+8+16+32 = 62s of coverage
+# (observed 2026-07-04: a burst outlasted the previous ~14s window).
+ARCTIC_SHIFT_MAX_ATTEMPTS = 6
 
-# Base seconds for exponential backoff between retries (2s -> 4s -> 8s)
+# Base seconds for exponential backoff between retries (2s -> 4s -> ... -> 32s)
 ARCTIC_SHIFT_RETRY_BACKOFF = 2.0
 
 # HTTP statuses treated as transient. 422 is included deliberately: the API
 # intermittently surfaces backend hiccups as 422 on requests that succeed
 # when replayed (observed 2026-07-02 on the v2 season download). 429 is
 # normally avoided via the rate-limit headers, but retrying covers the case
-# where those headers are absent.
-ARCTIC_SHIFT_RETRYABLE_STATUSES = frozenset({422, 429, 500, 502, 503, 504})
+# where those headers are absent. The Cloudflare 52x family is origin-side
+# (520 "unknown response" killed the first v2 download attempt; 521-524 are
+# origin down/unreachable/timeout) — transient by nature, never client error.
+ARCTIC_SHIFT_RETRYABLE_STATUSES = frozenset(
+    {422, 429, 500, 502, 503, 504, 520, 521, 522, 523, 524}
+)
 
 
 

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -58,10 +58,12 @@ ARCTIC_SHIFT_REQUEST_DELAY = 0.5
 # Rate limit buffer - sleep when remaining requests drop below this
 ARCTIC_SHIFT_RATE_LIMIT_BUFFER = 10
 
-# Total attempts per page request (1 initial + retries). The window must
-# ride out correlated failure bursts (origin restarts run 30-120s), not
-# just single-request blips: 6 attempts -> 2+4+8+16+32 = 62s of coverage
-# (observed 2026-07-04: a burst outlasted the previous ~14s window).
+# Total attempts per page request (1 initial + retries). Sized for
+# correlated failure bursts (origin restarts), not just single-request
+# blips: 6 attempts -> 2+4+8+16+32 = 62s of coverage, which rides out
+# short restarts (observed 2026-07-04: a burst outlasted the previous
+# ~14s window). Bursts longer than the window still exhaust retries;
+# the download script's resume-from-file is the backstop there.
 ARCTIC_SHIFT_MAX_ATTEMPTS = 6
 
 # Base seconds for exponential backoff between retries (2s -> 4s -> ... -> 32s)


### PR DESCRIPTION
## What

Two-line policy change in `utils/constants.py`, from failures observed on the running v2 download:

- **`{520, 521, 522, 523, 524}` added to `ARCTIC_SHIFT_RETRYABLE_STATUSES`.** The Cloudflare 52x family is origin-side and transient by nature — and 520 ("origin returned unknown response") is the exact error that killed the first v2 download attempt, yet it currently raises with zero retries.
- **`ARCTIC_SHIFT_MAX_ATTEMPTS` 4 → 6**, extending backoff coverage from ~14s (2+4+8) to ~62s (2+4+8+16+32). The observed retry exhaustion mid-download has the signature of a correlated failure burst (origin restart, typically 30–120s), not a single-request blip — the old window couldn't outlast it. Worst case cost: a one-minute stall in a multi-hour run.

## Tests (red-first)

- Parametrized retry-then-succeed over all five 52x statuses
- `test_default_backoff_window_covers_short_outages` pins the default schedule (`[2, 4, 8, 16, 32]`, ≥60s total) so the window can't silently shrink

`uv run pytest` (292 passed) and `uv run ruff check .` clean.

## Notes

The download script's resume-from-file (#50) remains the backstop for outages longer than the window — a failure is a restart, not a lost run.