### PR TITLE
feat(config): alias batch — vet/nickname recall fixes (config v2.1)

### DIFF
--- a/config/2025-26/players.yaml
+++ b/config/2025-26/players.yaml
@@ -3,7 +3,7 @@
 # Carry-overs verbatim (+ §1.4 gaps); 108 new players: full-name + diacritic
 # floor + collision-safe surname. Flagged surnames -> Step 3 nba-superfan round.
 
-version: '2.0'
+version: '2.1'
 season: 2025-26
 short_aliases:
 - ad
@@ -1216,6 +1216,7 @@ players:
     headshot_url: https://cdn.nba.com/headshots/nba/latest/1040x760/1629661.png
     aliases:
     - cameron johnson
+    - cam johnson
 
   Jalen Johnson:
     team: Atlanta Hawks

--- a/config/2025-26/players.yaml
+++ b/config/2025-26/players.yaml
@@ -255,6 +255,9 @@ players:
     - banchero
     - paolo
     - pb
+    - big rig
+    - banchurrow
+    - pabracadabra
 
   Desmond Bane:
     team: Orlando Magic

--- a/config/2025-26/players.yaml
+++ b/config/2025-26/players.yaml
@@ -104,6 +104,15 @@ short_aliases:
 - keldon
 - terry
 - brown
+- p5
+- dyson
+- kcp
+- kuz
+- rj
+- bones
+- pj
+- hunter
+- benny
 players:
   Steven Adams:
     team: Houston Rockets
@@ -140,6 +149,7 @@ players:
     headshot_url: https://cdn.nba.com/headshots/nba/latest/1040x760/1628960.png
     aliases:
     - grayson allen
+    - grayson
 
   Jarrett Allen:
     team: Cleveland Cavaliers
@@ -148,6 +158,11 @@ players:
     headshot_url: https://cdn.nba.com/headshots/nba/latest/1040x760/1628386.png
     aliases:
     - jarrett allen
+    - jarrett
+    - frohio
+    - the big fro
+    - froski
+    - one of us  # watchlist: verify post-filter (common phrase)
 
   Jose Alvarado:
     team: New York Knicks
@@ -258,6 +273,7 @@ players:
     - big rig
     - banchurrow
     - pabracadabra
+    - p5
 
   Desmond Bane:
     team: Orlando Magic
@@ -292,6 +308,7 @@ players:
     headshot_url: https://cdn.nba.com/headshots/nba/latest/1040x760/1629628.png
     aliases:
     - rj barrett
+    - rj  # watchlist: verify post-filter (Richard Jefferson)
 
   Nicolas Batum:
     team: Los Angeles Clippers
@@ -338,6 +355,7 @@ players:
     - bogdan bogdanović
     - bogdan bogdanovic
     - bogdanović
+    - bogdan
 
   Devin Booker:
     team: Phoenix Suns
@@ -458,6 +476,7 @@ players:
     aliases:
     - kentavious caldwell-pope
     - caldwell-pope
+    - kcp
 
   Toumani Camara:
     team: Portland Trail Blazers
@@ -512,6 +531,9 @@ players:
     aliases:
     - julian champagnie
     - champagnie
+    - jcpenney
+    - the counterfeit
+    - sham penny
 
   Jordan Clarkson:
     team: New York Knicks
@@ -586,6 +608,9 @@ players:
     aliases:
     - dyson daniels
     - daniels
+    - dyson
+    - the vacuum
+    - the great barrier thief
 
   Anthony Davis:
     team: Washington Wizards
@@ -1101,6 +1126,7 @@ players:
     headshot_url: https://cdn.nba.com/headshots/nba/latest/1040x760/1629631.png
     aliases:
     - de'andre hunter
+    - hunter  # watchlist: verify post-filter (common word)
 
   Bones Hyland:
     team: Minnesota Timberwolves
@@ -1110,6 +1136,7 @@ players:
     aliases:
     - bones hyland
     - hyland
+    - bones
 
   Brandon Ingram:
     team: Toronto Raptors
