### PR TITLE
feat(config): add Terry Rozier and Jaden Ivey (config v2.0)

### DIFF
--- a/config/2025-26/players.yaml
+++ b/config/2025-26/players.yaml
@@ -102,6 +102,8 @@ short_aliases:
 - keynote
 - kg3
 - keldon
+- terry
+- brown
 players:
   Steven Adams:
     team: Houston Rockets
@@ -400,6 +402,7 @@ players:
     - jaylen brown
     - jaylen
     - robin to tatum
+    - brown  # watchlist: verify post-filter (Bruce Brown collision, color)
     - jb
 
   Jalen Brunson:
@@ -625,7 +628,7 @@ players:
     aliases:
     - gradey
     - grady
-    - dick
+    - dick  # watchlist: verify post-filter (standalone insult)
 
   Rob Dillingham:
     team: Chicago Bulls
@@ -1835,6 +1838,7 @@ players:
     - terry rozier
     - rozier
     - scary terry
+    - terry  # watchlist: verify post-filter (common name/word)
 
   D'Angelo Russell:
     team: Washington Wizards
@@ -1971,7 +1975,7 @@ players:
     headshot_url: https://cdn.nba.com/headshots/nba/latest/1040x760/1631095.png
     aliases:
     - jabari smith
-    - jabari
+    - jabari  # watchlist: verify post-filter (Jabari Parker)
 
   Jalen Smith:
     team: Chicago Bulls

--- a/config/2025-26/players.yaml
+++ b/config/2025-26/players.yaml
@@ -3,7 +3,7 @@
 # Carry-overs verbatim (+ §1.4 gaps); 108 new players: full-name + diacritic
 # floor + collision-safe surname. Flagged surnames -> Step 3 nba-superfan round.
 
-version: '1.0'
+version: '2.0'
 season: 2025-26
 short_aliases:
 - ad
@@ -1132,6 +1132,15 @@ players:
     - third eye
     - antisemite
 
+  Jaden Ivey:
+    team: null
+    conference: null
+    player_id: 1631093
+    headshot_url: https://cdn.nba.com/headshots/nba/latest/1040x760/1631093.png
+    aliases:
+    - jaden ivey
+    - ivey
+
   GG Jackson:
     team: Memphis Grizzlies
     conference: West
@@ -1816,6 +1825,16 @@ players:
     - rollins
     - rylo
     - lightskin blade
+
+  Terry Rozier:
+    team: null
+    conference: null
+    player_id: 1626179
+    headshot_url: https://cdn.nba.com/headshots/nba/latest/1040x760/1626179.png
+    aliases:
+    - terry rozier
+    - rozier
+    - scary terry
 
   D'Angelo Russell:
     team: Washington Wizards


### PR DESCRIPTION
## Summary
Two major 2025-26 storylines weren't covered because the players weren't in the config:
1. **Terry Rozier** — betting scandal
2. **Jaden Ivey** — public breakdown

Neither appears on a 2025-26 roster in `data/2025-26/reference/rosters.parquet`, so both enter **teamless** (`team: null`) per the discourse-driven inclusion policy — off-roster ≠ no discourse, and these two are storyline-central.

## Details
- `player_id` from nba_api's static registry (1626179 / 1631093); headshots derived from id
- Aliases: `rozier`, `scary terry`, `terry` / `ivey` — bare `jaden` deliberately omitted (collides with Jaden McDaniels)
- Second commit binds `brown` → Jaylen Brown (accepted Bruce Brown collision, volume asymmetry) — the alias returns bound after its v1 orphan removal
- Config `version` 1.0 → 2.0 (major = roster add, per the scheme)
- Validated through the pipeline loaders: 221 players, 98 short_aliases, no alias collisions

## Post-filter watchlist (inline `# watchlist` comments in the YAML)
Verify these four aliases against real matches **post-filter / pre-batch-submission**, before classification spend:
| Alias | Player | Risk |
|---|---|---|
| `terry` | Terry Rozier | common name/word |
| `brown` | Jaylen Brown | Bruce Brown mis-attribution, color |
| `dick` | Gradey Dick | standalone insult |
| `jabari` | Jabari Smith Jr. | Jabari Parker |

## Timing
The v2 download is still running; these land before the filter step, so both players are fully covered in the v2 run.

Refs #30