### PR TITLE
test(sentiment): port classifier eval suite to pytest (#62 item 1)

### DIFF
--- a/pipeline/evaluation.py
+++ b/pipeline/evaluation.py
@@ -24,6 +24,7 @@ import anthropic
 import yaml
 
 from pipeline.batch import MAX_TOKENS, MODEL, TEMPERATURE, build_prompt, parse_response
+from utils.player_config import resolve_sentiment_player
 
 logger = logging.getLogger(__name__)
 
@@ -271,6 +272,34 @@ def player_match(predicted: str | None, expected: str | None) -> bool:
     if pred_norm is None or exp_norm is None:
         return False
     return pred_norm in exp_norm or exp_norm in pred_norm
+
+
+def attribution_match(
+    predicted: str | None, expected: str | None, alias_map: dict[str, str]
+) -> bool:
+    """
+    Check attribution the way production consumes the model's p field.
+
+    Resolves the predicted name through the alias map exactly as
+    resolve_player() does at aggregation, so nickname or initialism
+    output (e.g. "AD") counts as correct when it resolves to the
+    expected canonical player. Unresolvable output counts as None —
+    matching production, where such attributions are dropped.
+
+    Contrast with player_match(), which compares raw model output by
+    substring: useful for measuring what the model literally says
+    (issue #62 item 4), but stricter than the pipeline's behavior.
+
+    Args:
+        predicted: The model's attributed player, or None.
+        expected: The ground-truth canonical player name, or None.
+        alias_map: Mapping of lowercase aliases to canonical player names,
+            as returned by build_alias_to_player_map().
+
+    Returns:
+        True if the resolved prediction equals the expected canonical name.
+    """
+    return resolve_sentiment_player(predicted, alias_map) == expected
 
 
 def accuracy_by_category(

--- a/pipeline/evaluation.py
+++ b/pipeline/evaluation.py
@@ -1,0 +1,299 @@
+"""Eval harness for the LLM sentiment classifier.
+
+Loads ground-truth cases from a YAML file and runs them through the
+production prompt/parse path (pipeline.batch.build_prompt +
+parse_response) with production model parameters.
+
+Cases are classified via the synchronous Messages API rather than the
+Batch API used in production: identical model, temperature, and token
+limits — only the transport differs. This is deliberate; a 23-case eval
+must finish in seconds, not hours. Do not "fix" this to use batches.
+
+The prompt_builder parameter on classify_cases exists so prompt-variant
+experiments (issue #62 item 3) can reuse this harness against candidate
+prompts without touching the pytest suite, which always measures the
+production prompt.
+"""
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+import anthropic
+import yaml
+
+from pipeline.batch import MAX_TOKENS, MODEL, TEMPERATURE, build_prompt, parse_response
+
+logger = logging.getLogger(__name__)
+
+VALID_SENTIMENTS = ("pos", "neg", "neu")
+VALID_SOURCES = ("synthetic", "mined-v1", "mined-v2")
+REQUIRED_KEYS = ("id", "text", "expected", "expected_player", "category", "source")
+
+DEFAULT_CASES_PATH = (
+    Path(__file__).resolve().parent.parent / "tests" / "eval" / "cases.yaml"
+)
+
+
+@dataclass(frozen=True)
+class EvalCase:
+    """A single ground-truth classification case.
+
+    Attributes:
+        id: Unique, category-prefixed identifier (e.g. "sarcasm-01").
+        text: Comment body sent to the classifier.
+        expected: Ground-truth sentiment ("pos" | "neg" | "neu").
+        expected_player: Ground-truth attributed player, or None.
+        category: Grouping used for aggregate accuracy floors.
+        source: Provenance ("synthetic" | "mined-v1" | "mined-v2").
+        comment_id: Reddit comment id for mined cases, if any.
+        note: Free-text context (e.g. why a case is a known miss).
+        known_miss: Sentiment test is xfail — the current prompt misses it.
+        known_miss_player: Player-attribution test is xfail.
+    """
+
+    id: str
+    text: str
+    expected: str
+    expected_player: str | None
+    category: str
+    source: str
+    comment_id: str | None = None
+    note: str | None = None
+    known_miss: bool = False
+    known_miss_player: bool = False
+
+
+def _read_cases_file(path: Path) -> tuple[dict[str, float], list[dict]]:
+    """
+    Read and structurally validate the cases YAML file.
+
+    Args:
+        path: Path to the cases file.
+
+    Returns:
+        Tuple of (category_floors mapping, raw case dicts).
+
+    Raises:
+        ValueError: If the top-level structure is malformed.
+    """
+    with open(path) as f:
+        payload = yaml.safe_load(f)
+
+    if not isinstance(payload, dict):
+        raise ValueError(f"Cases file {path} is not a mapping")
+
+    floors = payload.get("meta", {}).get("category_floors")
+    if not isinstance(floors, dict):
+        raise ValueError(f"Cases file {path} is missing meta.category_floors")
+
+    cases = payload.get("cases")
+    if not isinstance(cases, list):
+        raise ValueError(f"Cases file {path} is missing a 'cases' list")
+
+    return floors, cases
+
+
+def load_cases(path: Path = DEFAULT_CASES_PATH) -> list[EvalCase]:
+    """
+    Load and validate eval cases from a YAML file.
+
+    Args:
+        path: Path to the cases file. Defaults to tests/eval/cases.yaml.
+
+    Returns:
+        List of validated EvalCase objects in file order.
+
+    Raises:
+        ValueError: On duplicate ids, missing required keys, invalid
+            expected/source values, or a case category that has no entry
+            in meta.category_floors. Messages name the offending case.
+    """
+    floors, raw_cases = _read_cases_file(path)
+
+    cases: list[EvalCase] = []
+    seen_ids: set[str] = set()
+
+    for index, raw in enumerate(raw_cases):
+        case_label = raw.get("id", f"case #{index}")
+
+        missing = [key for key in REQUIRED_KEYS if key not in raw]
+        if missing:
+            raise ValueError(f"Case {case_label!r} is missing keys: {missing}")
+
+        if raw["id"] in seen_ids:
+            raise ValueError(f"Duplicate case id: {raw['id']!r}")
+        seen_ids.add(raw["id"])
+
+        if raw["expected"] not in VALID_SENTIMENTS:
+            raise ValueError(
+                f"Case {case_label!r} has invalid expected value "
+                f"{raw['expected']!r} (must be one of {VALID_SENTIMENTS})"
+            )
+
+        if raw["source"] not in VALID_SOURCES:
+            raise ValueError(
+                f"Case {case_label!r} has invalid source {raw['source']!r} "
+                f"(must be one of {VALID_SOURCES})"
+            )
+
+        if raw["category"] not in floors:
+            raise ValueError(
+                f"Case {case_label!r} has category {raw['category']!r} "
+                "with no entry in meta.category_floors"
+            )
+
+        cases.append(
+            EvalCase(
+                id=raw["id"],
+                text=raw["text"],
+                expected=raw["expected"],
+                expected_player=raw["expected_player"],
+                category=raw["category"],
+                source=raw["source"],
+                comment_id=raw.get("comment_id"),
+                note=raw.get("note"),
+                known_miss=raw.get("known_miss", False),
+                known_miss_player=raw.get("known_miss_player", False),
+            )
+        )
+
+    return cases
+
+
+def load_category_floors(path: Path = DEFAULT_CASES_PATH) -> dict[str, float]:
+    """
+    Load and validate per-category accuracy floors.
+
+    Args:
+        path: Path to the cases file. Defaults to tests/eval/cases.yaml.
+
+    Returns:
+        Mapping of category name to minimum acceptable accuracy in [0, 1].
+
+    Raises:
+        ValueError: If a floor is outside [0, 1] or names a category with
+            no cases in the file.
+    """
+    floors, raw_cases = _read_cases_file(path)
+
+    for category, floor in floors.items():
+        if not isinstance(floor, int | float) or not 0.0 <= floor <= 1.0:
+            raise ValueError(
+                f"Floor for category {category!r} must be in [0, 1], got {floor!r}"
+            )
+
+    case_categories = {raw.get("category") for raw in raw_cases}
+    unused = sorted(set(floors) - case_categories)
+    if unused:
+        raise ValueError(f"Floors defined for categories with no cases: {unused}")
+
+    return {category: float(floor) for category, floor in floors.items()}
+
+
+def classify_cases(
+    cases: list[EvalCase],
+    prompt_builder: Callable[[str], str] = build_prompt,
+    client: anthropic.Anthropic | None = None,
+) -> dict[str, dict]:
+    """
+    Classify each case via the synchronous Messages API.
+
+    Uses production model parameters (MODEL, TEMPERATURE, MAX_TOKENS) and
+    the production response parser, so results measure exactly what the
+    batch pipeline would produce for the same prompt.
+
+    Args:
+        cases: Cases to classify.
+        prompt_builder: Builds the user message from a comment body.
+            Defaults to the production prompt; pass a variant for prompt
+            experiments.
+        client: Anthropic client. Defaults to a fresh client reading
+            ANTHROPIC_API_KEY from the environment.
+
+    Returns:
+        Mapping of case id to parsed result dict (parse_response shape).
+    """
+    if client is None:
+        client = anthropic.Anthropic()
+
+    results: dict[str, dict] = {}
+    for case in cases:
+        response = client.messages.create(
+            model=MODEL,
+            max_tokens=MAX_TOKENS,
+            temperature=TEMPERATURE,
+            messages=[{"role": "user", "content": prompt_builder(case.text)}],
+        )
+        results[case.id] = parse_response(response.content[0].text)
+        logger.debug("Classified %s: %s", case.id, results[case.id]["s"])
+
+    return results
+
+
+def normalize_player(name: str | None) -> str | None:
+    """
+    Normalize a player name for comparison.
+
+    Args:
+        name: Raw player name, possibly None.
+
+    Returns:
+        Lowercased, stripped name; None for None, empty, or whitespace
+        input (an empty string would otherwise substring-match anything).
+    """
+    if name is None:
+        return None
+    stripped = name.strip()
+    return stripped.lower() if stripped else None
+
+
+def player_match(predicted: str | None, expected: str | None) -> bool:
+    """
+    Check whether a predicted player attribution matches the expected one.
+
+    Uses bidirectional substring matching after normalization so partial
+    names ("LeBron" vs "LeBron James") count as matches.
+
+    Args:
+        predicted: The model's attributed player, or None.
+        expected: The ground-truth player, or None.
+
+    Returns:
+        True if both are None or either normalized name contains the other.
+    """
+    pred_norm = normalize_player(predicted)
+    exp_norm = normalize_player(expected)
+
+    if pred_norm is None and exp_norm is None:
+        return True
+    if pred_norm is None or exp_norm is None:
+        return False
+    return pred_norm in exp_norm or exp_norm in pred_norm
+
+
+def accuracy_by_category(
+    cases: list[EvalCase], results: dict[str, dict]
+) -> dict[str, tuple[int, int]]:
+    """
+    Tally sentiment accuracy per case category.
+
+    Known-miss cases are included in the totals; category floors are set
+    with them priced in.
+
+    Args:
+        cases: The cases that were classified.
+        results: Mapping of case id to parsed result (classify_cases shape).
+
+    Returns:
+        Mapping of category to (correct, total) sentiment counts.
+    """
+    tallies: dict[str, tuple[int, int]] = {}
+    for case in cases:
+        correct, total = tallies.get(case.category, (0, 0))
+        if results[case.id]["s"] == case.expected:
+            correct += 1
+        tallies[case.category] = (correct, total + 1)
+
+    return tallies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,10 @@ exclude = ["notebooks/"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-x --tb=short"
+addopts = "-x --tb=short -m 'not eval'"
+markers = [
+    "eval: live LLM classifier eval (needs ANTHROPIC_API_KEY; run: uv run pytest -m eval --maxfail=0 -rxX)",
+]
 
 [tool.uv]
 dev-dependencies = [

--- a/tests/eval/cases.yaml
+++ b/tests/eval/cases.yaml
@@ -1,0 +1,210 @@
+# Ground-truth cases for the LLM classifier eval suite (issue #62).
+#
+# Ported verbatim from VALIDATION_SET in
+# notebooks/2024-25/04_cost_analysis.ipynb — the 23-case set the
+# production minimal prompt was validated against. Categories follow the
+# notebook's grouping.
+#
+# Per-case schema (loader: pipeline/evaluation.py):
+#   id                unique, category-prefixed
+#   text              comment body sent to the classifier
+#   expected          pos | neg | neu
+#   expected_player   canonical player name, or null
+#   category          must have an entry in meta.category_floors
+#   source            synthetic | mined-v1 | mined-v2
+#   comment_id        (optional) Reddit comment id for mined cases
+#   note              (optional) context, e.g. why a case is a known miss
+#   known_miss        (optional) sentiment test is xfail at current baseline
+#   known_miss_player (optional) player-attribution test is xfail
+#
+# meta.category_floors are minimum sentiment-accuracy fractions per
+# category, pinned from the baseline run (see PR for the recorded run).
+
+# Baseline (2026-07-09, 3 runs, claude-haiku-4-5-20251001 @ temp 0):
+# 21/23 sentiment stable-correct; sarcasm-01 stable miss, sarcasm-02
+# unstable across runs. Floors: baseline minus one case of slack for
+# categories with >=5 cases, exact baseline otherwise.
+meta:
+  category_floors:
+    clear_positive: 0.8
+    clear_negative: 0.83
+    neutral: 1.0
+    slang_inversion: 1.0
+    sarcasm: 0.0
+    negative_nickname: 1.0
+
+cases:
+  # --- Clear positive ---
+  - id: pos-01
+    text: "LeBron is the GOAT"
+    expected: pos
+    expected_player: "LeBron James"
+    category: clear_positive
+    source: synthetic
+
+  - id: pos-02
+    text: "Curry is absolutely disgusting from three"
+    expected: pos
+    expected_player: "Stephen Curry"
+    category: clear_positive
+    source: synthetic
+
+  - id: pos-03
+    text: "That dunk was NASTY"
+    expected: pos
+    expected_player: null
+    category: clear_positive
+    source: synthetic
+
+  - id: pos-04
+    text: "Jokic is a generational talent"
+    expected: pos
+    expected_player: "Nikola Jokic"
+    category: clear_positive
+    source: synthetic
+
+  - id: pos-05
+    text: "Shai is so good it's unfair"
+    expected: pos
+    expected_player: "Shai Gilgeous-Alexander"
+    category: clear_positive
+    source: synthetic
+
+  # --- Clear negative ---
+  - id: neg-01
+    text: "Westbrook is absolute trash"
+    expected: neg
+    expected_player: "Russell Westbrook"
+    category: clear_negative
+    source: synthetic
+
+  - id: neg-02
+    text: "LeBron is washed"
+    expected: neg
+    expected_player: "LeBron James"
+    category: clear_negative
+    source: synthetic
+
+  - id: neg-03
+    text: "Harden choked again in the playoffs"
+    expected: neg
+    expected_player: "James Harden"
+    category: clear_negative
+    source: synthetic
+
+  - id: neg-04
+    text: "Another brick from Westbrick"
+    expected: neg
+    expected_player: "Russell Westbrook"
+    category: clear_negative
+    source: synthetic
+
+  - id: neg-05
+    text: "Ben Simmons is a fraud"
+    expected: neg
+    expected_player: "Ben Simmons"
+    category: clear_negative
+    source: synthetic
+
+  - id: neg-06
+    text: "KD took the easy way out"
+    expected: neg
+    expected_player: "Kevin Durant"
+    category: clear_negative
+    source: synthetic
+
+  # --- Neutral ---
+  - id: neu-01
+    text: "Lakers play tomorrow at 7pm"
+    expected: neu
+    expected_player: null
+    category: neutral
+    source: synthetic
+
+  - id: neu-02
+    text: "Tatum had 25 points last night"
+    expected: neu
+    expected_player: "Jayson Tatum"
+    category: neutral
+    source: synthetic
+
+  - id: neu-03
+    text: "Trade deadline is next week"
+    expected: neu
+    expected_player: null
+    category: neutral
+    source: synthetic
+
+  # --- Slang that inverts meaning ---
+  - id: slang-01
+    text: "Ant is fucking sick bro"
+    expected: pos
+    expected_player: "Anthony Edwards"
+    category: slang_inversion
+    source: synthetic
+
+  - id: slang-02
+    text: "Giannis is a freak of nature"
+    expected: pos
+    expected_player: "Giannis Antetokounmpo"
+    category: slang_inversion
+    source: synthetic
+
+  - id: slang-03
+    text: "Luka cooked the entire defense"
+    expected: pos
+    expected_player: "Luka Doncic"
+    category: slang_inversion
+    source: synthetic
+    note: "active 'cooked' = dominated (positive); contrast pair with slang-04"
+
+  - id: slang-04
+    text: "Dame got cooked on defense"
+    expected: neg
+    expected_player: "Damian Lillard"
+    category: slang_inversion
+    source: synthetic
+    note: "'got cooked' = exposed (negative); contrast pair with slang-03"
+
+  # --- Sarcasm ---
+  - id: sarcasm-01
+    text: "Wow Simmons shot a three, league fucked"
+    expected: neg
+    expected_player: "Ben Simmons"
+    category: sarcasm
+    source: synthetic
+    known_miss: true
+    note: "layered sarcasm — the known accuracy ceiling (§4.2); baseline: pos @ 0.85, stable"
+
+  - id: sarcasm-02
+    text: "Great defense from Trae Young as usual"
+    expected: neg
+    expected_player: "Trae Young"
+    category: sarcasm
+    source: synthetic
+    known_miss: true
+    note: "unstable at temp 0 — baseline flipped pass/neu@0.5 across runs; xfail(strict=False) tolerates both"
+
+  # --- Negative nicknames ---
+  - id: nickname-01
+    text: "LeMickey needs more help"
+    expected: neg
+    expected_player: "LeBron James"
+    category: negative_nickname
+    source: synthetic
+
+  - id: nickname-02
+    text: "Westbrick back at it"
+    expected: neg
+    expected_player: "Russell Westbrook"
+    category: negative_nickname
+    source: synthetic
+
+  - id: nickname-03
+    text: "ADisney only shows up in the bubble"
+    expected: neg
+    expected_player: "Anthony Davis"
+    category: negative_nickname
+    source: synthetic
+    known_miss_player: true
+    note: "baseline: model attributes 'AD' — initialism, not caught by substring player_match; sentiment itself correct"

--- a/tests/eval/cases.yaml
+++ b/tests/eval/cases.yaml
@@ -206,5 +206,4 @@ cases:
     expected_player: "Anthony Davis"
     category: negative_nickname
     source: synthetic
-    known_miss_player: true
-    note: "baseline: model attributes 'AD' — initialism, not caught by substring player_match; sentiment itself correct"
+    note: "baseline: model attributes 'AD' — raw initialism output; resolves to Anthony Davis via the alias map (item-4 data point)"

--- a/tests/eval/conftest.py
+++ b/tests/eval/conftest.py
@@ -1,0 +1,22 @@
+"""Fixtures for the live classifier eval suite."""
+
+import os
+
+import pytest
+from dotenv import load_dotenv
+
+from pipeline.evaluation import classify_cases, load_cases
+
+
+@pytest.fixture(scope="session")
+def eval_results() -> dict[str, dict]:
+    """
+    Classify all cases once per session (~23 live API calls).
+
+    Skips (rather than fails) when ANTHROPIC_API_KEY is unavailable, so
+    the eval suite degrades cleanly on machines without credentials.
+    """
+    load_dotenv()
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        pytest.skip("ANTHROPIC_API_KEY not set; eval suite requires live API access")
+    return classify_cases(load_cases())

--- a/tests/eval/test_classifier_eval.py
+++ b/tests/eval/test_classifier_eval.py
@@ -17,15 +17,17 @@ import pytest
 from pipeline.evaluation import (
     EvalCase,
     accuracy_by_category,
+    attribution_match,
     load_cases,
     load_category_floors,
-    player_match,
 )
+from utils.player_config import build_alias_to_player_map
 
 pytestmark = pytest.mark.eval
 
 CASES = load_cases()
 FLOORS = load_category_floors()
+ALIAS_MAP = build_alias_to_player_map()
 
 
 def _case_params(known_miss_attr: str) -> list:
@@ -61,11 +63,12 @@ class TestSentimentPerCase:
 class TestPlayerAttributionPerCase:
     @pytest.mark.parametrize("case", _case_params("known_miss_player"))
     def test_player(self, case: EvalCase, eval_results: dict[str, dict]):
-        """The model's p field matches the expected player attribution."""
+        """The model's p field, resolved as production does, matches."""
         result = eval_results[case.id]
-        assert player_match(result["p"], case.expected_player), (
+        assert attribution_match(result["p"], case.expected_player, ALIAS_MAP), (
             f"{case.id}: expected player {case.expected_player!r}, "
-            f"got {result['p']!r} for text {case.text!r}"
+            f"got {result['p']!r} (unresolved or wrong after alias-map "
+            f"resolution) for text {case.text!r}"
         )
 
 

--- a/tests/eval/test_classifier_eval.py
+++ b/tests/eval/test_classifier_eval.py
@@ -1,0 +1,83 @@
+"""Live accuracy eval of the production sentiment classifier.
+
+Deselected by default (see addopts in pyproject.toml). Run with:
+
+    uv run pytest -m eval --maxfail=0 -rxX -v
+
+--maxfail=0 overrides the -x in addopts so one miss doesn't hide the
+rest of the accuracy picture; -rxX reports xfails and xpasses (a prompt
+improvement shows up as XPASS on a known_miss case).
+
+Do NOT run with pytest-xdist (-n): the session-scoped eval_results
+fixture runs once per worker, multiplying API spend for zero benefit.
+"""
+
+import pytest
+
+from pipeline.evaluation import (
+    EvalCase,
+    accuracy_by_category,
+    load_cases,
+    load_category_floors,
+    player_match,
+)
+
+pytestmark = pytest.mark.eval
+
+CASES = load_cases()
+FLOORS = load_category_floors()
+
+
+def _case_params(known_miss_attr: str) -> list:
+    """Build per-case params, applying xfail marks from known-miss flags."""
+    return [
+        pytest.param(
+            case,
+            id=case.id,
+            marks=[
+                pytest.mark.xfail(
+                    strict=False, reason=case.note or "known miss at baseline"
+                )
+            ]
+            if getattr(case, known_miss_attr)
+            else [],
+        )
+        for case in CASES
+    ]
+
+
+class TestSentimentPerCase:
+    @pytest.mark.parametrize("case", _case_params("known_miss"))
+    def test_sentiment(self, case: EvalCase, eval_results: dict[str, dict]):
+        """The production prompt classifies this case's sentiment correctly."""
+        result = eval_results[case.id]
+        assert result["s"] == case.expected, (
+            f"{case.id}: expected {case.expected!r}, got {result['s']!r} "
+            f"(confidence {result['c']}) for text {case.text!r}"
+            + (f" — note: {case.note}" if case.note else "")
+        )
+
+
+class TestPlayerAttributionPerCase:
+    @pytest.mark.parametrize("case", _case_params("known_miss_player"))
+    def test_player(self, case: EvalCase, eval_results: dict[str, dict]):
+        """The model's p field matches the expected player attribution."""
+        result = eval_results[case.id]
+        assert player_match(result["p"], case.expected_player), (
+            f"{case.id}: expected player {case.expected_player!r}, "
+            f"got {result['p']!r} for text {case.text!r}"
+        )
+
+
+class TestCategoryFloors:
+    @pytest.mark.parametrize("category,floor", sorted(FLOORS.items()))
+    def test_category_accuracy_floor(
+        self, category: str, floor: float, eval_results: dict[str, dict]
+    ):
+        """Sentiment accuracy for the category stays at or above its floor."""
+        correct, total = accuracy_by_category(CASES, eval_results)[category]
+        accuracy = correct / total
+        assert accuracy >= floor, (
+            f"{category}: accuracy {correct}/{total} ({accuracy:.2f}) "
+            f"below floor {floor:.2f}"
+        )

--- a/tests/unit/test_evaluation.py
+++ b/tests/unit/test_evaluation.py
@@ -1,0 +1,333 @@
+"""Unit tests for pipeline/evaluation.py — all offline, no API calls."""
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+import yaml
+
+from pipeline.batch import MAX_TOKENS, MODEL, TEMPERATURE
+from pipeline.evaluation import (
+    accuracy_by_category,
+    classify_cases,
+    load_cases,
+    load_category_floors,
+    normalize_player,
+    player_match,
+)
+
+EXPECTED_CATEGORIES = {
+    "clear_positive",
+    "clear_negative",
+    "neutral",
+    "slang_inversion",
+    "sarcasm",
+    "negative_nickname",
+}
+
+
+def make_case(**overrides) -> dict:
+    """Build a valid case dict, with optional field overrides."""
+    case = {
+        "id": "pos-01",
+        "text": "LeBron is the GOAT",
+        "expected": "pos",
+        "expected_player": "LeBron James",
+        "category": "clear_positive",
+        "source": "synthetic",
+    }
+    case.update(overrides)
+    return case
+
+
+def write_cases_file(
+    tmp_path: Path,
+    cases: list[dict],
+    floors: dict[str, float] | None = None,
+) -> Path:
+    """Write a cases YAML file into tmp_path and return its path."""
+    if floors is None:
+        floors = {"clear_positive": 0.0}
+    payload = {"meta": {"category_floors": floors}, "cases": cases}
+    path = tmp_path / "cases.yaml"
+    path.write_text(yaml.safe_dump(payload))
+    return path
+
+
+class TestLoadCases:
+    def test_loads_valid_file(self, tmp_path):
+        """Valid file yields EvalCase objects with fields mapped."""
+        path = write_cases_file(
+            tmp_path,
+            [make_case(), make_case(id="pos-02", text="Jokic is a genius")],
+        )
+
+        cases = load_cases(path)
+
+        assert len(cases) == 2
+        assert cases[0].id == "pos-01"
+        assert cases[0].expected == "pos"
+        assert cases[0].expected_player == "LeBron James"
+        assert cases[1].text == "Jokic is a genius"
+
+    def test_applies_optional_defaults(self, tmp_path):
+        """Optional fields default to None/False when omitted."""
+        path = write_cases_file(tmp_path, [make_case()])
+
+        case = load_cases(path)[0]
+
+        assert case.comment_id is None
+        assert case.note is None
+        assert case.known_miss is False
+        assert case.known_miss_player is False
+
+    def test_preserves_optional_fields(self, tmp_path):
+        """Optional fields are carried through when present."""
+        path = write_cases_file(
+            tmp_path,
+            [
+                make_case(
+                    source="mined-v1",
+                    comment_id="abc123",
+                    note="baseline miss",
+                    known_miss=True,
+                    known_miss_player=True,
+                )
+            ],
+        )
+
+        case = load_cases(path)[0]
+
+        assert case.source == "mined-v1"
+        assert case.comment_id == "abc123"
+        assert case.note == "baseline miss"
+        assert case.known_miss is True
+        assert case.known_miss_player is True
+
+    def test_rejects_duplicate_ids(self, tmp_path):
+        """Duplicate case ids raise ValueError naming the id."""
+        path = write_cases_file(tmp_path, [make_case(), make_case()])
+
+        with pytest.raises(ValueError, match="pos-01"):
+            load_cases(path)
+
+    def test_rejects_invalid_sentiment(self, tmp_path):
+        """An expected value outside pos|neg|neu raises ValueError."""
+        path = write_cases_file(tmp_path, [make_case(expected="positive")])
+
+        with pytest.raises(ValueError, match="pos-01"):
+            load_cases(path)
+
+    def test_rejects_invalid_source(self, tmp_path):
+        """A source outside the known set raises ValueError."""
+        path = write_cases_file(tmp_path, [make_case(source="handwritten")])
+
+        with pytest.raises(ValueError, match="pos-01"):
+            load_cases(path)
+
+    def test_rejects_missing_required_key(self, tmp_path):
+        """A case missing a required key raises ValueError naming the id."""
+        case = make_case()
+        del case["category"]
+        path = write_cases_file(tmp_path, [case])
+
+        with pytest.raises(ValueError, match="pos-01"):
+            load_cases(path)
+
+    def test_rejects_category_without_floor(self, tmp_path):
+        """A case category absent from meta.category_floors raises ValueError."""
+        path = write_cases_file(
+            tmp_path,
+            [make_case(id="sarcasm-01", category="sarcasm")],
+            floors={"clear_positive": 0.0},
+        )
+
+        with pytest.raises(ValueError, match="sarcasm-01"):
+            load_cases(path)
+
+
+class TestLoadCategoryFloors:
+    def test_loads_floors(self, tmp_path):
+        """Floors are returned as a category → fraction mapping."""
+        path = write_cases_file(tmp_path, [make_case()], floors={"clear_positive": 0.8})
+
+        floors = load_category_floors(path)
+
+        assert floors == {"clear_positive": 0.8}
+
+    def test_rejects_floor_out_of_range(self, tmp_path):
+        """A floor outside [0, 1] raises ValueError naming the category."""
+        path = write_cases_file(tmp_path, [make_case()], floors={"clear_positive": 1.5})
+
+        with pytest.raises(ValueError, match="clear_positive"):
+            load_category_floors(path)
+
+    def test_rejects_floor_without_cases(self, tmp_path):
+        """A floor category with zero cases raises ValueError."""
+        path = write_cases_file(
+            tmp_path,
+            [make_case()],
+            floors={"clear_positive": 0.0, "sarcasm": 0.5},
+        )
+
+        with pytest.raises(ValueError, match="sarcasm"):
+            load_category_floors(path)
+
+
+class TestNormalizePlayer:
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            (None, None),
+            ("", None),
+            ("   ", None),
+            ("LeBron James", "lebron james"),
+            ("  LeBron James  ", "lebron james"),
+        ],
+    )
+    def test_normalizes(self, name: str | None, expected: str | None):
+        """Names lowercase and strip; None/empty/whitespace collapse to None."""
+        assert normalize_player(name) == expected
+
+
+class TestPlayerMatch:
+    @pytest.mark.parametrize(
+        "predicted,expected,matches",
+        [
+            (None, None, True),
+            ("LeBron James", None, False),
+            (None, "LeBron James", False),
+            ("LeBron James", "LeBron James", True),
+            ("LeBron", "LeBron James", True),
+            ("lebron james", "LeBron", True),
+            ("Stephen Curry", "LeBron James", False),
+            ("", None, True),
+        ],
+    )
+    def test_matches(self, predicted: str | None, expected: str | None, matches: bool):
+        """Bidirectional substring match after normalization."""
+        assert player_match(predicted, expected) is matches
+
+
+class TestClassifyCases:
+    def make_client(self, response_text: str) -> Mock:
+        """Build a mock Anthropic client returning fixed response text."""
+        client = Mock()
+        client.messages.create.return_value = Mock(content=[Mock(text=response_text)])
+        return client
+
+    def load_two_cases(self, tmp_path) -> list:
+        """Two valid cases for keyed-results assertions."""
+        path = write_cases_file(
+            tmp_path,
+            [make_case(), make_case(id="pos-02", text="Jokic is a genius")],
+        )
+        return load_cases(path)
+
+    def test_returns_results_keyed_by_case_id(self, tmp_path):
+        """Each case id maps to its parsed classification."""
+        cases = self.load_two_cases(tmp_path)
+        client = self.make_client('{"s": "pos", "c": 0.9, "p": "LeBron James"}')
+
+        results = classify_cases(cases, client=client)
+
+        assert set(results) == {"pos-01", "pos-02"}
+        assert results["pos-01"] == {"s": "pos", "c": 0.9, "p": "LeBron James"}
+
+    def test_uses_production_model_params(self, tmp_path):
+        """Requests go out with production MODEL/TEMPERATURE/MAX_TOKENS."""
+        cases = self.load_two_cases(tmp_path)[:1]
+        client = self.make_client('{"s": "pos", "c": 0.9, "p": null}')
+
+        classify_cases(cases, client=client)
+
+        kwargs = client.messages.create.call_args.kwargs
+        assert kwargs["model"] == MODEL
+        assert kwargs["temperature"] == TEMPERATURE
+        assert kwargs["max_tokens"] == MAX_TOKENS
+
+    def test_uses_prompt_builder(self, tmp_path):
+        """The prompt_builder callable shapes the user message."""
+        cases = self.load_two_cases(tmp_path)[:1]
+        client = self.make_client('{"s": "pos", "c": 0.9, "p": null}')
+
+        classify_cases(
+            cases, prompt_builder=lambda body: f"VARIANT: {body}", client=client
+        )
+
+        kwargs = client.messages.create.call_args.kwargs
+        assert kwargs["messages"] == [
+            {"role": "user", "content": "VARIANT: LeBron is the GOAT"}
+        ]
+
+    def test_malformed_response_yields_error_dict(self, tmp_path):
+        """Unparseable model output surfaces as the parse_response error dict."""
+        cases = self.load_two_cases(tmp_path)[:1]
+        client = self.make_client("not json at all")
+
+        results = classify_cases(cases, client=client)
+
+        assert results["pos-01"]["s"] == "error"
+
+
+class TestAccuracyByCategory:
+    def test_counts_correct_per_category(self, tmp_path):
+        """Correct/total tallies are grouped by case category."""
+        path = write_cases_file(
+            tmp_path,
+            [
+                make_case(),
+                make_case(id="pos-02", text="Jokic is a genius"),
+                make_case(
+                    id="sarcasm-01",
+                    text="Wow Simmons shot a three",
+                    expected="neg",
+                    category="sarcasm",
+                ),
+            ],
+            floors={"clear_positive": 0.0, "sarcasm": 0.0},
+        )
+        cases = load_cases(path)
+        results = {
+            "pos-01": {"s": "pos", "c": 0.9, "p": None},
+            "pos-02": {"s": "neg", "c": 0.8, "p": None},
+            "sarcasm-01": {"s": "neg", "c": 0.7, "p": None},
+        }
+
+        accuracy = accuracy_by_category(cases, results)
+
+        assert accuracy == {"clear_positive": (1, 2), "sarcasm": (1, 1)}
+
+    def test_error_results_count_incorrect(self, tmp_path):
+        """Parse-error results count against accuracy, not as skips."""
+        path = write_cases_file(tmp_path, [make_case()])
+        cases = load_cases(path)
+        results = {"pos-01": {"s": "error", "c": 0.0, "p": None, "raw": "?"}}
+
+        accuracy = accuracy_by_category(cases, results)
+
+        assert accuracy == {"clear_positive": (0, 1)}
+
+    def test_includes_known_miss_cases(self, tmp_path):
+        """known_miss cases stay in the totals — floors price them in."""
+        path = write_cases_file(tmp_path, [make_case(known_miss=True)])
+        cases = load_cases(path)
+        results = {"pos-01": {"s": "neg", "c": 0.9, "p": None}}
+
+        accuracy = accuracy_by_category(cases, results)
+
+        assert accuracy == {"clear_positive": (0, 1)}
+
+
+class TestRealCasesFile:
+    def test_cases_file_loads_with_23_cases(self):
+        """The committed cases.yaml parses cleanly at its baseline size."""
+        cases = load_cases()
+
+        assert len(cases) == 23
+
+    def test_floors_cover_expected_categories(self):
+        """Floors exist for exactly the six baseline categories."""
+        floors = load_category_floors()
+
+        assert set(floors) == EXPECTED_CATEGORIES

--- a/tests/unit/test_evaluation.py
+++ b/tests/unit/test_evaluation.py
@@ -9,6 +9,7 @@ import yaml
 from pipeline.batch import MAX_TOKENS, MODEL, TEMPERATURE
 from pipeline.evaluation import (
     accuracy_by_category,
+    attribution_match,
     classify_cases,
     load_cases,
     load_category_floors,
@@ -207,6 +208,32 @@ class TestPlayerMatch:
     def test_matches(self, predicted: str | None, expected: str | None, matches: bool):
         """Bidirectional substring match after normalization."""
         assert player_match(predicted, expected) is matches
+
+
+class TestAttributionMatch:
+    ALIAS_MAP = {
+        "ad": "Anthony Davis",
+        "anthony davis": "Anthony Davis",
+        "lebron": "LeBron James",
+        "lebron james": "LeBron James",
+    }
+
+    @pytest.mark.parametrize(
+        "predicted,expected,matches",
+        [
+            ("AD", "Anthony Davis", True),
+            ("Anthony Davis", "Anthony Davis", True),
+            ("LeBron", "Anthony Davis", False),
+            (None, None, True),
+            (None, "Anthony Davis", False),
+            ("AD", None, False),
+            ("the refs", None, True),
+            ("the refs", "Anthony Davis", False),
+        ],
+    )
+    def test_matches(self, predicted: str | None, expected: str | None, matches: bool):
+        """Predicted resolves through the alias map as production does."""
+        assert attribution_match(predicted, expected, self.ALIAS_MAP) is matches
 
 
 class TestClassifyCases:


### PR DESCRIPTION
## Summary

PR one of #62: ports the 23-case `VALIDATION_SET` from `notebooks/2024-25/04_cost_analysis.ipynb` to an opt-in pytest suite that measures the **production** prompt/parse path (`pipeline/batch.py`'s `build_prompt` + `parse_response`, production MODEL/TEMPERATURE/MAX_TOKENS). This is the instrument the rest of #62 (slang audit, sarcasm-line experiment, `p`-field evaluation) measures against.

- `pipeline/evaluation.py` — reusable harness: validated YAML case loader, `classify_cases` (synchronous Messages API — same inference as batch, seconds not hours) with a `prompt_builder` hook for prompt-variant experiments, per-category accuracy tallies. Attribution scoring goes through `attribution_match` (production `resolve_sentiment_player` + alias map — what the pipeline actually does with `p`); `player_match` (raw substring, ported from the notebook) is kept for the item-4 raw-output analysis. 41 offline unit tests.
- `tests/eval/cases.yaml` — 23 cases, schema ready for mined cases (`source`, `comment_id`); per-category accuracy floors in `meta` so future case PRs retune floors in the same diff.
- Opt-in: `eval` marker deselected via addopts; `uv run pytest` stays offline and free; suite skips cleanly without `ANTHROPIC_API_KEY`. Run: `uv run pytest -m eval --maxfail=0 -rxX`.
- One API session per run (session-scoped fixture); ~23 Haiku calls, fractions of a cent.

## Baseline record (2026-07-09, claude-haiku-4-5-20251001 @ temp 0, 3 runs)

| Category | Sentiment accuracy | Floor |
|---|---|---|
| clear_positive | 5/5 | 0.8 |
| clear_negative | 6/6 | 0.83 |
| neutral | 3/3 | 1.0 |
| slang_inversion | 4/4 | 1.0 |
| sarcasm | 0–1/2 (see below) | 0.0 |
| negative_nickname | 3/3 | 1.0 |

Known misses, marked `xfail(strict=False)` so prompt fixes surface as XPASS:
- `sarcasm-01` ("Wow Simmons shot a three, league fucked") → `pos` @ 0.85, **stable** — the §4.2 accuracy ceiling, now a permanent regression sentinel for the sarcasm-line experiment.
- `sarcasm-02` ("Great defense from Trae Young as usual") → **unstable at temp 0**: passed run 1, `neu` @ 0.5 runs 2–3.

Player attribution: **23/23** when scored as production consumes `p` (alias-map resolution). Raw model output is 22/23 — `nickname-03` ("ADisney…") returns `"AD"`, which the alias map resolves to Anthony Davis; recorded as an item-4 data point in the case note. Floors deliberately gate sentiment only.

## Verification

- `uv run pytest` — 379 passed, 52 eval tests deselected (offline, no key needed)
- `uv run pytest -m eval` without key — 52 skipped, exit 0
- `uv run pytest -m eval --maxfail=0 -rxX` — 50 passed, 2 xfailed
- `uv run ruff check .` — clean

## Out of scope (later PRs on #62)

Corpus-mined case expansion (short/multi-player//s-sarcasm/genuine-praise), slang audit, sarcasm prompt experiment, `p`-field decision.

Closes nothing — #62 stays open until the prompt is frozen.