@@ -1306,6 +1333,7 @@ players:
     aliases:
     - kyle kuzma
     - kuzma
+    - kuz
 
   Zach LaVine:
     team: Sacramento Kings
@@ -1404,6 +1432,14 @@ players:
     headshot_url: https://cdn.nba.com/headshots/nba/latest/1040x760/1631097.png
     aliases:
     - bennedict mathurin
+    - mathurin
+    - benedict mathurin
+    - mathurhim
+    - the mathematician
+    - quick math
+    - the math problem
+    - eggs bennedict
+    - benny  # watchlist: verify post-filter (Benny the Bull mascot)
 
   Tyrese Maxey:
     team: Philadelphia 76ers
@@ -1722,6 +1758,8 @@ players:
     aliases:
     - payton pritchard
     - pritchard
+    - fast pp
+    - p-rabbit
 
   Derik Queen:
     team: New Orleans Pelicans
@@ -1902,6 +1940,7 @@ players:
     headshot_url: https://cdn.nba.com/headshots/nba/latest/1040x760/1629012.png
     aliases:
     - collin sexton
+    - young bull
 
   Landry Shamet:
     team: New York Knicks
@@ -1962,6 +2001,7 @@ players:
     aliases:
     - anfernee simons
     - simons
+    - anfernee
 
   Marcus Smart:
     team: Los Angeles Lakers
@@ -2087,6 +2127,7 @@ players:
     headshot_url: https://cdn.nba.com/headshots/nba/latest/1040x760/1629018.png
     aliases:
     - gary trent jr
+    - gary trent
 
   Myles Turner:
     team: Milwaukee Bucks
@@ -2169,6 +2210,7 @@ players:
     headshot_url: https://cdn.nba.com/headshots/nba/latest/1040x760/1629023.png
     aliases:
     - pj washington
+    - pj
 
   Peyton Watson:
     team: Denver Nuggets


### PR DESCRIPTION
Ongoing batch of alias-only recall fixes (config **2.0 → 2.1**, minor = alias-only). Collecting the vet-tail gaps as they surface rather than one-line PRs.

## Included so far
- **Cameron Johnson** + `cam johnson` — his dominant r/NBA form. Bare `cam` omitted (Cam Thomas/Whitmore mis-attribution).
- **Paolo Banchero** + `big rig`, `banchurrow`, `pabracadabra`, `p5` — 2025-26 meme coinage not covered by any existing alias substring.
- **Vet nickname batch (16 players, 32 aliases)** — nba-superfan triaged the 57 untouched vets; finalized Tier-1 keeps: Dyson Daniels (`dyson`, `the vacuum`, `the great barrier thief`), KCP (`kcp`), Kuzma (`kuz`), Pritchard (`fast pp`, `p-rabbit`), RJ Barrett (`rj`), Bones Hyland (`bones`), P.J. Washington (`pj`), Grayson Allen (`grayson`), Sexton (`young bull`), Bogdanović (`bogdan`), Simons (`anfernee`), Jarrett Allen (`jarrett`, `frohio`, `the big fro`, `froski`, `one of us`), Mathurin (`mathurin`, `benedict mathurin`, `mathurhim`, `the mathematician`, `quick math`, `the math problem`, `eggs bennedict`, `benny`), Gary Trent (`gary trent`), Champagnie (`jcpenney`, `the counterfeit`, `sham penny`), Hunter (`hunter`). `gg` rejected (good-game flood); Tier 2/3 skipped by decision.

## Batch rule
An alias earns a row only if **no existing alias is a substring of it** — containment means the matcher already catches it.

## Post-filter watchlist (inline `# watchlist` comments, grep `watchlist`)
`terry` (Rozier · merged in #56), `brown` (Jaylen/Bruce · #56), `dick` (Gradey/insult), `jabari` (Parker), **`rj`** (Richard Jefferson), **`one of us`** (common phrase), **`benny`** (Benny the Bull), **`hunter`** (common word). Verify post-filter / pre-batch-submission.

Validated per commit: loaders resolve, zero alias collisions (221 players, 107 short_aliases).

Refs #30