### PR TITLE
docs(data): add filtered baseline notebook (pre-batch decision doc)

### DIFF
--- a/notebooks/2025-26/04_filtered_baseline.ipynb
+++ b/notebooks/2025-26/04_filtered_baseline.ipynb
@@ -1,0 +1,748 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7c4fdf14",
+   "metadata": {},
+   "source": [
+    "# 2025-26 Filtered Baseline — The Classify Population and Its Price\n",
+    "\n",
+    "**Objective:** The quotable numbers for the pre-batch decision (\"submitting N comments,\n",
+    "expect $X\") and, later, the launch methodology. Runs on the final population\n",
+    "(config v4.1 re-filter, verified by 03); with #29/#63 merged, this is the last document\n",
+    "before batch submission. Parallels 02 (corpus baseline) one stage downstream.\n",
+    "Deliverable: this notebook + small derived parquets under\n",
+    "`data/2025-26/reference/coverage/`.\n",
+    "\n",
+    "**This notebook answers:**\n",
+    "\n",
+    "- §1 — What is the final classify population, and how does the match rate compare to\n",
+    "  the floor, the corpus, and v1's filter stage?\n",
+    "- §2 — How many players does a typical kept comment mention?\n",
+    "- §3 — How is player volume distributed: who qualifies, how concentrated is discourse?\n",
+    "- §4 — What share of the classify population carries a resolvable `fan_team` flair?\n",
+    "- §5 — What will classification cost? (v1-02 §1.4's deferred estimate, finally on the\n",
+    "  actual population)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75d25d07",
+   "metadata": {},
+   "source": "## Load Data\n\nReuse-first: §1–§3 read the artifacts 03 already persisted from this exact file\n(`mentions_census`, `mentions_per_comment`, `player_mention_counts`) plus 02's corpus\ncensus for denominators — zero new scans. Only two passes over the 975 MB mentions file\nare new: §4 (flair) and §5 (body length). One extra count-only scan of the v1 filtered\nfile gives the YoY filter-stage comparison.\n\nGuardrails:\n\n- **`body` never materializes.** §5 computes `strlen(body)` inside the scan and groups\n  by it — no body value ever leaves the reader, not even into a temp table.\n- Every scan cell is guarded on artifact existence with a staleness warning against the\n  mentions file; the reused 03 artifacts get the same check, so a future re-filter\n  flags every consumer here too.\n- Cost constants come from `pipeline/batch.py` (production), not hand-rolled numbers —\n  verified against current Anthropic Batch pricing (Haiku 4.5 $1/$5 standard, 50%\n  batch discount) on 2026-07-07."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f8cbf013",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T19:06:46.000869Z",
+     "iopub.status.busy": "2026-07-09T19:06:46.000664Z",
+     "iopub.status.idle": "2026-07-09T19:06:47.025263Z",
+     "shell.execute_reply": "2026-07-09T19:06:47.024956Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Classify population: 2,154,982 comments (config v4.1 re-filter)\n",
+      "Corpus total (02):   7,283,478\n",
+      "Model / batch price: claude-haiku-4-5-20251001  ($0.5/MTok in, $2.5/MTok out)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Bootstrap: run from anywhere (see 01/02/03 — walk up to the repo root, chdir).\n",
+    "_root = Path.cwd()\n",
+    "while not (_root / \"pyproject.toml\").exists() and _root != _root.parent:\n",
+    "    _root = _root.parent\n",
+    "os.chdir(_root)\n",
+    "if str(_root) not in sys.path:\n",
+    "    sys.path.insert(0, str(_root))\n",
+    "\n",
+    "import duckdb\n",
+    "import matplotlib.pyplot as plt\n",
+    "import polars as pl\n",
+    "\n",
+    "from pipeline.aggregation import extract_team_from_flair\n",
+    "from pipeline.batch import (\n",
+    "    INPUT_COST_PER_MTOK,\n",
+    "    MODEL,\n",
+    "    OUTPUT_COST_PER_MTOK,\n",
+    "    build_prompt,\n",
+    "    calculate_cost,\n",
+    ")\n",
+    "from utils.paths import get_data_dir\n",
+    "from utils.player_config import load_player_config\n",
+    "from utils.season_config import get_active_season\n",
+    "from utils.team_config import build_alias_to_team_map\n",
+    "\n",
+    "SEASON = \"2025-26\"  # pinned: this notebook is season-scoped (notebooks/2025-26/)\n",
+    "assert get_active_season() == SEASON, \"active season flipped — review before re-running\"\n",
+    "\n",
+    "MENTIONS_RAW = get_data_dir(season=SEASON) / \"filtered\" / \"r_nba_player_mentions.jsonl\"\n",
+    "V1_MENTIONS_RAW = get_data_dir(season=\"2024-25\") / \"filtered\" / \"r_nba_player_mentions.jsonl\"\n",
+    "CORPUS_DIR = get_data_dir(season=SEASON) / \"reference\" / \"corpus\"\n",
+    "COVERAGE_DIR = get_data_dir(season=SEASON) / \"reference\" / \"coverage\"\n",
+    "assert MENTIONS_RAW.exists(), f\"missing mentions file: {MENTIONS_RAW}\"\n",
+    "\n",
+    "\n",
+    "def warn_if_stale(pq: Path, raw: Path) -> None:\n",
+    "    \"\"\"Companion to the existence-only reuse guards: flag a persisted\n",
+    "    artifact older than the file it derives from.\"\"\"\n",
+    "    if pq.exists() and pq.stat().st_mtime < raw.stat().st_mtime:\n",
+    "        print(f\"WARNING: {pq.name} predates {raw.name} — delete it to force a rescan\")\n",
+    "\n",
+    "\n",
+    "# Reused artifacts — 02's corpus census (denominators) and 03's filtered-file\n",
+    "# stats (this file's row grain, already scanned post-re-filter).\n",
+    "CENSUS_02 = CORPUS_DIR / \"comments_census.parquet\"\n",
+    "V1_CENSUS_02 = CORPUS_DIR / \"v1_comments_census.parquet\"\n",
+    "YIELD_03 = COVERAGE_DIR / \"mentions_census.parquet\"\n",
+    "NPLAYERS_03 = COVERAGE_DIR / \"mentions_per_comment.parquet\"\n",
+    "COUNTS_03 = COVERAGE_DIR / \"player_mention_counts.parquet\"\n",
+    "for _pq in (YIELD_03, NPLAYERS_03, COUNTS_03):\n",
+    "    assert _pq.exists(), f\"missing 03 artifact: {_pq} — run 03_filter_coverage first\"\n",
+    "    warn_if_stale(_pq, MENTIONS_RAW)\n",
+    "\n",
+    "corpus = pl.read_parquet(CENSUS_02).row(0, named=True)\n",
+    "v1_corpus = pl.read_parquet(V1_CENSUS_02).row(0, named=True)\n",
+    "myield = pl.read_parquet(YIELD_03).row(0, named=True)\n",
+    "M_TOTAL = myield[\"n_rows\"]\n",
+    "\n",
+    "V1_PLAYER_OVERALL = get_data_dir(season=\"2024-25\") / \"dashboard\" / \"player_overall.parquet\"\n",
+    "V1_ATTRIBUTED = int(\n",
+    "    duckdb.sql(f\"SELECT sum(comment_count) AS n FROM '{V1_PLAYER_OVERALL}'\").pl()[\"n\"][0]\n",
+    ")\n",
+    "\n",
+    "players, short_aliases = load_player_config()\n",
+    "TEAM_MAP = build_alias_to_team_map()\n",
+    "QUALIFIED_BAR = 5_000\n",
+    "\n",
+    "duckdb.sql(\"SET temp_directory = '/tmp/duckdb_baseline_spill'\")\n",
+    "\n",
+    "print(f\"Classify population: {M_TOTAL:,} comments (config v4.1 re-filter)\")\n",
+    "print(f\"Corpus total (02):   {corpus['n_comments']:,}\")\n",
+    "print(f\"Model / batch price: {MODEL}  (${INPUT_COST_PER_MTOK}/MTok in, ${OUTPUT_COST_PER_MTOK}/MTok out)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2f3da95",
+   "metadata": {},
+   "source": [
+    "## 1. Yield & match rate — the population, in context\n",
+    "\n",
+    "Three comparisons give the headline its meaning: the **v1-rate floor** (what the corpus\n",
+    "would yield at v1's measured match rate), the **corpus share** (how much of r/NBA talks\n",
+    "about tracked players at all), and the **v1 filter stage** (the true YoY population\n",
+    "comparison — v1's filtered file, counted once here)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f59e175c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T19:06:47.026636Z",
+     "iopub.status.busy": "2026-07-09T19:06:47.026532Z",
+     "iopub.status.idle": "2026-07-09T19:06:47.408966Z",
+     "shell.execute_reply": "2026-07-09T19:06:47.408559Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "scanned v1 filtered file ONCE; census persisted\n",
+      "=== the quotables ===\n",
+      "classify population:   2,154,982 comments\n",
+      "match rate:            29.6% of the 7,283,478 corpus\n",
+      "vs v1-rate floor:      1,621,657 → +32.9% above (the config broadening, measured)\n",
+      "v1 filter stage:       1,939,290 rows (27.5% of v1 corpus)\n",
+      "YoY population:        +11.1%\n",
+      "note: v1 attributed (1,567,722) is post-classification — the filter-stage comparison above is the like-for-like one\n"
+     ]
+    }
+   ],
+   "source": [
+    "# §1 — the ONE count-only scan of the v1 filtered file (891 MB; id projected).\n",
+    "V1F_PQ = CORPUS_DIR / \"v1_filtered_census.parquet\"\n",
+    "\n",
+    "if not V1F_PQ.exists():\n",
+    "    duckdb.sql(f\"\"\"\n",
+    "        COPY (\n",
+    "            SELECT count(*) AS n_rows, count(DISTINCT id) AS n_distinct_ids\n",
+    "            FROM read_ndjson('{V1_MENTIONS_RAW}',\n",
+    "                format = 'newline_delimited',\n",
+    "                columns = {{id: 'VARCHAR'}})\n",
+    "        ) TO '{V1F_PQ}' (FORMAT parquet)\n",
+    "    \"\"\")\n",
+    "    print(\"scanned v1 filtered file ONCE; census persisted\")\n",
+    "else:\n",
+    "    print(\"reusing persisted v1 filtered census (no rescan)\")\n",
+    "warn_if_stale(V1F_PQ, V1_MENTIONS_RAW)\n",
+    "\n",
+    "v1f = pl.read_parquet(V1F_PQ).row(0, named=True)\n",
+    "\n",
+    "v1_match_rate = V1_ATTRIBUTED / v1_corpus[\"n_comments\"]\n",
+    "floor = v1_match_rate * corpus[\"n_comments\"]\n",
+    "match_rate = M_TOTAL / corpus[\"n_comments\"]\n",
+    "v1_filter_rate = v1f[\"n_rows\"] / v1_corpus[\"n_comments\"]\n",
+    "\n",
+    "print(\"=== the quotables ===\")\n",
+    "print(f\"classify population:   {M_TOTAL:,} comments\")\n",
+    "print(f\"match rate:            {match_rate:.1%} of the {corpus['n_comments']:,} corpus\")\n",
+    "print(f\"vs v1-rate floor:      {floor:,.0f} → {(M_TOTAL / floor - 1):+.1%} above \"\n",
+    "      \"(the config broadening, measured)\")\n",
+    "print(f\"v1 filter stage:       {v1f['n_rows']:,} rows ({v1_filter_rate:.1%} of v1 corpus)\")\n",
+    "print(f\"YoY population:        {(M_TOTAL / v1f['n_rows'] - 1):+.1%}\")\n",
+    "print(f\"note: v1 attributed ({V1_ATTRIBUTED:,}) is post-classification — the filter-stage \"\n",
+    "      \"comparison above is the like-for-like one\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8ffadb6",
+   "metadata": {},
+   "source": [
+    "## 2. Mentions per comment — the shape of a kept comment\n",
+    "\n",
+    "Reused from 03's row-grain pass. Context for what classification does with this: the\n",
+    "classifier returns **one** `sentiment_player` per comment (the model names the player\n",
+    "it reads the comment as being about), so multi-mention comments contribute one\n",
+    "attributed reading, not one per mentioned player — `mentioned_players` is the\n",
+    "population/coverage field, attribution happens at the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "bd40e217",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T19:06:47.410100Z",
+     "iopub.status.busy": "2026-07-09T19:06:47.410038Z",
+     "iopub.status.idle": "2026-07-09T19:06:47.434887Z",
+     "shell.execute_reply": "2026-07-09T19:06:47.434497Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "single-mention: 1,537,415 (71.3%)\n",
+      "multi-mention:  617,567 (28.7%)\n",
+      "mean players/comment: 1.46; max: 107 (list-every-player copypasta tail)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (8, 6)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>n_players</th><th>n_rows</th><th>n_distinct_ids</th><th>min_utc</th><th>max_utc</th><th>share</th></tr><tr><td>i64</td><td>i64</td><td>i64</td><td>i64</td><td>i64</td><td>f64</td></tr></thead><tbody><tr><td>1</td><td>1537415</td><td>1537415</td><td>1759291237</td><td>1782791970</td><td>0.7134</td></tr><tr><td>2</td><td>422731</td><td>422731</td><td>1759291245</td><td>1782791951</td><td>0.1962</td></tr><tr><td>3</td><td>114185</td><td>114185</td><td>1759291397</td><td>1782791643</td><td>0.053</td></tr><tr><td>4</td><td>42810</td><td>42810</td><td>1759291966</td><td>1782791975</td><td>0.0199</td></tr><tr><td>5</td><td>18194</td><td>18194</td><td>1759293194</td><td>1782789940</td><td>0.0084</td></tr><tr><td>6</td><td>8446</td><td>8446</td><td>1759292139</td><td>1782789763</td><td>0.0039</td></tr><tr><td>7</td><td>4339</td><td>4339</td><td>1759330057</td><td>1782782706</td><td>0.002</td></tr><tr><td>8</td><td>2385</td><td>2385</td><td>1759317521</td><td>1782782087</td><td>0.0011</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (8, 6)\n",
+       "┌───────────┬─────────┬────────────────┬────────────┬────────────┬────────┐\n",
+       "│ n_players ┆ n_rows  ┆ n_distinct_ids ┆ min_utc    ┆ max_utc    ┆ share  │\n",
+       "│ ---       ┆ ---     ┆ ---            ┆ ---        ┆ ---        ┆ ---    │\n",
+       "│ i64       ┆ i64     ┆ i64            ┆ i64        ┆ i64        ┆ f64    │\n",
+       "╞═══════════╪═════════╪════════════════╪════════════╪════════════╪════════╡\n",
+       "│ 1         ┆ 1537415 ┆ 1537415        ┆ 1759291237 ┆ 1782791970 ┆ 0.7134 │\n",
+       "│ 2         ┆ 422731  ┆ 422731         ┆ 1759291245 ┆ 1782791951 ┆ 0.1962 │\n",
+       "│ 3         ┆ 114185  ┆ 114185         ┆ 1759291397 ┆ 1782791643 ┆ 0.053  │\n",
+       "│ 4         ┆ 42810   ┆ 42810          ┆ 1759291966 ┆ 1782791975 ┆ 0.0199 │\n",
+       "│ 5         ┆ 18194   ┆ 18194          ┆ 1759293194 ┆ 1782789940 ┆ 0.0084 │\n",
+       "│ 6         ┆ 8446    ┆ 8446           ┆ 1759292139 ┆ 1782789763 ┆ 0.0039 │\n",
+       "│ 7         ┆ 4339    ┆ 4339           ┆ 1759330057 ┆ 1782782706 ┆ 0.002  │\n",
+       "│ 8         ┆ 2385    ┆ 2385           ┆ 1759317521 ┆ 1782782087 ┆ 0.0011 │\n",
+       "└───────────┴─────────┴────────────────┴────────────┴────────────┴────────┘"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# §2 — no scan; 03's artifact.\n",
+    "nplayers = pl.read_parquet(NPLAYERS_03)\n",
+    "\n",
+    "_single = nplayers.filter(pl.col(\"n_players\") == 1)[\"n_rows\"].sum()\n",
+    "_multi = M_TOTAL - _single\n",
+    "_mean = (nplayers[\"n_players\"] * nplayers[\"n_rows\"]).sum() / M_TOTAL\n",
+    "_max = nplayers[\"n_players\"].max()\n",
+    "\n",
+    "print(f\"single-mention: {_single:,} ({_single / M_TOTAL:.1%})\")\n",
+    "print(f\"multi-mention:  {_multi:,} ({_multi / M_TOTAL:.1%})\")\n",
+    "print(f\"mean players/comment: {_mean:.2f}; max: {_max} (list-every-player copypasta tail)\")\n",
+    "display(\n",
+    "    nplayers.sort(\"n_players\")\n",
+    "    .head(8)\n",
+    "    .with_columns((pl.col(\"n_rows\") / M_TOTAL).round(4).alias(\"share\"))\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df4b9e8d",
+   "metadata": {},
+   "source": [
+    "## 3. Player volume distribution — who qualifies, how concentrated\n",
+    "\n",
+    "Reused from 03's exploded pass. The 5,000-comment qualified bar is the published\n",
+    "threshold (`manifest.json`'s future single home). Concentration matters for launch\n",
+    "framing: if the top 10 players hold most of the discourse, \"most hated\" is a\n",
+    "story about a small cast."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "4d852b08",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T19:06:47.436026Z",
+     "iopub.status.busy": "2026-07-09T19:06:47.435969Z",
+     "iopub.status.idle": "2026-07-09T19:06:47.642971Z",
+     "shell.execute_reply": "2026-07-09T19:06:47.642665Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tracked players:  223 (of 223 in config)\n",
+      "qualified (≥5,000): 105\n",
+      "median player:    4,482 mentions\n",
+      "top 10 share:     40.0% of all mentions\n",
+      "top 25 share:     60.7% of all mentions\n",
+      "top 50 share:     77.2% of all mentions\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA90AAAGGCAYAAABmGOKbAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAXw5JREFUeJzt3Qd8VfX9//F39k6AJIQV9lA2smQqLsS6R622CmrtcFatVvqv0vpzDxyV1lar2GpbR+uuWxEElCV775mEsLL3/T8+X7gxgQAJ5Obm5r6ej8d53HvPPffc7/3eEPI+3xXi8Xg8AgAAAAAA9S60/k8JAAAAAAAI3QAAAAAA+BAt3QAAAAAA+AihGwAAAAAAHyF0AwAAAADgI4RuAAAAAAB8hNANAAAAAICPELoBAAAAAPARQjcAAAAAAD5C6AYAHLdp06YpJCTE3cK3Tj31VLcFukD+mfn973/vyp6dna2mYurUqe4zzZs3z99FAYAmh9ANADjqH+LeLTo6Wt27d9dNN92kzMxMas5Hli9f7oLdxo0bqWMAAAJcuL8LAABo/O677z516tRJRUVF+vrrr/XnP/9Z//vf/7R06VLFxsb6u3hNMnT/4Q9/cC3aHTt2rPbcJ5984rdyAQCAuiN0AwCOaty4cRo0aJC7/9Of/lTJycmaPHmy3nnnHV1xxRWNvgbz8/MVFxenpiAyMtLfRYCfeDwed+ErJiaG7wAAAgjdywEAdXbaaae52w0bNhz2mBkzZuiyyy5T+/btFRUVpfT0dN12220qLCysPOall15y3da/++67Q17/4IMPKiwsTNu2bavc9+233+rss89WUlKSa2E/5ZRTNHPmzBrH21pr8ZVXXqnmzZtr5MiRR+1Cby34t9xyi1JTU9WsWTP9/Oc/V0lJifbu3aurr77ance2u+66y4WfqioqKvTUU0+pV69ergt+Wlqae/2ePXuqHWet1ueee657ryFDhrhjO3furL///e/VymP1ZsaMGVPZtd879rmmMd1ZWVm67rrr3PvaOfv166eXX3652jHWVd3O8/jjj+uvf/2runTp4r6XwYMHa+7cuToSG+drrz34nObjjz92z73//vuV++z7tAs1iYmJio+P1+mnn65vvvnmiO/hrZ8JEyYcsv/gz+wdD/7666+7HgFt27ZVQkKCLr30Uu3bt0/FxcX61a9+pZYtW7r3v+aaa9y+g73yyisaOHCgC7EtWrTQj370I23ZskW1ZWO6f/jDH7rPaReibr31VheKvezn076LmvTo0UNjx449an3Yz4vVsV30snL+5S9/qfy3Y/8O7TPa99izZ0/XA+Vw5zjSz9zh2M+vvaZdu3ZatWpVLWoEAFATWroBAHW2bt06d2tB43DeeOMNFRQU6Je//KU7bs6cOfrjH/+orVu3uueMhaQbb7xRr776qgYMGFDt9bbPgpYFKvPFF1+4IGchadKkSQoNDa0MHhbwLRxUZcG1W7duLrwfHJJrcvPNN6tVq1YuxFlAtGBq4XvWrFnuwoGdx7rUP/bYY+rdu7cL4l4WsC0sW7iz4G4XI5599lkXPu2iQEREROWxa9eudZ/bQvL48eP14osvuqBpn8tC++jRo905nnnmGf32t7/ViSee6F7nvT2YXcSwerLz2lh7GwZg9WvntAsGFgSr+uc//6nc3FxXZguujz76qC6++GKtX7++WjmrssBnQc1CrpW5qtdee81djPAGyGXLlmnUqFEuiNoFCjunBUUr41dffaWhQ4eqvjz00EMuiN59993u89vPl72f/WxYYLQLMPZd2ndj9XLvvfdWvvaBBx7QPffc40Kz9d7YuXOne73Vv31v9t0fjb3WQq2Vw97HvjN7X2+gveqqq3T99de7YRj2M+NlFzlWr16t3/3ud0d9Dwu71pvEvi87l4V1YwHbfl7OP/98hYeH67333tMNN9zgLgDZv6mqjvYzd7gLCmeeeaZ2797tvje7SAMAOEYeAAAO46WXXrK06vnss888O3fu9GzZssXz73//25OcnOyJiYnxbN261R335ZdfuuPs1qugoOCQ8z300EOekJAQz6ZNmyr3XXHFFZ42bdp4ysvLK/ctWLDAnc/e31RUVHi6devmGTt2rLtf9T06derkOfPMMyv3TZo0yb3WzluXz3jwuYcNG+bK+otf/KJyX1lZmaddu3aeU045pXLfjBkz3OtfffXVauf96KOPDtnfoUMHt2/69OmV+7KysjxRUVGeO+64o3LfG2+8cUh9etl7V33/p556yh37yiuvVO4rKSlx5Y+Pj/fk5OS4fRs2bHDH2Xe3e/fuymPfeecdt/+99947Yj1NnDjRExERUe21xcXFnmbNmnmuvfbayn0XXnihJzIy0rNu3brKfdu3b/ckJCR4Ro8eXbmvpp8Zq5/x48cf9TN7X9u7d2/3Wb3sO7fvbNy4cdVeb3Vh5/bauHGjJywszPPAAw9UO27JkiWe8PDwQ/YfzPszdv7551fbf8MNN7j9ixYtco/37t3riY6O9vzmN7+pdtwtt9ziiYuL8+Tl5R3xfbw/L/azdLCa/n3Zz3Dnzp1rPMfRfua8/w7mzp3r2bFjh6dXr17uXFZXAIDjQ/dyAMBRnXHGGa7btXURty641mX3rbfeqmyFrknVcac2ptpazoYPH+5anat2J7cW4+3bt+vLL7+s1sptr7/kkkvc44ULF2rNmjWuu/iuXbvcuWyz81rX5enTp7sWvqp+8Ytf1OmbtVZAa/n1shZZK6vt97Lu7tbqa63CXtaqbN3drVXQWy7brBXR6qnq5zLWDdhagr2sXq31suo568Ja362FvurYemvttdbyvLw810pZ1eWXX+5apr28ZTna+9vrSktL9d///rfapG7Wmm7PmfLycrfvwgsvdC3jXq1bt3bfnXVxzsnJUX2xn52qrfPe7+zaa6+tdpztt27jZWVl7rF9Bvt5sZbqqt+Z1aP1jjj4Ozucg1uUrbeE9zsx9nNxwQUX6F//+ldlbwurI+sdYHVUm3kGrIW+pm7oVf99WZd6K791Z7fv0R4f68+c9USx89h3bf+uOnToUIuaAAAcCd3LAQBHNWXKFLdUmHVjtXHD9ge7deE9ks2bN7vuvO++++4hY5urhgILqxbKLGhbgLYwZCHFwoqN0zUWuM3BXZsPPmfVMGlhpS6sC3lVFpiMXWg4eH/Vz2Nls/e2sbU1sfHWR3ofY+U+uI5qa9OmTS4oHvx9eLuj2/NHen9vnR3t/W1s8gknnOACo/dChN1PSUmpHONvXbRtSIG3C/TB5bHv1sLv4bo011VdvjN7b/uebKiDfWcWgq3eanK4bvYHO/j11gXbvoeqS73ZhQGrJxsCYV3XP/vsM7fcnnU9r43D/RzbsAUbZjF79mxX51XZ5/TWRV1/5qxc9u98xYoV7iIEAOD4EboBAEdl46W9s5fXhrXmeceD/uY3v3FhzVr1bFI0G0tatVXaWo+tFfT555/Xn/70JxcmrOX7Jz/5SeUx3uNtPHX//v1rfE9rVa6qrjM8Wzlqu7/qGHErmwVuu2hQE2tVrM371GbceX04nve3Fm0bC22tqnZBxC6oWAu7hbT6ULWnwcE/TzWVuy7fWdXPaN+ZvdeHH35Y47EH/ywdT/mtldouVNmkbRa67dbCrPUeqY2afo5tTgW7QGX/rmwVAbvIYLPaWwv7k08+eUivj7p85za+38akP/30026sOgDg+BG6AQD1bsmSJW6iKJvtuuqEY59++mmNx9sxTzzxhJsMyoKQBdWqXWq9kzjZ5Fy1DSsNxcpmrZcjRoyot6WcDhc+a2LdfxcvXuyCVtXW7pUrV1Y+X18sdNtEc//5z39ckLSu4jbcwMu+N5tVvqaZrq08Vr6DW6EPbn217uoHs9b6qt3V6+M7s8BprcjWg+NYWYt51ZZom7DMvoeqa6t7LyrZZG6PPPKI3n77bTch2uGCcG3YvxObjd0uelRtxa5tt/gjsS7yXbt2db1UrLXcJqkDABwfxnQDAOqdN1BUbUmz+9Z6VpO+ffu67YUXXnCBzoJc1dZTGx9tQcmWu7Jxygezbs3+YuOCrSX2//7v/w55zsYQ1xQij8Y71rc2rz3nnHOUkZHhujBXfV+bidtabG18bn2xLuJ9+vRx72WbDQuw1tuq3/tZZ53l1m+v2sXaulPbrOm2dJtdODkc+45tFnBbqs3LliKryzJetWGtuVZWu4BwcGuvPbZ5A2o77KIqq3Njs+wf3GXbunLbDOT281u1F0d9/fuyLuU2m399sFndf/3rX2vixIk1LkMGAKgbWroBAPXOur1agLI/3K1LuQUtC9NHGjdsrd12vDk4lFgLqQVyCzM2HtiW5rJJ3Ozc1rpn57fWP3+wUGthyrri2oRvFjptTLC1gtoka3ahwZZrqgvrQm/BylpGLUzZOszeNZkP9rOf/cwtyWXd9ufPn+9aWd98803XTd/WDveOi6/P1m5rBbX1nm1s98Fjye+//37Xo8ECti1hZRdPrHzWMmvLkx2JLd1lZbe12O1ihnWjtu7Y9b1clZ3Pymmh0i4O2KRmVk+21JtNEGh16v1ZPBI73pbssvLa2Gorq7VqH7w2ty2HZ0uG2c+DXbg46aSTjqv89jNm3cnPO++8yiBvwzPs52PHjh2qDzaUw372bLI4q5vjvVAAAMGMlm4AQL2z0Gkh2MKjhVFrUbRJp7zrF9fkxz/+sQua1t334DW3ja3zbMHGxpbbGtjWDda67Nr42Ntuu82v3+Jzzz3n1vW2SdNsbW0Lc7auuAUV63ZeV/aZ7Jx2Pgu2Nm56+fLlNR5rXdqnTZvm6s+6899xxx1uLL21eh68Rnd9hW7rQm2Td3lnLa/KLorYpGEWMr3fvXVxt4sjR1uj24YU2DADG5rwq1/9yn3f1tLdrl27ev8c1m3aLgTZRQMro4Vs665tgdaCdG1Ya79dELFzffDBB26d9L/97W81HusdZlHbCdSOxCaqs4sTNgzBym0/K3ahoL6/bzuv9Tqxi1zWewEAcGxCbN2wY3wtAAD1xibnsu7K1opq3VuBpsR6PNjFIWtZr2k2cQBA00VLNwCgUbBWaxsbXR8tgUBjYu0b1gJuQxEI3AAQfBjTDQDwK+uGbV2nbSkqG1tbdeZnIJDl5+e7LuvWtd5m9KeLNgAEJ7qXAwD8ysZqz5o1y419tomobII0oCmwruS2pFizZs3cpHJ2YQkAEHwI3QAAAAAA+AhjugEAAAAA8BFCNwAAAAAAPhL0E6nZWqPbt29XQkKCW+8SAAAAAIDarE6Rm5urNm3aKDT08O3ZQR+6LXCnp6cftUIBAAAAADjYli1b1K5dOx1O0Idua+H2VlRiYuJhKwoAAAAAAK+cnBzXgOvNlIcT9KHb26XcAjehGwAAAABQF0cbpsxEagAAAAAA+AihGwAAAAAAHyF0AwAAAADgI0EbuqdMmaKePXtq8ODB/i4KAAAAAKCJCvHY4mJBPuNcUlKS9u3bx0RqAAAAAIB6zZJB29INAAAAAICvEboBAAAAAPARQjcAAAAAAD5C6AYAAAAAwEcI3QAAAAAA+Ei4r06M+vP4x6v0/uLtapkQrZaJUZW3aQfu221qQrQSo8MVEhJC1QMAAABAI0HoDgAxkWGKjgjTmqxczdm4+7DHRYWHKi0xWi0TLJBHKzUhan84rwzp+59LiokgnAMAAABAA2Cd7gBbp7u4rFw7c4uVZVtO0YHbYmV67x/Yvyu/5LDniAwPdeHbG87d/Sq33hb05rGEcwAAAAA4nixJS3eAiQoPU7vmsW47kpKyCmXnfR/CM3OLtdNuc2zf/oC+eXehvtuyVx5PzeeICAtx4dtazL1BvLIVvUoLeovYSIWG0q0dAAAAAA5G6G6irDW7TbMYtx1JWbmF85L9QdxazA/cVn28fW+hFm/dq4rDhPPw0JD9XdmrtpgfGGtedQx6clyUwgjnAAAAAIIIoTvIhYeFqlVStNuOpLzCo13elvPcAy3mVUL6zgP7lm7PccfWxAJ3SnxktcnfqnZxd7cunEe6cgEAAABAoCN0o1YsMLtW7EQL50mHPa7Cwnn+gZZz77jzai3o+/etzMhRaXnN4dwaw5PjDxpzXqUV3RvOU+KjFEE4BwAAANCIEbpRr0IPdDW3rdcRjrNwvqfAwvn+IG4TwdkEcW5CuAPd263lfE1mnkrKK2o8h62OZq3i1mK+f8x59SXU9ndvj1ZqfJTrbg8AAAAADS1oQ/eUKVPcVl5e7u+iBG04t9Zs205sffjjPB6P9haUVu/WXsO48/Xr8lRcVnM4Ny3iIg8ac17TzO1RbqI6AAAAAKgvLBkWYEuG4fDhPKewrLJbu3cJNe/tzipd3AtLD3+hpVlsRPV1zitb0b+/tXBu66YDAAAACF45LBmGYBISEqKk2Ai3dUtLOGI4zy0uq9ZS/n0L+vdrny/YtEf5JYcP54nR4dXWNK/aYm7BPSYizAXz2Mgwxdh24HFUeKgrKwAAAIDgELTdyxGcLPAmRke4rWvL+CMem+fCedGhY85dON/fcr54yz7lFu+q9fvbJHEWwC2IV4byA4Hc9tljd//A5h4fOMb7upiajrXHEeGKjgxVZBjBHgAAAGgsCN3AYcRHhSs+NV6dU48czgtKvC3n+0N5blGZ68JeWOK9raj+uLRCRSXlKigtU2FJuVsnveDAc0Wlhx+XXvdgH66YyNAaA3vVwO9Cvwvt3z+3P/Dvf321x+5Ygj0AAABQW4Ru4DhZGO2YYlvccdelzepuE8J9H8L3h/Zqj0vLVVBi+6s/3n/sQY8P7LNW+v2Bv36CvS0h930LfahrZbfAbl3rm8dGKilm/6093r9FqrndxkSqWVyEEqLC6WYPAACAoEDoBhrZrO6uRTrSdxO1WbAvKvs+oBdVCfHVHh8I7FUfe4N9tccHnt+7r0QrduQccRb5qqHdgrkL5AcCuo3Hd0Hd9sftvz04uMdFhhHWAQAAEFAI3UAQBntrnbfNFyyI2zJvtg673e6128L9j/dV21+qvYUl2rKnUEu27VNpueeo544Is7B+oNXcJs6rct9CebOqwb3K4+gIxrkDAADAPwjdAOqVdTlvlWRbdK1fY7PKW4v5Hm9IPxDKXVC3wJ6/P7h7n7P9G7Lztbdgr8oqjh7WI8NDv+/efiCkt4iLUt92STq5c7I6JsfSgg4AAACfIHQDaBSzyntb39s2i6lTWLdZ5qu2nFtw31ew/7amlvbVmbkuyFtW/9ec/eexpd8sfHs3QjgAAADqC6EbQECH9YToCLelt6jbuPbs/P3rsX+zfre+Wb9L7yzc7jZDCAcAAEB9CfFYU1EQy8nJUVJSkvbt26fExER/FweAn+zKK9acDfsDuAXxVZm5lc+1SozWyZ1bVLaEd6A7OgAAQNDLqWWWJHQTugEQwgEAAFBHhO56rigAwY2WcAAAAFRF6K4lQjeAY0EIBwAACG45dC+v34oCgCPJrjYmfJdWZ+ZVPtc6KfrAePD948Lbt2CJMgAAgEBH6K7nigKAuiCEAwAANG2E7nquKADwVQjvnhavCcM76aIBbRUTGUZFAwAABABCdz1XFAD4IoR/vTZb7y3crtziMjWLjdAVQ9rr6mEd1DophgoHAABoxIIqdHfs2NF9yNDQUDVv3lxffvllrV9L6Abgb3nFZfrP/K16aeYGbdxVoLDQEJ3Tp7WuGdFRJ7Vv7u/iAQAAoAZBF7qXLl2q+Pj4Or+W0A2gsaio8OjLVVl6aeZG1wJu+qc307UjO2lc71aKCAv1dxEBAABQxywZfthnAAANKjQ0RKefmOa2VRm5mjprg/67YJtu+dd3apUYrauGddCVQ9qreVwk3wwAAECA8HuzyfTp03XeeeepTZs2CgkJ0dtvv33IMVOmTHGt2dHR0Ro6dKjmzJlT7Xl73SmnnKLBgwfr1VdfbcDSA4Bv9GiVoIcu7qvZE0/XnWN7yCOPHvt4lU5+6HNN/O9irc7MpeoBAAACgN9Dd35+vvr16+eCdU1ee+013X777Zo0aZIWLFjgjh07dqyysrIqj/n66681f/58vfvuu3rwwQe1ePHiBvwEAOA7LeIideOYrvr6N6fp6R/11wmtE/WvOVt01pPTddXfvtUXKzNdt3QAAAA0To1qTLe1WL/11lu68MILK/dZy7a1YD/77LPucUVFhdLT03XzzTfr7rvvPuQcd955p3r16qUJEybU6j0Z0w0g0CzYvEcvfr1BHy7NUHmFR51S4jRheEddOrCd4qIYNQQAANAQapsl/d7SfSQlJSWuBfuMM86o3GczlNvj2bNnV7aU5+bu72aZl5enL774woXuwykuLnaVU3UDgEBiM5o/e+VJmnHXGP3y1C7anV+iSe8uc13PH/hgubbsLvB3EQEAABAIoTs7O1vl5eVKS0urtt8eZ2RkuPuZmZkaOXKk63Z+8skn6+qrr3Yt44fz0EMPuasR3s1azQEgELVpFqPfnH2Cvpl4uh68qI/SEqP1/IwNOuWxL/WLf8x364A3os5MAAAAQSng+yF27txZixYtqvXxEydOdGPEvaylm+ANIJDFRIbpyqHtdcWQdLfUmHU9/2hZhtt6tUnUtSM66dx+rRUVHubvogIAAASdRh26U1JSFBYW5lqzq7LHrVq1OqZzRkVFuQ0AmhqbF2NUt1S3rduZp5dnbdQb87bqjjcW6aEPV+onJ7fXj4d2UGoCvwMBAAAaSqMO3ZGRkRo4cKA+//zzysnVbCI1e3zTTTf5u3gA0Gh1SY3XfRf01h1n9tBr8zbr5Vmb9NRna/SnL9dpQPtmSoyJUEJ0uBKjIxQfFe7uJ0Tv3xfv9u9/7H0uLjLcrSMOAACAAAvdNvnZ2rVrKx9v2LBBCxcuVIsWLdS+fXvXFXz8+PEaNGiQhgwZoqeeespNnnbNNdcc1/vaEmW22ZhxAGiqkmIj9LPRXVwX80+XZ2rqrI1amZGr3KJS1WWlsZAQKT7y+3BuwbzyfpQ3pO9/PLBDc9et3VreAQAAgp3flwybNm2axowZc8h+C9pTp0519225sMcee8xNnta/f38988wzbimx+sCSYQCCkf3qLywtV25RmQvgOUVlynP39z/OKy5z+9x97/7iUndrj73PFZdV1Hh+W8bs3L6tdW7fNurRKqHBPx8AAICv1TZL+j10+xuhGwCOXUlZhQvoFsAtkO/KL9EXKzL1wZIMZecVu2O6tYzXDw4E8K4t46luAADQJBC667miAAC1V17h0bcbdumDxTv04dIMt5a4OaFVQmULeMeUOKoUAAAELEJ3HcZ0r169mtANAD5SVl6h2et36f1FO9wyZvsKS93+3m0TXfj+QZ/WSm8RS/0DAICAQuiu54oCABy/0vIKt5a4BfBPlme4LummX3oznde3tc7p01ptmsVQ1QAAoNEjdNdzRQEA6ldxWblmrM7W+4u3u5nV80v2ryZhs5+feyCApyVGU+0AAKBRInTXc0UBAHynqLRc01btdAH88xVZbmZ1W3FsSMcWGt09VbGRYQoLDVFoSIi7dduB+6FV7u/f5I4LDw1VaKgqn4sKD1Pb5jFqHhvBcmYAAOC4EbrruaIAAA2joKRMX6zMcpOw2e3hliU7VnGRYW4MebvmsUpvEaP05rFq38Lu738cGxler+8HAACaJkL3UTCRGgA0frYc2aqMXDcbum0VHo/K7PbAY3ffU+W5co/KPQeeP7DfuxWWlGvb3kJt2VOgLbsLtX1voXv9wZLjItXOAnjzmO/DePNYdUi2oB5DKzkAAHAI3bVESzcABO+s6hk5Rdq8u0Bbd3vDeIG27Cl0+3bm7l9nvKq2zWJ0Vq80ndWzlQZ3bK5w68sOAACCUk4te02HeDyeQy/zBxFCNwDgcOPMtx5oFbdAvjYrz403t9Zy0yw2Qqed0NIF8NHdU+iWDgBAkMkhdNdvRQEAYNepV+zIdcudfbIsU8t35LhKiQoP1ahuqTqrZ5pOP7GlkuOjqCwAAJq4HEJ3/VYUAAAHs+7on63IdAF8zsbdbux4aIg0qEML1w39zJ5p6pAcR8UBANAEEbrruaIAADiSvQUlbrZ1C+Bfrd7plj0zPdISdEbPljqle0sNaN9MEYwDBwCgSSB0HwWzlwMAfDkefObabBfArSV8V36J258QFa5hXZI1qnuqTumWqvbJsXwJAAAEKEJ3PVcUAADHwrqcL9q6VzNWZ2v6mp36bvMeeVcq65gc68aCj+6e6sJ4fBRrhAMAECgI3fVcUQAA1Id9haWatdYCeLamr95ZORt6eGiITurQXKd0T9Xobqnq1SZRoTZAHAAANEqE7nquKAAAfDEb+vrsfM1YvdOF8NnrdlWOBW8eG6E2zWJc67fboqvcRn7/OCE6XHEHjmnbPEYtE6L5ogAAaACE7nquKAAAfK24rFzzN+7ZH8DX79Lu/GLlFZUpr7hMpeUH+qQfReukaPVtl6R+6c3Ur10z9WmXpMToCJ+XHQCAYJPDkmH1W1EAAPg7kHsDeG5RmfKL99/3PrbbDTvz3fjx1Zm5lePGTefUOBfAvWG8Z+tERUeE+fPjAAAQNFkyaGdsqTp7OQAAjV1UeJii4sOUHB911GMLSsq0bHuOFm3Zq0Vb92nx1r1667ttbvOOH+/aMt51X09LjHJd0lsmRinNe5sYreS4SIWzvBkAAMctxGMDyoIYLd0AgGCwJ79Ei7ft02IXxPdqxY5cZeUWHbbbus3hZgHfQnlyXJQbY94sNlLN7DYmQs3jIpVkt959sZFKjA5XSAiTvwEAgkMOLd0AAMDLQrLNjG6bl11331NQ6sJ3Zk6xsnKKlJW7/9Y9PrB/XVZ+5QRvR9IqMVpn9GypM05Mc0ugWes8AADBjpZuxnQDAHBURaXl2ltQqr2FJdqTX6p9dmuP3Vai3fklmrtxtzbuKnDH22zqFvDP7JmmMT1aKimWydwAAE0LLd0AAKDe2MRrrZJsO/ySZNZyvm5nnj5ZnqnPlmfqf0t36IMlOxQWGqIhHVu4AH5Kj1R1aBHLeHEAQNCgpZuWbgAAfMK6p3+xIkufrcjUjDXZKi6rqJzIzdYU75Acp47JsWrfIlYdk+PUITlW6S1imVkdABAQWDKsnisKAAAcO5tR3YL33A27tWl3gTbvKtCm3fkqKt0fxL1sHjZbVzwiLFQRYSEH3YYqPCxEsZFh6pIar+5pCW7rkZZA93UAQIMjdNdzRQEAgPpVUeFxE7dt2pWvTQdCuI0J351XorKKCjezemm53VaorNyjkgO3uUWlyi+pPrGbzbJeNYR3S4tXt7QEN7YcAABfYEz3UbBONwAA/hUaGuLGiNs2tHNyrV9nY8d37CvSqsxcrcnM1aqMPK3OzHUTuVlrelXtmsd8H8ZbxatbywR1To1TbCRhHADQMBjTTUs3AABNQnmFR1v3FGhVRq4L4asz94dxm9zt4PXIUxOi3IRuHQ6MJe9wYGz5ia0TGVMOAKgVWroBAEBQsVnS94foOJ3Vq1Xlfuuebl3YrUXcWsftvnVjtzA+b9OeQ9Ya/78Le7uZ1gEAqA+0dNPSDQBA0MopKt0/qduuAhfIX5q5QblFZTqnTyv9/rxeapl4+CXSAADBLaeWWZLQTegGAAAHZOUUadK7y/Th0gwlRIfrt+ecqMsHpbvx5wAAHEuWDD3sMwAAAEHGWrb//JOB+utVA93SZBP/u0Q/ev4b1xUdAIBjQUs3Ld0AAOAwXc8f/WilXvlmsyLDQzW8S7Ib8+1mXE+MVlpStFonRSslPqpyPfHw0P23IbbgOACgSaN7eT1XFAAACE7zNu7W/72/XCsyclVSVlHrSd0iw0LVMSVOvdskqpdtbZPc7OisHQ4ATQOhu54rCgAABDdbH3xvQakycoqUsa+o8nZXfrFKyzwqrahwy5aVlXvcjOmFpeVak5nnjvOyBvBOyXEa1S1FZ/durSGdWriADgAIPITueq4oAACAY7Err1jLtucc2PZp4Za92rqn0D2XHBeps3qlaVzv1hrWJdl1UwcABAZCdz1XFAAAQH21mK/MyNWHS3a4WdLXZO2fpK1ZbIRuOLWLJgzv5MaQAwAaN0L3UUyZMsVt5eXlWr16NaEbAAD4xdqsPH20dIf+PXeLawHvmBzrlio7s2caE7IBQCNG6K7nigIAAPClotJyvThzg6Z8sVb5JeUa0TVZ95zbUye04u8TAGiMCN31XFEAAAANISunSI9/skpvzN8qm2JtRNcUt2Z4ZHiYmxHdup4nRofrvH5t1LttEl8KAPgJobueKwoAAKAhLdm6Tw/+b4UWbN6jkvIKeTyHHjO4Y3NdM6KTzuqZpnAmYQOABkXorueKAgAA8Ofka2UVHrdOuG2bdhfoH7M36b1F210gb5MUrauGddQPB7VTcnwUXxQANABCdz1XFAAAQGOTnVesf367Wf/4ZpN25hYrIixEZ5yYph8OTtfobqmsAQ4APkTorueKAgAAaKys9fujZRl6fe4Wfb022+1rlRitSwe2049Pbq/WSTH+LiIANDmE7nquKAAAgECwZXeB3py/1W3b9ha6ideuHNJeN4zpopYJ0f4uHgA0GYTueq4oAACAQFJe4dG0VVl6+vM1Wrx1n6IjQnX1sI76+ejOjPsGgHpA6K7nigIAAAjUSdg+W5GlyZ+u1oodOW75sZFdUzS0c7KGdmqhE1snMvYbAI4BobueKwoAACCQVVR49PGyDD0/Y70Wbd3nWsJNQnS4BrRvrrbNYtw48FZJUUpLjFZiTITCQ0MUHhqq8LAQdxxjwwGg7lkyXHWwd+9evfXWW5oxY4Y2bdqkgoICpaamasCAARo7dqyGDx9el9MBAACggYSGhmhcn9Zuyysu07yNu/Xtht36dv0ufbNul1t67Gj6tUvSZYPSdV6/NkqKiWiQcgNAoAvxWJ+jo9i+fbvuvfdevfrqq2rTpo2GDBnibmNiYrR7924tXbpU8+fPV4cOHTRp0iRdfvnlChS0dAMAgGBnreB7CkqUkVOkzJwiZewrVn5xmVsbvKy8wt1u3VOoD5fuUEFJuaLCQzWudysN65Kszqnx6pQSp+S4SIWEhPj7owBAYHYvT0tL0/jx4zVhwgT17NmzxmMKCwv19ttv65lnntEll1yiX//61woEhG4AAIDasSD+wZIdbmmyeZv2VHsuMTpcbZrFqFlshJrHRqpZbKTaJEWrZ5tE9WqTpLTEKEI5gCalXkP3rl27lJycXOs3r+vx/kToBgAAOLalyVZl5Gp9dp42ZOdr3c58ZeUUaU9BqfYVlh5yfIu4SJ3aI1W/+0FPdx8AAh0TqR3FlClT3FZeXq7Vq1czkRoAAEA9sUna9haUaPPuAi3fkaPl23PcsmVLtu1TSnyUHrmkj04/MY36BhDQfBa633333ZpPFBKi6Ohode3aVZ06dVKgoKUbAADA9+xPzncXbdc9by9VTlGZfjQ4Xb87t6fio+o0ry8ANP3QHRoa6gL2wS/z7rPbkSNHuvHdzZs3V2NH6AYAAGg4O/YV6q43F2vGmmy3Zvgp3VN1Vq80ndYjTUmxzIgOIHDUNkuG1vXEn376qQYPHuxu7eS22f2hQ4fq/fff1/Tp092Y7kCZSA0AAAANx9b6/vu1Q/ToJX3Vu02SPlqWodteW6ST7v9UVz7/jabO3KBtewv5SgA0GXVu6e7du7f++te/HrIm98yZM/Wzn/1My5Yt02effaZrr71WmzdvVmNHSzcAAID/ZOcV64sVWfpkeYamr8lWSdn+9cL7tE3Sz0/prHN6t3ZrjANAoGbJOg+iWbduXY0ntH3r169397t166bs7Oy6nhoAAABBxiZW++HgdLfZkmQz1uzUJ8sy9fGyDN30z+/Us/U63Tm2h5v5nHXAAQRFS7eN105ISNDf//53paamun07d+7U1Vdfrfz8fNe93Fq6b7zxRq1atUqNHS3dAAAAjc/u/BL9edpavTx7k2v9btssRs3jItzEawnREe5xp5Q4dUyJU8/WiUpNiPJ3kQEEmRxfTaRmQfqCCy7Qhg0blJ6e7vZt2bJFnTt31jvvvKPu3bu7SdRyc3N11VVXqbEjdAMAADTuidemfLlW8zbuUV5xmdtyi8rcsmReISHS4I4t9IM+rTWudyu1TIz2a5kBBIccX4VuU1FRoU8++cStb2169OihM888081sHmgI3QAAAIHFAreF8Y3ZBdqwK1+z12Xri5VZKirdPx48LTFK3dMS3GYt4i0To5QaH+XCuLWIs0wZgEYfupsSQjcAAEDgs/HgX67KcuF7dWau1mblVYbwg9lSZSe2TtS95/ZUv/RmDV5WAE2DT0P3V199pccff1wrVqxwj3v27Kk777xTo0aNUqAhdAMAADTN1vBtewpdi3hWbrF25hZXuS3SN+t3uWOuHdFJt5/VXbGRdZ5fGECQy/FV6H7llVd0zTXX6OKLL9aIESPcvq+//tqN4546daquvPJKBRJCNwAAQPBZlZGru/6zWIu27FWz2Aglx0UqOiJMLeIidU6f1vpB39ZKjI7wdzEBBGPoPvHEE9163Lfddlu1/ZMnT9bzzz9f2fodKAjdAAAAwclaul+etVHvLNymgpJyFZaWu9Zwmy09KjzUhe/bz+yu9Bax/i4qgGAK3VFRUVq2bJm6du1abf/atWvVu3dvFRUVKZAQugEAAOCVW1Sq/y3Zof/M36Y5G3crOiJUt5zeTT8d2VmR4YE3aTAA/2fJOv/msGXCPv/880P229rc3iXEAAAAgEBka4BfPri9Xv/FML1y3VC1SYrRox+t0tinpuvP09Zp+95CfxcRQICp84wRd9xxh2655RYtXLhQw4cPd/tmzpzpxnM//fTTvigjAAAA0OBGdkvRh78apb98tV5/+3qDHvlopR79eKV6pCW4sd9JMRFu3HdSbIS7b13SbbNJ2Xq2SXRLloWFhvDNAUHumGYvf+utt/TEE09Ujt+2cd42e/kFF1ygQEP3cgAAAByNjfOetipLby/cpsVb9ymnsFS5xWU60l/StjTZSe2b69QeqRpzQkt1TolTSAghHGgqWKe7nisKAAAAOHgitrziMhfA9xWWqqi03IVzu7942z59t3mPvtu8V8Vl+9cLv+Skdnrkkj4KD2NsOBBMWZIFCQEAAIBjYF3HrVu5bQfPbDSuT2t3W1hSrlnrsjV11kb9Z8FWFZeV68nL+yuC4A0EjVqF7ubNm9e6K8zu3bvlDwUFBa6b+2WXXabHH3/cL2UAAAAAqoqJDNPpJ6ZpdPdU3frv7/T+4h2uNfyBi/ooNSGKygKCQK1C91NPPaXG7oEHHtDJJ5/s72IAAAAAh7CW7Wd+NEDhoYv07qLtmrZ6p344qJ3O6d1arZvFqHVStKIjwqg5IFhD9/jx49WYrVmzRitXrtR5552npUuX+rs4AAAAwCFsLPdTl/fXOX1a689frdMr32x2m7FOpV1T49W3XTP1bZfktm5pCQoPDXHd2OmODjTx0J2fn6+4uLhan7Qux0+fPl2PPfaY5s+frx07driZ0S+88MJqx0yZMsUdk5GRoX79+umPf/yjhgwZUvn8r3/9a/f8rFmzal1GAAAAoKGFhobo7N6tNLZXmuZt2qPl23O0fV+hNu8q0JJt+9y4b9uqvSZEunpYR/3uBycyCRvQVEN3165ddeutt7oW79at908KcTBbeeyzzz7T5MmTNXr0aE2cOLHWAd2C9LXXXquLL774kOdfe+013X777Xruuec0dOhQ19V97NixWrVqlVq2bKl33nlH3bt3dxuhGwAAAIHA5ksa3LGF26ralVfswveSrfu0YVe+W5JsbVaem4htfXa+nr1ygFsbHEATW6fbAu5vf/tbffDBBy4gDxo0SG3atFF0dLT27Nmj5cuXa/bs2QoPD3dh++c//7nCwsKO6ZfPwS3dFrQHDx6sZ5991j2uqKhQenq6br75Zt19993u/V555RX3fnl5eSotLdUdd9yhe++9t1bvyZJhAAAAaMxs4rV731mqf8/dovQWMZo47kSN692KNb+BprhO9+bNm/XGG29oxowZ2rRpkwoLC5WSkqIBAwa41udx48YdU9g+XOguKSlRbGys3nzzzWpB3Frc9+7d61q5q5o6daob032k2cuLi4vdVrWiLMSzTjcAAAAaK/uT/R/fbNJjH61SbnGZerdNVJ+2SWrfIs4F8I4ptR8KCqARr9Pdvn1714psW0PIzs5WeXm50tLSqu23xzZx2rF46KGH9Ic//KGeSggAAAD4njVO2bhum4Ttqc9W678Ltmnpthz33KMfr9SZJ6bpp6M6a3DH2i/1C6Bh1Cl0N3YTJkw46jHWHd3GiB/c0g0AAAA0dinxUbr/wj76vwt6a3d+iZbvyNHLszbp0xWZ+mR5ppv1/ML+bd0SZJ1T49WjVYK/iwwEvUYduq3runVXz8zMrLbfHrdq1eqYzhkVFeU2AAAAIFBZa3ZyfJRGdUt12/qdefrb1xvczOf3vb+88riRXVP0y1O7qGvLeDWLjVBUOGuBAw2tUYfuyMhIDRw4UJ9//nnlmG6bSM0e33TTTcd1bluGzDbrvg4AAAAEMmvVfuCiPrpzbA+3DNnOvGJ9uTJL7y7arq/XZlceFxsZpuT4SF00oJ1+Nrqz4qMadRwAmoQ6TaTmCzbj+Nq1a919m5DNlhwbM2aMWrRo4caQ25JhNnHaX/7yF7c2ty0Z9vrrr7sx3QeP9T4WzF4OAACApspawD9YvEO78ku0p6DEdUlfvzNf2/YWKiU+0o0Dv2JIeyXFsAwZ0ChmL/eFadOmuZB9MAvaNhu5seXCHnvsMWVkZKh///565pln3FJi9YHQDQAAgGBSVl6hN+ZvdROyZeYUu9bvsb1a6bQTWmp091QCOODv0P3RRx8pPj5eI0eOdI+ti/bzzz+vnj17uvvNmzdXICF0AwAAIBgVl5Xr/UU79PLsjVq8dZ/bFx4aosEdW+iqYR1YCxzwV+ju06ePHnnkEZ1zzjlasmSJBg8e7GYD//LLL3XCCSfopZdeUiAhdAMAACDY7dhXqC9WZumLFVluDHhxWYVbfuzRS/upE2uAAw0buq2Ve+nSperYsaN+//vfu/tvvvmmFixY4IK4dQEPBFUnUlu9evVRKwoAAAAIBtl5xXry09X615zNap0Uo7duHK6WCdH+LhYQsKE79FhmFC8oKHD3P/vsM5111lnuvk18Zm8aKG688UYtX75cc+fO9XdRAAAAgEa1FrjNhP7wJX3dhGvXTZ2nmWuz3azoFRV+nQ4KCEh1XiPAxnJbd/IRI0Zozpw5bnZxY63F7dq180UZAQAAADSwHw5K19Y9hXrm8zX68Qvfun1dUuM0fnhH9W6bpFaJ0W4MeLPYSEWG17ktDwgadQ7dNpP4DTfc4LqU//nPf1bbtm3d/g8//FBnn322L8oIAAAAwA9uO6ObTmrfTFv2FGpjdr7emLdF976zrNoxLROi9PzVg9QvvRnfEdAYlwzzNyZSAwAAAGonv7hMX63eqU27CpSVW6SSsgr9Z8FW99wzPxqgs3q1arJV+dno0Rr83HNK6tlTiyZOVNvzz1fKsGEq2btXc66/XuWFhWo9bpwqSkoU37mz2l1wQZ3Ov+zBBxUeF6cet956yHPvdemis7/7ThE+mINq3k03qfO116rFSSdp1dNPa+Mrryg6Lc09l9Ctm0568skaX7dn4UIt/n//T+VFRYpu1UoDnnhCMa1aHfNz5cXFmnnZZRr26quKSEhQU8qSdW7pNhUVFVq7dq2ysrLc/apGjx6tQJtIDQAAAMDRxUWF65w+ravtu2xQun768lz9/JX5uvfcnrpmRKcmX5X9Hnqo8v7Or792YXnkG2+oMasoK1NoePX4t2fRIpXu3esCt5ddTOh9zz1HPJenokILbrtN/R580F14WPf881p2//0a9Oyzx/xcWFSU2l10kda98IJOuO02NSV1Dt3ffPONrrzySm3atEkHN5KHhIQETIi1idRs816dAAAAAFB3/dOb6b+/HKEJU+foD+8tdy3hPxnaQaO6pygqPMwvVZrx2Wda8eijCgkPV8vRo7X5zTc1+u23FduuXbUWazP9ggvUc+JEpZx8stb97W/a9t578pSVudf2vvfeaoHUa9aVV6rThAkubC9/+GGV5ebqq3PPdefZ+vbb7tydr7lGFaWlWvXkk8qePdvdj+vUSX3vv1+RSUkqysrSwrvuUuGOHYpu2VKRzZsrvkuXw34mC6iZ06apvKBA3W+5pbIl3UJs3vr17vwxrVur38MPKzo1VQVbt7oydbjiCu2cOVPpF13kylTVpn/9y4Xsutq3dKmrHwvOxt5j5eTJrrU6d9WqY3ouLCpKbc49V9PPO089fvUrly2DNnT/4he/0KBBg/TBBx+odevWTaoyAAAAANRd++RY/feXw/Xbt5boo6UZmrZqp2IiwjS4Uwt1TY3XoI7NdVbPNIWH+X7CteLsbC38zW804t//dt2jLViW7tlTq9e2u/BCdbnuOnd/z3ff6bu77tJpn3562ONTR4zQCb/6lXZ8+qmG/OUvbp+F7qpBOSwmRqPeess9Xv3HP2rV5Mnq84c/aOl996lZ3746eepUFWZkuLB5pNCtkBCd8t57yt+8WTMuvFAtBg50FxF6/e53ikpOdoesee45rX76aRfsjV0MsDro+Zvf1HjKXd9+e0gQ3/Hhh9r1zTeKaNZM3W+6qTIgV1WwfbtiD8ztZcLj491WlJl5zM/FtW/vLhaERUcrd/VqJfbooaAN3WvWrHGTqHXt2tU3JQIAAAAQcGwW8z/9eKC27y3U2wu36atVO/XNul2avnqnXpy5QW2bxehHg9N1Qf+2LqT7io0ZtsBmYdO0/+EPXcCtjX3Ll2vNn/7kQrq1yOavX+/GHlsQPBYZn36q0txc7fj4Y/fYWqO9oTN71izXMm5sTHPa6acf8VztL7/c3Vo4bTF4sHbNmeNC97Z333VBv6K42LUYR7ZoUfmakIgIdyHhcIoyMhSVklL5uMOVV6rbDTcoNCJCu+fN09xf/lKjrIdAlaDsa1EpKa5cQR26hw4d6sZzE7oBAAAAHKxNsxjdcGpXt5VXeLR1T4HeXbhdL8/epCc+Xe229BYxOq9vG905tofve84edP6QsDB5qgyJtbDqbktKNO+GGzT81VddC7SF5Y/693f7jzV023Dc3pMmqeWoUbUoZh3rISREu+bN04a//92NJ7ewat3qVz31VOUhVu6Q0MP3LrDnvZ/fWEuzV4tBg5TUq5f2LllySOiObdNGBdu2VT4uy8tzm03AZmPEj+U5r/KSEoUeY303VnXu33HzzTfrjjvu0NSpUzV//nwtXry42hYobBK1nj17avDgwf4uCgAAANAkhYWGqENynG4+vZtmTzxNL10zWJcPSpdNDfWnaev08qyN9f6ezQcMUM6qVcpdt8493vzGGy44e8V16KC9ixZVTiSWt2GDu2+txG5cdJs27rGF2ePV6swztf7FF1VWWOge2611nTYpI0Zoy4HJ12x8twXmI9ny5pvu1sZqWyt08uDBKt23z40rt/Hg9hmtK31dJJxwQuXnNza+3Mv2W8u/t8XZWuu/u+MOdz+pd2837t3Gqht737TTTnPjso/1OWMXQwo2bWpSrdzH1NJ9ySWXuNtrr7222lUZu4rDRGoAAAAAahIRFqoxPVq6LbeoVOf+8Ws9+L+V6paWoOFdkuutxdvGN/d/+GHN++UvXTfp1NGjFdG8eeXzJ9x+uxurbYHPArq3G7otU2WzZs+46CIXYm1Sr+PV9ec/1+qSEn198cWVLe62L6F7dzdDuE2k9uXYsa6lt6ax01VZIP3qvPPcRGo2wZt1LbfXbXv7bX1xxhmuzCnDh7vx0bXV5uyztXP6dDc23ax84onKSdKshdzGnsd32j8bff7GjQo/sJSXPWdLfS3+3e9cS7mVY8Djjx/Xc8Za7q2XQWSzZsG9TrfNWn4kHTp0UCBhnW4AAACg4S3asleXPjdLpeUeN947JSFKSTERat8iRh1axLlx3z3SEtQhOfa4A/lHgwZVzl6O75Xl5+vryy7TyDffVHjskcfZz/n5z92FAl/W4fxbbnFj8FNHjmxSWbLOobupIXQDAAAA/rEyI0evz92qGWt2Kr+4TLvyS1RcVlHtmIEdmuvpH/VXu+bHPvkaofvwbDkxGw/u7y7d5cXFrgt9xx//WIHCp6F73bp1euqpp7RixQr32MZG33rrrepypCnuGylCNwAAANA4VFR4lJ1XrM27C7R+Z77mbNytN+dvVUJ0uK4Y0l6XDmynbi3jWbYYTTt0f/zxxzr//PPVv39/jTjQ93/mzJlatGiR3nvvPZ155pkKJIRuAAAAoPH6cmWW7nt/uTZk57vHHZNj1T+9mYZ1Sdb5/doqJjLM30VEkMrxVegeMGCAxo4dq4cffrja/rvvvluffPKJFixYoECsqOytWysryiZcsOnzbU0+m8HQKzQy0s2sV1ZQUG2ZAdtnz9mYCE/F991hwmJiFBoe7pYbqMqNlwgNddPjV9sfH2+X99z5q7JJHSrKylR+YNZD7yQENlOhzVJoXTEq94eFufO72RerzNLIZ+J74mePf0/8juB3Of8/8X8uf0fwt1Gg/g1rs35/uyZLnyzP0Ndrs7VpX6nKwiLUPKxcLeMiFBkeqmYxEbrrvL7q0zElID4TWSMy4L+nfXv2KKVdu/oP3dHR0VqyZIm6HZjlz2v16tXq27evioqKFChLhtlWXl7uyv7vjh0Ve2ANOxu83++hh7Ro4kRtfv31ytd0v+UW9bj1Vn0zYYJ2zphRub/vgw+qw+WX68uzz1bemjWV+4e+9JJajh6tD/v1q/YDcuqHHyq6dWu37l9VZy9cqKIdOzRt3LhqP0jjFi1S1vTp+vaaayr3x3frpjEffaRNr72mxb/9beX+1FGjdPLUqVr19NNa/cwzlfv5THxP/Ozx74nfEfwu5/8n/s/l7wj+Nmoqf8O2/+WNWjj8YhXd8yu12bikcv9/h/5Y1993i4pv+knAfSayhgLue9r01Vf60caN9R+609PTNXnyZF122WXV9r/++uv69a9/rc2bNyuQ0NJN632gXVEL1CvUfCa+J372+PfE7wh+l/P/E//n+vLviG837NINry1VTnmIxnVN0uk9UjWyW4qS4yL52eNnTwHV0n3ffffpySefdN3Jhw8fXjmm+5FHHtHtt9+ue+65R4GEMd0AAABA07BuZ54e+t9KfbZi/1rV4aEhbvbzhOgIjeyarAv6t1XzuEh/FxNNhM/GdNvhNnP5E088oe3bt7t9bdq00Z133qlbbrkl4GYSJHQDAAAATcuOfYWavW6X3vpum77bvFeFpeUqr/AoMixUY3u30n3n9yJ8IzDW6c490HU1ISFBgYrQDQAAADRthSXl+mjZDrcm+Oz1u9zs56/+dKjiosL9XTQEsAYJ3U0BoRsAAAAIHo9+tFJ/mrZOqQlR+uGgdhrdLdW1endNjVdoaGD12kUTCt0nnXSSPv/8czVv3twtGXakLuSBumTY0SoKAAAAQOCz+PPSzI16YcZ6bd/3/cpLI7om66UJQ9zyY0B9Zsla9ae44IILFBUVVXk/0MZtAwAAAICxLHPtyE66elgHLdyyV/M27dF3m/fo42WZuv7v83RWrzRdclI7RUeEUWGoF0Hbvfzgdbpp6QYAAACCU1l5hW785wIXvM0JrRJ06cD9wdu2uMgwndw5mcnX0DBjujt37qy5c+cqOTm52v69e/e6bujr169XIKF7OQAAAACLRRk5RW6ytac/X62Kg1JSRFiITu3RUteM6KjhXVKoMMhnoTs0NFQZGRlq2bJltf2ZmZlKT09XSZUFxQMBoRsAAABAVVv3FChjX5GKSitUVFqunXnF+t+SHZq5Ntt1T3/5miEa2Y3gHexy6nNMt3n33Xcr73/88cfu5F7WRdsmWuvUqdPxlBkAAAAA/K5d81i3VXXFkPZalZGrS5+bpetenqsRXVM0rHOyLjqprVLi989/BRxXS7e1cLsXhIS4rhdVRUREqGPHjnriiSd07rnnKpDQ0g0AAACgtuZu3K1HPlzpJmErq/CoVWK0nr1ygAZ1bEElBpkcX3Uvt9ZsG9OdktI0ulMQugEAAADUVX5xmd5btF2T3l2m4rIKndUzTfdf1FstE6KpzCCR46vQ3dQQugEAAAAcq7VZuXrik9X6cGmGmsdG6LYzu+uHg9JZciwI5PgydNv4bduysrJUUVFR7bkXX3xRgYTQDQAAAOB4fbB4h37/3jLtzC1WYnS4LhzQVlcP66iuLeOp3Caq3idS8/rDH/6g++67T4MGDVLr1q3dGG8AAAAACGY/6NtaY05I1b/nbNFrc7fo77M36ZVvNun6UZ018ZwT/V08+FGdW7otaD/66KO66qqr1BTQ0g0AAACgPlnEmr9pj/7vgxVatGWvHrioty4bmK7I8P2TU6Np8Fn38uTkZM2ZM0ddunRRU0DoBgAAAOALu/NLNO7p6crMKVZ4aIg6psTpxNaJuv3M7uqUEkelB0mWrPOllp/+9Kf65z//qUA3ZcoU9ezZU4MHD/Z3UQAAAAA0QS3iIvWv60/WDad20ZgTWqqsvELvL96uS/88S0u37fN38dBA6tzSfeutt+rvf/+7+vbt6zZbo7uqyZMnK5DQ0g0AAACgoXy6PFM3/nOBIsNC9fzVgzSsSzKVH6B81r18zJgxhz9ZSIi++OILBRJCNwAAAICG9M36Xbr+5XkqLq/QY5f21fn92jBBdQBine56rigAAAAAqC/WvXzCS3OVnVeskV1T9OuxPdQ/vRkVHEB8Nqbba+3atfr4449VWFjoHh/Dct8AAAAAEJR6t03SR78apYsHtNWsddn68fPfaP3OPH8XCz5Q59C9a9cunX766erevbvOOecc7dixw+2/7rrrdMcdd/iijAAAAADQ5KTER2ny5f31j+uGqrC0XD/7x3xt2V3g72LB36H7tttuc5Onbd68WbGxsZX7L7/8cn300Uf1XT4AAAAAaNJGdE3R737QU2uz8nT6E1/pJy98q+enr9fqzFx6FDcB4XV9wSeffOK6lbdr167a/m7dumnTpk31WTYAAAAACArXjuykTqlxemnmRjfR2tdrs/XA/1aoQ3Ksfn9+Lw3rnKzoiDB/FxMNEbrz8/OrtXB77d69W1FRUcdSBgAAAAAIemN6tHRbYUm5vtmwS1+t2qk35m3RNS/NdXXTvkWs/vTjk9x4cDTh7uWjRo1y63RXXSasoqJCjz766BGXEwMAAAAAHF1MZJgL39bC/b9bR+mGU7u4ZcUycorcjOf3v79cOUWlVGWAqPM63UuXLnUTqZ100kluTe7zzz9fy5Ytcy3dM2fOVJcuXRRIWDIMAAAAQCB4f/F2TfzvEuUWlWlUtxS9OGGwIsKOeUEqNNYlw3r37q3Vq1dr5MiRuuCCC1x384svvljfffddwAVuAAAAAAgU5/Zto8WTztIVQ9I1Y022fvnKfH23eY+/i4X6buluamjpBgAAABBIysordMcbi/TOwu3u8W1ndNcF/duoY0qcv4sWVHJq2dJ9TKG7qKhIixcvVlZWlhvPXZV1Nw8khG4AAAAAgcZi3NyNe3TP20u1KjPX7TvjxJZ66OK+Sk1gguuADt22FvfVV1+t7OzsQ08WEqLy8nIFEkI3AAAAgEC1O79E7y7c5gL4B0t2qEVcpEZ3S1Gz2Ei1TorWaSe0VLe0BH8Xs0nyWei29bjPOuss3XvvvUpLS1OgmjJlitvsIoGNUT9aRQEAAABAY/b2d9v0zOdrtD47v3JfeGiILhrQVuOHd2SpsUAJ3XaypjRpGi3dAAAAAJqS/OIyt6TYmsw8PfzhSi3fkaOU+Eh9fvupSoqN8HfxmgyfzV5+6aWXatq0acdbPgAAAACAD8RFhat1UoxGd0/VB7eM1KOX9FV2Xonu+s8ilZZXn5MLvlfnlu6CggJddtllSk1NVZ8+fRQRUf1KyS233KJAQks3AAAAgKbMIt9N//pOHyzeoVaJ0frNuB66sH9bNycXGmH38r/97W/6xS9+oejoaCUnJ1f7ouz++vXrFUgI3QAAAACaOmvh/tOX6/SPbzYpO69YnVLi1D+9mX5/Xi+6nDe20N2qVSvXmn333XcrNLTOvdMbHUI3AAAAgGBhgdsmW/t4WYYyc4o1oH0zPXBhH/Vsw6TSjWZMd0lJiS6//PImEbgBAAAAIJikxEfpvgt665uJp+tnozvru817dcmfZ2lt1v61vlH/6pycx48fr9dee80HRQEAAAAANAQbGvzbc07Uqz8dquKycv3qtYUqr6hTJ2jUUrjqyNa1fvTRR/Xxxx+rb9++h0ykNnny5LqeEgAAAADgByO6puj6UZ31l+nr9edpa3XjmK5MsObv0L1kyRINGDDA3V+6dGm155j9DgAAAAACy82nd9P/lu7Q45+s1vuLd2jSeb00rEuyv4vVZNR5IrWmhonUAAAAAAS7fYWl+uPna/TKt5tUXFbhWr/vOKu7osLD/F204JtIDQAAAADQtCTFROh35/bUh7eOVr92zfTX6ev1w798o6LScn8XLeARugEAAAAAjq3f/eYvhmnC8I5atGWvbnh1geZu3K0g7yDdsGO6AQAAAABNV3hYqO45t6e27y3UJ8sz9cXKLBfGH7u0rwZ1bOHv4gUcxnTXsh8+AAAAAASbVRm5+s+CrXrlm/1jvU/tnqqze7fShQPaKiIsuDtO59QySxK6Cd0AAAAAcETLt+fooQ9XaNa6XW4978sHpeuRS/sGda3lMJEaAAAAAKA+9GyTqH9cN1QL7jlTJ3duodfmbdHirXup3FoI7v4AAAAAAIA6zXL+h/N7KzREuu+95UywVguEbgAAAABArfVolaAfD+2geZv26MtVWdRcUw/de/fu1aBBg9S/f3/17t1bzz//vL+LBAAAAABN2g1juig8NETPfrFWxWWs5d2kQ3dCQoKmT5+uhQsX6ttvv9WDDz6oXbt2+btYAAAAANBktU6K0eWD07Vg815N/O8SfxenUQv40B0WFqbY2Fh3v7i42I0pYOF2AAAAAPCtP5zfS51T4jRv4x6qujGHbmulPu+889SmTRuFhITo7bffPuSYKVOmqGPHjoqOjtbQoUM1Z86cQ7qY9+vXT+3atdOdd96plJSUBvwEAAAAABB8wsNCld4iVpk5RTR8NubQnZ+f7wKzBeuavPbaa7r99ts1adIkLViwwB07duxYZWV9P2C/WbNmWrRokTZs2KB//vOfyszMbMBPAAAAAADBqVVitIrLKrSvsNTfRWm0/B66x40bp/vvv18XXXRRjc9PnjxZ119/va655hr17NlTzz33nOtO/uKLLx5ybFpamgvlM2bMaICSAwAAAEBwS0uKdrcZOUX+Lkqj5ffQfSQlJSWaP3++zjjjjMp9oaGh7vHs2bPdY2vVzs3Ndff37dvnuqv36NHjsOe0cd85OTnVNgAAAADAsbV0m4x9hO6ADN3Z2dkqLy93LdhV2eOMjAx3f9OmTRo1apRr4bbbm2++WX369DnsOR966CElJSVVbunp6T7/HAAAAADQFLVKinK3Nq4bNQtXgBsyZIhbLqy2Jk6c6MaIe1lLN8EbAAAAAOourbKlu5jqC8TQbbOQ25JgB0+MZo9btWp1TOeMiopyGwAAAADg+LRrHqvQEGn+ZpYNC8ju5ZGRkRo4cKA+//zzyn0VFRXu8bBhw47r3DZbuk3MNnjw4HooKQAAAAAEn6SYCJ3du5Wmr96pf367WQUlZf4uUqPj99Cdl5fnuod7u4jbsl92f/Pmze6xdQV//vnn9fLLL2vFihX65S9/6ZYZs9nMj8eNN96o5cuXa+7cufXyOQAAAAAgGN1walfFRobpt28t0QXPzlRZeYW/i9So+L17+bx58zRmzJjKx97x1uPHj9fUqVN1+eWXa+fOnbr33nvd5Gn9+/fXRx99dMjkagAAAACAhte7bZJm3326Hv5opf41Z7M+XpapH/RtzVdxQIjH4/EoiNlEajaLuS03lpiY6O/iAAAAAEBAys4r1vCHv1DH5Fi9f/MoRYb7vWN1o8iSTbsWAAAAAAANIiU+Sjec2kWrM/P04swN1Hqwh24mUgMAAACA+h/f3bZZjP46fb3yi5lULahDNxOpAQAAAED9si7lvzils3bnl+idhdup3mAO3QAAAACA+nfRSe0UFxmm37+3TLPWZQd9FRO6AQAAAAD1Jj4qXFcN66iSsgrd997yoK9ZQjcAAAAAoF7dPe4EjeiarHU781z4DmZBG7qZSA0AAAAAfGdAenOVlnu0PjsvqKs5aEM3E6kBAAAAgO+c0DrB3a7YkRPU1Ry0oRsAAAAA4Dt92ia52399u0Vl5cHbxZzQDQAAAACodx2S4zR+WAfN2bhbf5+9KWhrmNANAAAAAPCJu8edqDZJ0Xrys9VuUrVgFLShm4nUAAAAAMC3YiLD9NAlfVVQUq5f/XuhPB5P0FV50IZuJlIDAAAAAN87pXuqrjq5g5Zs26cZa7KDrsqDNnQDAAAAABrGtSM6udv3Fm0PuiondAMAAAAAfKp9cqw6pcRp9vpdQVfThG4AAAAAgM+d3DlZW/cUasvugqCqbUI3AAAAAMDnBnVo7m5tbHcwIXQDAAAAAHyua8t4d7suK7iWDgva0M2SYQAAAADQcLocCN1rg2y97qAN3SwZBgAAAAANJz4qXK2TorWWlm4AAAAAAHzTxXzZ9hx9uGRH0FRv0LZ0AwAAAAAa1l1jT1B0RKge/2RV0FQ9oRsAAAAA0CD6tEvSBf3aat3O/KBZOozQDQAAAABoMGNOSHW301ZlBUWtE7oBAAAAAA1mRNcUhYeG6MtVO4Oi1gndAAAAAIAGkxAdoUEdm2vWumzlFpU2+ZoP2tDNOt0AAAAA4B/n9WujotIK/fTlefJ4PE36awjxNPVPeBQ5OTlKSkrSvn37lJiY6O/iAAAAAECT5/F4dOebi/Xm/K165bqhGtktRU01SwZtSzcAAAAAwD9CQkJ06+nd3P23vtvWpL8GQjcAAAAAoMGlt4hV66RorcrMadK1T+gGAAAAAPhF97QErcnMU3lF0x31TOgGAAAAAPhFj1YJKi6r0ObdBU32GyB0AwAAAAD81tJtVmXkqqkidAMAAAAA/KLHgdC9OpPQDQAAAABAveraMl4hIdIqQjcAAAAAAPUrJjJM7VvEajXdywEAAAAA8M247vXZ+Sotr2iS1Ru0Y7qnTJminj17avDgwf4uCgAAAAAErXbNY9ySYTtzi9UUBW3ovvHGG7V8+XLNnTvX30UBAAAAgKCVlhjtbjNzitQUBW3oBgAAAAD4X1pilLvNzKGlGwAAAACA+g3dCftburNyaekGAAAAAKBetaR7OQAAAAAAvpFG93IAAAAAAHwjPipcCVHhWrB5j4pKy5tcNTORGgAAAADAb0JCQnTdqE5avzNfb87f2uS+CUI3AAAAAMCvLujf1t1u3VPY5L4JQjcAAAAAwK9SE/YvG7Yzt+ktG0boBgAAAAD4VVxkmGIiwrQzj9ANAAAAAEC9j+tOTYhSNi3dAAAAAADUv5T4SFq6AQAAAADwhdSEKO3KK1Z5hadJVTBjugEAAAAAjSJ0V3ikXflNa1x30IbuKVOmqGfPnho8eLC/iwIAAAAAQa9TSryrg2XbcppUXQRt6L7xxhu1fPlyzZ07199FAQAAAICgd0r3FFcHX63e2aTqImhDNwAAAACg8eiSGq+2zWL0/uLt2p1foqaC0A0AAAAAaBTLht1xVndl55Xo5Vkb1VQQugEAAAAAjcLYXq3c7ZbdBWoqCN0AAAAAgEYhLipc8VHhysptOjOYE7oBAAAAAI1Gy4QoZeYUqakgdAMAAAAAGo2WiVG0dAMAAAAA4JPQnRCtfYWlKiotbxIVTEs3AAAAAKDRSEuMcrc7m8i4bkI3AAAAAKBRtXSbpjKuO9zfBQAAAAAAwOv0E1sqvUWMOqfGqykgdAMAAAAAGo3OqfFNJnAbupcDAAAAAOAjhG4AAAAAAHyE0A0AAAAAgI8QugEAAAAA8BFCNwAAAAAAPkLoBgAAAADARwjdAAAAAAD4CKEbAAAAAAAfIXQDAAAAAOAjhG4AAAAAAHwkXEHO4/G425ycHH8XBQAAAAAQILwZ0pspDyfoQ3dubq6riPT09Ab5YgAAAAAATStTJiUlHfb5EM/RYnkTV1FRoe3btyshIUEhISGHPD948GDNnTv3uN/neM5jV1DsosCWLVuUmJh43GWBb9XXz0ygCcTP3VjK3NDl8PX71ff5G8PvYcPv4sDRWP5t+0OgffbGUl5+DzdcHfE3cfBoLP++fcmitAXuNm3aKDT08CO3g76l2yqnXbt2h62gsLCwegm69XEeez2hu/Grr5+ZQBOIn7uxlLmhy+Hr96vv8zem38OG38WNX2P5t+0PgfbZG0t5+T3ccHXE38TBo7H8+/a1I7VwezGR2lHceOONjeo8aPyC9bsOxM/dWMrc0OXw9fvV9/n5PQx//wwGkkD77I2lvPwebrg6aizfOXyP7/p7Qd+9PBBYl0a7grJv376guFoEAI0Rv4sBwL/4PYxARUt3AIiKitKkSZPcLQCA38UAEIz4mxiBipZuAAAAAAB8hJZuAAAAAAB8hNANAAAAAICPELoBAAAAAPARQjcAAAAAAD5C6G4C3n//ffXo0UPdunXTCy+84O/iAEDQueiii9S8eXNdeuml/i4KAASdLVu26NRTT1XPnj3Vt29fvfHGG/4uElANs5cHuLKyMvcL5ssvv3RreQ8cOFCzZs1ScnKyv4sGAEFj2rRpys3N1csvv6w333zT38UBgKCyY8cOZWZmqn///srIyHB/D69evVpxcXH+Lhrg0NId4ObMmaNevXqpbdu2io+P17hx4/TJJ5/4u1gAEFSshSUhIcHfxQCAoNS6dWsXuE2rVq2UkpKi3bt3+7tYQCVCt59Nnz5d5513ntq0aaOQkBC9/fbbhxwzZcoUdezYUdHR0Ro6dKgL2l7bt293gdvL7m/btq3Byg8Awf57GADQeH4Pz58/X+Xl5UpPT+drQaNB6Paz/Px89evXz/0iqclrr72m22+/XZMmTdKCBQvcsWPHjlVWVlaDlxUAmiJ+DwNA0/g9bK3bV199tf761782UMmB2iF0+5l1B7///vvdJDw1mTx5sq6//npdc801buz2c889p9jYWL344ovuebsiWLVl2+7bPgBAw/weBgD4//dwcXGxLrzwQt19990aPnw4XwkaFUJ3I1ZSUuK6yJxxxhmV+0JDQ93j2bNnu8dDhgzR0qVLXdjOy8vThx9+6K78AQAa5vcwAMC/v4c9Ho8mTJig0047TVdddRVfBxodQncjlp2d7cakpKWlVdtvj21mRhMeHq4nnnhCY8aMcRNI3HHHHcxcDgAN+HvY2B9/l112mf73v/+pXbt2BHIAaMDfwzNnznRd0G0suP09bNuSJUv4DtBohPu7ADh+559/vtsAAP7x2WefUfUA4CcjR45URUUF9Y9Gi5buRsyWOwgLC3PrDlZlj205BAAAv4cBoCnj72E0BYTuRiwyMlIDBw7U559/XrnPruLZ42HDhvm1bAAQDPg9DAD+xe9hNAV0L/czm/xs7dq1lY83bNighQsXqkWLFmrfvr1bHmH8+PEaNGiQmzTtqaeecssq2OyNAAB+DwNAoOPvYTR1IR6b7g9+M23aNDcJ2sEsaE+dOtXdf/bZZ/XYY4+5ySJsYohnnnlGQ4cO9UNpAaDp4fcwAPgXv4fR1BG6AQAAAADwEcZ0AwAAAADgI4RuAAAAAAB8hNANAAAAAICPELoBAAAAAPARQjcAAAAAAD5C6AYAAAAAwEcI3QAAAAAA+AihGwAAAAAAHyF0AwAAAADgI4RuAAB8qGPHjnrqqaeCro6nTp2qZs2a1fl1q1atUqtWrZSbm3tc5zmS7OxstWzZUlu3bq3X8wIAUBNCNwAAaDQmTpyom2++WQkJCT57j5SUFF199dWaNGmSz94DAAAvQjcAAE1cSUlJvR7nK5s3b9b777+vCRMm+Py9rrnmGr366qvavXu3z98LABDcCN0AAByjU089VTfddJPbkpKSXAvqPffcI4/Hc9jXTJ48WX369FFcXJzS09N1ww03KC8vzz2Xn5+vxMREvfnmm9Ve8/bbb7vjvV2ut2zZoh/+8Ieu23WLFi10wQUXaOPGjZXHW2i98MIL9cADD6hNmzbq0aNHjWX5/e9/r/79++uFF15Qp06dFB0d7fZ/9NFHGjlypDt/cnKyzj33XK1bt67ydfZeISEh+u9//6sxY8YoNjZW/fr10+zZsw/7uXfu3KlBgwbpoosuUnFxcY3HvP766+48bdu21ZH8+c9/VpcuXRQZGek+2z/+8Y9qz69cudKV3z5Pz5499dlnn7nyWj169erVy9XNW2+9dcT3AgDgeBG6AQA4Di+//LLCw8M1Z84cPf300y5UW4g97H+8oaF65plntGzZMvfaL774QnfddZd7zoL1j370I7300kvVXmOPL730UtflurS0VGPHjnX3Z8yYoZkzZyo+Pl5nn312tZbqzz//3I2P/vTTT13r8eGsXbtW//nPf1yAXrhwYWX4v/322zVv3jx3HiuzheWKiopqr/1//+//6de//rV7Xffu3XXFFVeorKzskPewiwSjRo1S79693QWFqKioGstin8eC+ZFYSL711lt1xx13aOnSpfr5z3/uWq2//PJL93x5ebm74GAXAr799lv99a9/deWsyZAhQ9x7AgDgUx4AAHBMTjnlFM+JJ57oqaioqNz3m9/8xu3z6tChg+fJJ5887DneeOMNT3JycuXjb7/91hMWFubZvn27e5yZmekJDw/3TJs2zT3+xz/+4enRo0e19ywuLvbExMR4Pv74Y/d4/PjxnrS0NLf/SCZNmuSJiIjwZGVlHfG4nTt3WtO9Z8mSJe7xhg0b3OMXXnih8phly5a5fStWrHCPX3rpJU9SUpJn5cqVnvT0dM8tt9xSrcw16devn+e+++6rts97Hq/hw4d7rr/++mrHXHbZZZ5zzjnH3f/www9dfe3YsaPy+U8//dSV7a233qr2uttuu81z6qmnHrFMAAAcL1q6AQA4DieffLLruuw1bNgwrVmzxrW41sS6Op9++umuC7W1Vl911VXatWuXCgoKKltfreuztYKbV155RR06dNDo0aPd40WLFrnWaXuttXDbZl3Mi4qKqnUBty7s1v36aOzcqamp1fZZ+a3VunPnzq67u83A7h1zXVXfvn0r77du3drdZmVlVe4rLCx0LdwXX3yx6wVQtZ5qYsd7u7gfzooVKzRixIhq++yx7TfWum/d9m0GdC+r05rExMRU1jsAAL5C6AYAoIHYWGgbH21h1bp0z58/X1OmTHHPVe0a/tOf/tQtleXtWm7dp72B1cZ/Dxw40HXprrqtXr1aV155ZeU5rKt6bdR03HnnnecmGHv++eddF23bDi6jiYiIqLzvLV/VLujWjfyMM85w3du3bdt21LLYmPg9e/aoodhnPPiCAwAA9Y3QDQDAcfAGUq9vvvlG3bp1U1hY2CHHWsi2UPrEE0+4FnIbB719+/ZDjvvJT36iTZs2ubHfy5cv1/jx4yufO+mkk1xLtK0z3bVr12qbTeZ2vKzV3VqLf/e737kW+RNPPPGYg7CNBbdJzuwigU24VtNnrWrAgAHu8x6JlcfGsVdlj23CNGMTq9kY8szMzMrn586dW+O5bEy4vScAAL5E6AYA4DhYl2ubdMyC6r/+9S/98Y9/dBN91cSCsU2EZsesX7/eBdLnnnvukOOaN2/uumTfeeedOuuss9SuXbvK53784x+7FmGbsdwmAduwYYOmTZumW265RVu3bj3u79Le22YstwnIrBu7TfRmn+9Y2cUHW5rLZiU/7bTTlJGRcdhjbYI4mwH9cF3zjdWJ9QKwGczt4oNNXGeTwNmEbubMM890M5vbhYrFixe7QG4XEEzV7u3Wrdwuglj9AgDgS4RuAACOw9VXX+3GItu44RtvvNEF7p/97Gc1HmvB00LiI4884mbytjD60EMP1Xjsdddd57pzX3vttdX226zc06dPV/v27V0wt5ZfO9bGdNv46+NlrdP//ve/XSC1Mt5222167LHHjuucNru7XZCwseoWvKuO+65q3Lhx7lgb9344NjO5jQ9//PHH3fn+8pe/uC74tnybN+Tb0mDWDX/w4MGuq7539vKq48XfeecdV4c25hwAAF8KsdnUfPoOAAA0URb0bJ3rp556qt7Pba3gFnitS3ZtJkRrKmyM+7vvvquPP/643s5prd22bre13FsruLHu/dY7oOo4eAAAfCHcJ2cFAADHxLo979ixQw8//LBbgzqYArexz7x3717l5ua6GdqPha3lbbO629h6C9rW+8BmOPcG7uzsbNdLwGZoBwDA1+heDgBAI/Loo4/qhBNOcEteTZw4UcHGupdbd/BjDdzGArt19bd6nDBhgutmbt3JvWxM/F133XXUJcwAAKgPdC8HAAAAAMBHaOkGAAAAAMBHCN0AAAAAAPgIoRsAAAAAAB8hdAMAAAAA4COEbgAAAAAAfITQDQAAAACAjxC6AQAAAADwEUI3AAAAAAA+QugGAAAAAEC+8f8Bh/W9qnQOo3IAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1000x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (10, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>player</th><th>mentions</th></tr><tr><td>str</td><td>i64</td></tr></thead><tbody><tr><td>&quot;Victor Wembanyama&quot;</td><td>242687</td></tr><tr><td>&quot;LeBron James&quot;</td><td>182150</td></tr><tr><td>&quot;Shai Gilgeous-Alexander&quot;</td><td>170210</td></tr><tr><td>&quot;Luka Doncic&quot;</td><td>156095</td></tr><tr><td>&quot;Nikola Jokic&quot;</td><td>123654</td></tr><tr><td>&quot;Stephen Curry&quot;</td><td>88746</td></tr><tr><td>&quot;Giannis Antetokounmpo&quot;</td><td>85531</td></tr><tr><td>&quot;Jalen Brunson&quot;</td><td>70819</td></tr><tr><td>&quot;Kevin Durant&quot;</td><td>70379</td></tr><tr><td>&quot;James Harden&quot;</td><td>66480</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (10, 2)\n",
+       "┌─────────────────────────┬──────────┐\n",
+       "│ player                  ┆ mentions │\n",
+       "│ ---                     ┆ ---      │\n",
+       "│ str                     ┆ i64      │\n",
+       "╞═════════════════════════╪══════════╡\n",
+       "│ Victor Wembanyama       ┆ 242687   │\n",
+       "│ LeBron James            ┆ 182150   │\n",
+       "│ Shai Gilgeous-Alexander ┆ 170210   │\n",
+       "│ Luka Doncic             ┆ 156095   │\n",
+       "│ Nikola Jokic            ┆ 123654   │\n",
+       "│ Stephen Curry           ┆ 88746    │\n",
+       "│ Giannis Antetokounmpo   ┆ 85531    │\n",
+       "│ Jalen Brunson           ┆ 70819    │\n",
+       "│ Kevin Durant            ┆ 70379    │\n",
+       "│ James Harden            ┆ 66480    │\n",
+       "└─────────────────────────┴──────────┘"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# §3 — no scan; 03's artifact.\n",
+    "counts = pl.read_parquet(COUNTS_03).sort(\"mentions\", descending=True)\n",
+    "_total_mentions = counts[\"mentions\"].sum()\n",
+    "_qualified = counts.filter(pl.col(\"mentions\") >= QUALIFIED_BAR)\n",
+    "\n",
+    "print(f\"tracked players:  {counts.height} (of {len(players)} in config)\")\n",
+    "print(f\"qualified (≥{QUALIFIED_BAR:,}): {_qualified.height}\")\n",
+    "print(f\"median player:    {counts['mentions'].median():,.0f} mentions\")\n",
+    "for _n in (10, 25, 50):\n",
+    "    _share = counts.head(_n)[\"mentions\"].sum() / _total_mentions\n",
+    "    print(f\"top {_n:>2} share:     {_share:.1%} of all mentions\")\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "ax.plot(range(1, counts.height + 1), counts[\"mentions\"], lw=1.2)\n",
+    "ax.axhline(QUALIFIED_BAR, color=\"firebrick\", ls=\"--\", lw=0.8)\n",
+    "ax.text(counts.height, QUALIFIED_BAR * 1.15, \"qualified bar (5,000)\",\n",
+    "        ha=\"right\", fontsize=8, color=\"firebrick\")\n",
+    "ax.set_xscale(\"log\")\n",
+    "ax.set_yscale(\"log\")\n",
+    "ax.set_xlabel(\"player rank (log)\")\n",
+    "ax.set_ylabel(\"mentions (log)\")\n",
+    "ax.set_title(\"Player mention volume by rank\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "display(counts.head(10))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5069547c",
+   "metadata": {},
+   "source": [
+    "## 4. Flair coverage among matched — the `fan_team` denominator, filtered stage\n",
+    "\n",
+    "02 measured flair on the whole corpus (62.9%); this section measures it on the\n",
+    "classify population. The delta answers a real question — do flaired (team-affiliated)\n",
+    "users engage in player discourse more than the unflaired? — and the resolver-weighted\n",
+    "number is the true `fan_team` denominator every fanbase view will divide by."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "40a3ec18",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T19:06:47.644085Z",
+     "iopub.status.busy": "2026-07-09T19:06:47.644003Z",
+     "iopub.status.idle": "2026-07-09T19:06:48.141930Z",
+     "shell.execute_reply": "2026-07-09T19:06:48.141499Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "scanned mentions file; flair census + values persisted (1,740 distinct, top 1000 kept)\n",
+      "flair coverage (matched set): 1,391,000 / 2,154,982 = 64.5%\n",
+      "flair coverage (corpus, 02):  62.9% → delta +1.7 pp\n",
+      "resolver match over top-value mass (99.8% of flaired): 93.4%\n",
+      "fan_team denominator: ≈60.2% of the classify population carries a resolvable fanbase\n"
+     ]
+    }
+   ],
+   "source": [
+    "# §4 scan — the ONE flair pass over the mentions file. body not projected.\n",
+    "FLAIR_CENSUS_PQ = COVERAGE_DIR / \"filtered_flair_census.parquet\"\n",
+    "FLAIR_VALUES_PQ = COVERAGE_DIR / \"filtered_flair_values.parquet\"\n",
+    "FLAIR_TOP_N = 1000  # persisted cap; the tail is reported, not silent\n",
+    "\n",
+    "if not (FLAIR_CENSUS_PQ.exists() and FLAIR_VALUES_PQ.exists()):\n",
+    "    _scan = duckdb.sql(f\"\"\"\n",
+    "        SELECT\n",
+    "            grouping(flair) = 1 AS is_total,\n",
+    "            flair,\n",
+    "            count(*)            AS n,\n",
+    "            count(DISTINCT flair) AS n_distinct_flairs,\n",
+    "            count(*) FILTER (WHERE flair IS NULL) AS null_flair\n",
+    "        FROM (\n",
+    "            SELECT author_flair_text AS flair\n",
+    "            FROM read_ndjson('{MENTIONS_RAW}',\n",
+    "                format = 'newline_delimited',\n",
+    "                columns = {{author_flair_text: 'VARCHAR'}})\n",
+    "        )\n",
+    "        GROUP BY GROUPING SETS ((flair), ())\n",
+    "    \"\"\").pl()\n",
+    "    _scan.filter(pl.col(\"is_total\")).drop(\"is_total\", \"flair\").write_parquet(FLAIR_CENSUS_PQ)\n",
+    "    _values = (\n",
+    "        _scan.filter(~pl.col(\"is_total\") & pl.col(\"flair\").is_not_null())\n",
+    "        .select(\"flair\", \"n\")\n",
+    "        .sort(\"n\", descending=True)\n",
+    "    )\n",
+    "    _values.head(FLAIR_TOP_N).write_parquet(FLAIR_VALUES_PQ)\n",
+    "    print(f\"scanned mentions file; flair census + values persisted \"\n",
+    "          f\"({_values.height:,} distinct, top {FLAIR_TOP_N} kept)\")\n",
+    "else:\n",
+    "    print(\"reusing persisted flair artifacts (no rescan)\")\n",
+    "for _pq in (FLAIR_CENSUS_PQ, FLAIR_VALUES_PQ):\n",
+    "    warn_if_stale(_pq, MENTIONS_RAW)\n",
+    "\n",
+    "fcensus = pl.read_parquet(FLAIR_CENSUS_PQ).row(0, named=True)\n",
+    "fvalues = pl.read_parquet(FLAIR_VALUES_PQ)\n",
+    "# Cross-pass consistency stays HARD (scan disagreement = corruption signal).\n",
+    "assert fcensus[\"n\"] == M_TOTAL, \"flair-scan rows != 03 census rows\"\n",
+    "\n",
+    "flaired = fcensus[\"n\"] - fcensus[\"null_flair\"]\n",
+    "corpus_flair_rate = 1 - corpus[\"null_flair\"] / corpus[\"n_comments\"]\n",
+    "\n",
+    "# Resolver-weighted fan_team coverage — production resolver, same as 02 §1.2.\n",
+    "fvalues = fvalues.with_columns(\n",
+    "    pl.col(\"flair\")\n",
+    "    .map_elements(lambda f: extract_team_from_flair(f, TEAM_MAP), return_dtype=pl.String)\n",
+    "    .alias(\"resolved_team\")\n",
+    ")\n",
+    "_top_mass = fvalues[\"n\"].sum()\n",
+    "_resolved_mass = fvalues.filter(pl.col(\"resolved_team\").is_not_null())[\"n\"].sum()\n",
+    "\n",
+    "print(f\"flair coverage (matched set): {flaired:,} / {M_TOTAL:,} = {flaired / M_TOTAL:.1%}\")\n",
+    "print(f\"flair coverage (corpus, 02):  {corpus_flair_rate:.1%} → \"\n",
+    "      f\"delta {(flaired / M_TOTAL - corpus_flair_rate) * 100:+.1f} pp\")\n",
+    "print(f\"resolver match over top-value mass ({_top_mass / flaired:.1%} of flaired): \"\n",
+    "      f\"{_resolved_mass / _top_mass:.1%}\")\n",
+    "print(f\"fan_team denominator: ≈{_resolved_mass / M_TOTAL:.1%} of the classify population \"\n",
+    "      \"carries a resolvable fanbase\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82344cb5",
+   "metadata": {},
+   "source": [
+    "## 5. Token & cost estimation — v1-02 §1.4, at its correct home\n",
+    "\n",
+    "v1-02 estimated cost on the *cleaned corpus* under hypothetical filter scenarios; this\n",
+    "runs the same machinery on the actual classify population. Two deliberate choices:\n",
+    "\n",
+    "- **Production constants, not hand-rolled numbers** — model, batch prices, and\n",
+    "  `calculate_cost` come from `pipeline/batch.py`; the prompt overhead is *measured*\n",
+    "  from the production `build_prompt`. If batch.py reprices, this cell reprices.\n",
+    "- **A sensitivity band, not v1 actuals** — v1-04's measured tokens (209-token overhead,\n",
+    "  ~112 output tokens) describe the old verbose prompt, superseded by the current\n",
+    "  minimal template; they'd anchor the estimate high. Instead: chars/token at\n",
+    "  3.5/4.0/4.5 and output tokens at 10/15/20 bracket the answer. #63's\n",
+    "  `summarize_actual_usage` closes the loop with real numbers after the first batch."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "4bb0e1cc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T19:06:48.143117Z",
+     "iopub.status.busy": "2026-07-09T19:06:48.143055Z",
+     "iopub.status.idle": "2026-07-09T19:06:48.459514Z",
+     "shell.execute_reply": "2026-07-09T19:06:48.459017Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "scanned mentions file; body-length distribution persisted\n",
+      "total body chars: 347,402,222\n",
+      "mean 161 | median 99 | p95 498 | p99 958 | max 9,961\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA90AAAFUCAYAAAA57l+/AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAZ3RJREFUeJzt3QeYU2XWwPEzvTAFhmGAoSNIb0sTUFEEWVRWwK6riF2KKOgnrqvoqou7NqSpq7vqrg1hBdZeEESKgggI0qXXoU1vzEy+57xyYybTkplkJpn8f88Tyb25ubm5ScacnPOeN8hms9kEAAAAAAB4XLDndwkAAAAAAAi6AQAAAADwIjLdAAAAAAB4CUE3AAAAAABeQtANAAAAAICXEHQDAAAAAOAlBN0AAAAAAHgJQTcAAAAAAF5C0A0AAAAAgJcQdAOAlwQFBcljjz3mkX0tXbrU7E//9XV6nOPHj/foPkt7/jfffLO0bNlSqoM+jj6e5Y033jDH88MPP1TL419wwQXmEgi88f7x1/Oufz/0fDgqKCiQ//u//5NmzZpJcHCwjBgxQgJBaecikP6uAvBvBN0AAoYVKDlekpKS5MILL5RPP/20pg/Pr6xcudJ8CU5NTRV/snnzZnPce/bsEV/jy8fmaf76/vEF//rXv+SZZ56RK6+8Ut5880257777avqQfN6cOXPM338AqCmhNfbIAFBD/vKXv0irVq3EZrPJ0aNHzZexSy65RD788EO57LLLeF1cDJoef/xxk/2tW7dujZyzV199VYqKitwObPW4NXvpTpZ827ZtJqvoTeUd2xdffCG1iS+8f/zBn//8Z5kyZUqxdV9//bU0adJEXnjhhRo7Ln8MuhMTE4tVq6jzzz9fcnJyJDw8vMaODUBgIOgGEHCGDRsmvXr1si/feuut0rBhQ3n33XcJuv1IWFiYV/evP8rk5uZKVFSURERESE0iKAhMoaGh5uIoJSWFHyo8RH9Ii4yM9NTuAKBMlJcDCHiaadPAyvnLbVZWlkyePNmMndSgq127dvLss8+aYMxRXl6eKfFs0KCBxMbGyh/+8Ac5cOBAsW2WLFliytkXLFhQ4ny/88475rZVq1a5/Vp8//338vvf/17i4+MlOjpaBg4cKCtWrCh1LOTOnTvtmUXdfsyYMZKdnV1sW8363HPPPSYrZD2XgwcPFhufrv8+8MAD5rpWDFil+s5l0QsXLpTOnTubc9epUyf57LPPXHpOeu50nGqdOnVM+b+eWz3Hzkob0/3ee+9Jz549zbHHxcVJly5d5MUXXzS3aUXDVVddZa7rkALruK3xnLovrXT4/PPPzY8y+p545ZVX7Lc5Z8mUnr8777xT6tevbx7vpptuklOnTrk0tt9xnxUdW2ljizX4sn4w0sChW7duptzYkb4muh993/7jH/+Qs846y7wevXv3ljVr1khN8OT7R9+bt9xyizkH1nZafu2qt956S/r06WM+O/Xq1TOZz/KqCvLz8+XRRx817zH9DOl79LzzzjOfb2flvRfV6dOnTba/bdu25vXT99C5554rX375ZanjmK3XUh/r559/tp83fb76b2mZb60o0Nv0B8WKxjXPnTtX/vSnP0mjRo3M89LP/v79+0tsP2/ePPO89POhfyf++Mc/mtfBkb6vY2JiZNeuXTJ06FCzv+TkZFNl5Pj3s6wx1dZzragk/PXXX5dBgwaZvxP6+nfs2FFeeumlEp8zPV/ffPON/ZxZn6WyHt+d56jr9e+VXtf/B9x///1SWFhY7nEDCDxkugEEnLS0NDl+/Lj58qeBy8yZMyUzM9N8sbLobfqlU7/gamDTvXt3E4xpsKBfshy/4N52223my/v1118v/fv3N+Wfl156abHH1C95Gry//fbbMnLkyGK36ToNhvr16+fW89DH0ay9fjmcOnWqydpYX0K//fZbE0w4uvrqq02QM23aNPnxxx/ltddeM19W//a3vxX7Ivn+++/LjTfeKOecc475our8XEaNGiXbt283X+T1POiXUqVfOC3Lly+XDz74QMaOHWuCjhkzZsgVV1wh+/btM8FFWTTov+iii8x2GvzrF/X//Oc/5rlWRIOV6667ztzfek5btmwxP0JMnDjRBFS6Tz0WDS46dOhgtrH+tcrIdR8aSN9+++3mh5byaMMv/RFDgyO9r37h37t3r/3LvKtcOTbn86TvKf0hRY9BX1cNFPT103HS+nydf9jJyMgwz0uP6+9//7t5HTUo8nbFgDNPvX90aIi+R63Ga3p/7c2gn9f09HS59957yz0ODXj1ddPPrAaDWk2gP2Lpe+3iiy8u9T66X/3c6HtE3x96Tv/5z3+awHL16tXm74Qr70Wlj62fRf37oZ9V3bc25tPP5pAhQ0o8tj4//Sw89dRT5u+V3lfptgMGDDB/R5zHd+s6PX+XX355ha+L7lfP5YMPPmj+Lk6fPl0GDx4s69evN8Gn0iBYf6zTH2308fU10B8S9HmtW7euWAZeA0/9QVBfI32/6Y8m+ndKG8Hp+fYE/bzpDy36t1p/NNUhQvqe0WEn48aNM9vo85gwYYIJih9++GGzTn+kKYu7z1Ff+759+5oftr766it57rnnzN/zu+++2yPPEUAtYQOAAPH6669riqXEJSIiwvbGG28U23bhwoXmtieffLLY+iuvvNIWFBRk27lzp1lev3692W7s2LHFtrv++uvN+qlTp9rXPfTQQ+axUlNT7etSUlJsoaGhxbYrzZIlS8z+9F9VVFRka9u2rW3o0KHmuiU7O9vWqlUr25AhQ+zrdN9631tuuaXYPkeOHGmrX7++fXnt2rVmu3vvvbfYdjfffHOJ5/LMM8+Ydbt37y5xrLo+PDzcfo7Uhg0bzPqZM2eW+zynT59utnv//fft67Kysmxt2rQp9vzV6NGjbS1atLAvT5w40RYXF2crKCgoc//z5s0rsR+L7ktv++yzz0q9TR/P+b3Us2dPW35+vn393//+d7N+0aJFxc5Haa+v8z7LO7aBAweai/N5euutt+zr9Dj69etni4mJsaWnp5t1+vrodvo6nzx50r6tHp+u//DDD201wRPvn1tvvdXWuHFj2/Hjx4vd/9prr7XFx8ebz0JZduzYYQsODjafgcLCwmK3OX6enM+7vrfy8vKKbX/q1Clbw4YNi32+XHkvduvWzXbppZfaymN9dh3p8XTq1KnYuldeecVst2XLlmLvh8TExGLvsfL+tjRp0sT+vlH6GdT1L774on1/SUlJts6dO9tycnLs23300Udmu0cffdS+Th9T102YMKHYedXnq6/tsWPHij2283veet/q56y8c1Haa6x/E1u3bl1snZ4vx9fR+blbj1+Z5/iXv/yl2D579Ohh/i4AgCPKywEEnNmzZ5tMlF40Q63lvJpt0sya5ZNPPpGQkBCTfXSk5eYaF1jdznU75bxdaVk2LT3WMun58+fb12lJp2Z+HLPsrtDs044dO0x2/cSJEyZzrxctidfs2rJly0o0GbvrrruKLWtZrN5XM2zKKt/VTJEjzRK5SzNkmu2xdO3a1ZTYama1PHo+GzdubDozW7T094477qjwMTUDpc/fsTzXXZox1syVq/S4HDPFmt3SjJv1vvAW3b+WAWs21aLHoe9DzYJqhYKja665xpRPO772qqLXo6ZU9P7Rz+B///tfGT58uLluvf/1oq+fVrNoxrgsWrqunw8tFXdukFdehYL+TbDG1+v9T548aT6/OhzB8fFceS/qNlr2rJ/jqtIqFi1R18y2RStz9Hy4+rdF/z5pVtyin0H9LFrvZc3CawZc/z44joPWSpj27dvLxx9/XGKfjlO/WRUJWqKvGWFPsDLwjhVMOsRG3ye67K7KPMfS/q766ucKQM2hvBxAwNFSTsdGahq49OjRw3wh1DG9+qVaS4S1tNnxS6hjua/ebv2rX9odAwRVWlmyfmnTkkX9YqwlsEqva/llmzZt3HoO1hf10aNHl7mNful0DLSaN29e7HbrNh2DrAGN9Vw08HTk7rGV9ljW4zmPd3amx6CP5xz4VFTmrfSLspbGa8m9dnfWEmENRrTE1VXOz70iOh7XkZawaqDi7Wm/9DzpYzsHjM7vT1de+7Jo6eyxY8cqdXwanDqWi3v6/aPHpWX0Ok5dL6XR4Kksv/zyizl3OgbYXTpuXkuIt27dasZll/beceW9qCXWWvZ99tlnm7HrepsO69AfGNylAbz+AKHDCJ544gn73xZ9bB1uUpn3sn4G9bNovZet91RZf9t0SIAjPb+tW7cutk6fq/LU50NLvrVkXfthOPen0L9/Ou7eHe4+Rw3Mnd/nrvydAxB4CLoBBDz9cqjZbh23p8GsjhH0Fs0m6ZhObRamWe/vvvtOZs2a5fZ+rCy2ztdrjSN1pgGgcyBUGufGcJ5QnY9l0fHpWgGgGT6tRNCLjnHXc+7cYMyVzJm3VWezpcq8HtpEy90fISwtWrSoUmBV0fFa73/N4pb1w1NlgteKaGWMjpvXxlna30Hfc3qsOvZXA3l33os6jl/vs2jRItO8TceK6xj3l19+2VTeuEv3reP6tXmaNm373//+Z4J/b091VxVlVRW48tnQc6dVPRoMP//886Znhv5gqpl5PY/uTifoyfcpADgj6AYAEVMiqrQ01woatARSGyU5Zrs1u2Xdbv2rX+70C6BjdkSbapXm2muvlUmTJpkmUtoMS0uCtfTXXVZmXTPUWorrCdZz2b17d7GslzbrcuZOkzB3j2HTpk0muHJ8jLLOpzP90q0ZP73oc9GgQzuQP/LII6Vm0KtKf6TRH2ws+v45fPiwmffdMfOlWVlHWmKr2zly59j0PP3000/mOToGVc7vz6rQ8vXKlupX9ONFVV8Ha6YADc4q8/7Xz4+eO50bvawfrUqjQ0M0e6tDURyfg2Zb3X0vqoSEBNO0Sy/63tFAXBusVSbo1ky5nhfNcGtjL838aubcVc5l7voZ1M++9eOF9Z7Sz6Jz9lzXOb/n9DlrmbWV3VbaQE9Zsw5YFRfOnw/nSo3SaNM0/eFSf1xwrIworZO8q+83d58jALjKd3/+BIBqoiWimmnSL8lWea4GTfqF3jkLrRkU/QKnZaPK+le7KzvSjrml0U7Neh/NmOmXY/2ibHVvdod2LNfAQTvmWj8UOKpMWbA1lnnOnDnF1mt3d2c6BVBpX5arSs/7oUOHio171+ChrBJiRzo+3ZEGo1bAYE055unj1uNyLDHWbsr6A471vlD6OukYe+f7OWfz3Dk2PU9HjhwxPQEs+rj6WmmFg45rrSotndWAtjIX7aZdnqq+Dpph1G7mOq5bf6Rx9/2vmWp9f2iJt3NGtLzsv5XZdNxGO547T/fnynvReRt93TQYL216PFdoLwEdKqNl7dqBW7Pd7mT7//3vf5sfGS36GdQfhqz3sg7J0Qy+ZuIdj1Gz+NqZ3XmWA+X491PPmS7rD42aoVYaxOo5df58OP8NcvW10JJyrSgo7f3mynutMs8RAFxBphtAwNEvUFZGUMd96jhIzfJMmTLFZI6VZqc0g6lTzGiZrM6BrIG5loJqkzQr06xZMv2iq18S9QufTj+0ePHiUrPDjmWgVqMwa/ylu/RLvJaj6hdiLYfXTJmO39TpzDTTo89DM0HuBvIayOgPBhoQWFOGWdkpx2yRbqv0/Gj2Xr9I6zmzgqnK0mmY9Iu5nqO1a9ea8dE6TZI2U6uIZge1sZVmqJo2bWqyZRqE6mtk/Zii1/XLuk7jpK+Xzu1rzfNbGZqx1gBCx+tqJkzfBzrXsk5h5Hhc2mxJz61O77RhwwZTduz8Y4s7x6YN3DRrqqXOep40c6hBko5x1dfPuReBr/HE++fpp58273XN6ur7Rsdn6+uvDc20SkWvl0WDW31s/fxp4yudxkzPt85drr0crOm4nGnPB81y67R/GoBpVYgGaPrYjj9+ufJe1PvotG96LjTjrU289DV0bD7mLv3c6A+Ael4cpwJ0hR6Dvnf1b4lOk6XvIz1Pem6Vvka6T71df9TRv3vWdFr6/nOerkx/tNHmjFr+r6+R/t3VRmQ6JZ41DlrHXOv89Hpu9O+L/l396KOPyh2Pb9Fx8lY1gU6Fp+f/1VdfNZ8X5yoSPcf6g9iTTz5pnpNuU9pYd3efIwC4rFgvcwAIsCnDIiMjbd27d7e99NJLxaYKUhkZGbb77rvPlpycbAsLCzNTdOlUR87b6dQy99xzj5mWqU6dOrbhw4fb9u/fX+ZUUTrlUL169cy0Ro7T0pSnrKl11q1bZxs1apR5bJ2OTKehuvrqq22LFy8uMdWONU2P8/lwnLZJp+caN26cLSEhwUw9NWLECNu2bdvMdk8//XSx+z/xxBNmmiGdeslxP3pd91HRFFll2bt3r+0Pf/iDLTo62kx5pNMv6TReFU0ZNn/+fNvFF19spvzRaYmaN29uu/POO22HDx8utv9XX33VTCkUEhJSbJ+6r7KmcCpryrBvvvnGdscdd5jXU8/XDTfcYDtx4kSx++qUVA8++KB5LvqcdEojnQ6rtPNR1rE5T12ljh49ahszZozZrz7fLl26FJtiyXHqJX3fOivr/VldPPH+0XOg2zZr1sx8Rhs1amS76KKLbP/4xz9cOoZ//etfZoon/ezoa6jn+Msvv7Tf7nze9bP/17/+1RyL3kfvq9NJVea9qNMR9unTx1a3bl1bVFSUrX379rannnqq2BR0rk4Z5khv03N64MABt/62vPvuu2ZaQz1mPR79LOhn0dncuXPt50z/Tuh73vmx9Hzo38JffvnFnAd93+u0avp8nKdo079LV1xxhdlGXwM9T5s2bXJpyrD//e9/tq5du5q/4y1btrT97W9/M6+p89+1I0eOmOcTGxtrbrNe07L+rrrzHJ2VdpwAEKSnwPUQHQBQVVoGrNk0zdD885//9PkTqg2htLu7lsTfcMMNNX04AMqhn1XNWmvFjSuWLl1qqnq0CZvjVH1VoRUYmrUvbegLAAQixnQDQDXTOYJ1zKmWgvoabe7mTMtMtZxdmzwB8F1aoq4/kvni3xYACGSM6QaAaqINl7TjtI4j1WyUJ5pdedrf//53M0ZYM1/amMma7kjHEOuUPAB8jzaT08+tzh+ufRAqMyMCAMB7yHQDQDXRRj533323aeKjnYJ9kTaC0wZQ+sPA5MmTTRM1ncJo9uzZNX1oAMqgpdza/Es76et0hNrEDADgOxjTDQAAAACAl5DpBgAAAADASwi6AQAAAADwkoBvpFZUVCSHDh2S2NhYCQoK8tZ5BgAAAADUIjr7dkZGhpkKVmd6KUvAB90acNORFwAAAABQGfv375emTZuWeXvAB92a4bZOVFxcXKVOMgAAAAAgsKSnp5sErhVTliXgg26rpFwDboJuAAAAAIA7KhqmTCM1AAAAAAC8hKAbAAAAAAAvCdige/bs2dKxY0fp3bt3TR8KAAAAAKCWCrJpn/MAH/weHx8vaWlpjOkGAAAAAHg0lgzYTDcAAAAAAN5G0A0AAAAAgJcQdAMAAAAA4CUE3QAQYAoKi2TXsUzzb2nXc/MLXLq9tO3cvc35eEpbBgAA8GehNX0AAICq0eB038lsaZ4QbZbLu54cHylXv/Kd/HQwTbokx4kEBclGp+tRYSGSc7qwwttL287d2565qps8MP8n+2M4Lz9/TXdpVi9K9p/KMc9Brx9KyzXPQ//V5xYawu/HAADAd9G9nO7lAPwssNYg01p2JYh2vN4uKUa2pWSKP4kMDZbcgl+z3mUF7iHBQcUCcucgneAcAADUVCxJ0E3QDcBHlRZYd20SL+/feY59uTJBdLuGMbLtaKZ0aaL/czgTmDtctwe0Fdxe2nbu3OZp1n5LC9L1PP337n6SkplfLChvlViHTDkAAPBqLEl5OQD4WPbaKgcfNWdlicBal7/ffdL8q3R9RUG04/WuTePl/TvOsWd/yypBd+X20rZz9TYNeie9v8F+fM9c6VBW7rRcXqbbkbVsbeu4Ts9Tz6cWS15BUbH9nZ0UIx/c3U8Op+eZ5dJK2cmSAwCAqqg1me7s7Gzp0KGDXHXVVfLss8+6fD8y3QCqS1lBtXP2Wpefu7qbDHlhmf2+VmBtBc32bV0Iop2v+8oY6PJ+dHAuoS9tTLeuu2/uetl0KL3MTHdEaLAJtMsTHhIk+YW//q+wtAD/7AZ15MXrepisOOPJAQBAwJaXP/zww7Jz505p1qwZQTcAnw+ynYPqN8f0ltGvr7Evf3nf+TL5/Q2lBtalBaiBSs/D7uNZ5nppY7obx0XIFS+vMj9YlBaUu8O6vxXIWyXrmiUvLLKZceWUqwMAEDjSA6m8fMeOHbJ161YZPny4bNq0qaYPB0CAqijItkrCrX91vRVU922VUGxZg7cPxvYvFli3bhBjfyzn5UCl56Ftw1j7snVOHNd9fM95Jcrb95zIlnveWyfbj2YWC8LLy5JbperWOi1Z/92TX9mz5Fa5+v/GD5DI8Frxv1cAAOABNf6tYNmyZfLMM8/I2rVr5fDhw7JgwQIZMWJEsW1mz55ttjly5Ih069ZNZs6cKX369LHffv/995vbV65cWQPPAAB+DbjdCbJLC6qdlxWBddU5/kBh/du+cZx84hCMO5avO2bJR720UranZJVZqu4YcKvtKZky7MVv5cPxA+wZcEdkwwEACDw1HnRnZWWZQPqWW26RUaNGlbh97ty5MmnSJHn55Zelb9++Mn36dBk6dKhs27ZNkpKSZNGiRXL22WebC0E3gOriXN6t190NshXZa98Ixh0z447XP5l4vr183bFU3QrASytV330iu0QG3FHbBnVkxnU9zOME8tAAAAAChU+N6Q4KCiqR6dZAu3fv3jJr1iyzXFRUZMZtT5gwQaZMmSIPPfSQvPXWWxISEiKZmZly+vRpmTx5sjz66KOlPkZeXp65ONbh6/4qqsMHELhKa/DlmNXWYFrZ1zWNlw/u/nUd465rF8fmbo7jx/MLimTcOz+asnVXOXZOtzLiZMIBAPAfftlIzTnozs/Pl+joaJk/f36xQHz06NGSmppqstyO3njjDTOmu7zu5Y899pg8/vjjJdYTdAOBp7RmZK4E2Hr7oOe+se/n68kDTcaU5maBLTe/QC6fvcJkwl1t1ubYOd05E251Sw/0ZnkAAPiqWtFI7fjx41JYWCgNGzYstl6XtXFaZWhmXMvVnTPdAAIvuC43W+0QYDuWjVv7cSwdtxqn0dwssGnzNMembZoBdxzTrdfvnbtOdpwZI65KK0HfcSxLhs1Ybi9h1ynLnr+mu0SEhdAdHQAAP+TTQbe7br755gq3iYiIMBdtzqYXDeoB1F6lBdeljcHWZet6RQF2WU3PgLLGiVs+nXi+7EzJLLVzujOradv2Y1ly2awV5nqbBtEy87rfMR4cAAA/4tNBd2JiohmrffTo0WLrdblRo0ZV2ve4cePMxSoJABAYDc50WYOisrLVrgbYZLVRGfq+Ka1zumbBS8uEO9t5LNtkwbUE/YVrupv9MQ4cAADf5tNBd3h4uPTs2VMWL15sH9OtjdR0efz48TV9eAD8IKtdXil4acE0ATZqMiPunAkvbcy3VYJuZb/NPhrUkWev6iYns/OlX+v6zBMOAIAPqfGgWzuO79y50768e/duWb9+vSQkJEjz5s3N+GttnNarVy8zN7dOGabTjI0ZM6ZKj0t5OeC/ympYVlZWu6xS8NKy1WSw4WuZcO2IPv6dH2XnsbIz4BqEXz5npbmugfq8O8+R6IgwxoADAOADarx7+dKlS+XCCy8ssV4Dbe1GrnS6sGeeeUaOHDki3bt3lxkzZpipxKqz4xwAzyuv23dZt5U1RrvEbWem7WK8NWoDfW/rfOE6NVlFJeiO2iRGy/1D20uL+tGMAwcAwMP8csqwmkDQDdQMl4Nnp9t2Hcssdboux/3S4AyBEIC7Og7cok3YnruquxzLzJMmdaMIwgEAqKJaMWWYN1FeDtSsskrBK7qtrDHaFsrDUdvpe9x5HLgG4Tn5hTLh3R9l78mcMpuwWSXoik7oAABUDzLdlJcDNVY+XlYpeEVl4mSzgYrL0Ce+p+PAf50Krzwt6kXJjOt0HvBQOqEDAOAGyss9fKIAuKe8EvGqjOkG4PpnUDuh7z2RJc98vq3cRmyOzkqMkgeGdjDjwFsl1pFDabl8DgEAKAVBt4sIugHvqGjsNYCayYAfOJXtchAeERokeQU26dQ4Vu4f2o7pyAAAcMCY7gowphvwrorGXgOomXHgnZrEy0UdGsq2Ixkycs6KUucBt2jArX4+nCFj3vjBTEf2wd39pH3jeCpQAABwEWO6KS8HvIYSccC35eYXyMpfTkj9OuEyed4Gl0vQtQnb9Gt6mMA7JDiI+cABAAEpnSnDPHuiAJREUA3UHpUtQVedk+Nk4bgBZL8BAAElnSnDANR0ozQA/l2Cro3Y7nlvnWw/mimhQSJnqs1L2HQoXT7beEQiw4OlQUyEnMzOZ/w3AABnME93YaF1LgC4oby5tAHUjiC8feM4+eSe88znOykmXEa+tFJ2pJSe/R7/3rpiy2EhQbJqygWSnltE93MAQEBjTDfl5UClSscrmksbQO2dhmzCu+tkR0qmhAaLFBRVfL/mdSPk4Us7ysB2SRIZHrC/9wMAahnGdHv4RAGBxNXSccZ0A4HJ+uwnRIdKn79+XW4HdEfhISLz7uwn0RFh0qxeFHOAAwD8GkG3h08UEEiYYxtAZTqgH8vMk/jIMLn+te/kdAUZcJ1+TIN1ekIAAPwVjdQAVBpzbANwlZaLD+rQsNi6dY8MkctmLpc9J3PKvJ+VHdeKmn+v2iPJ8VHSon60aebGUBUAQG3CmG4y3UCpKB0H4KkpyPaeyJInPt4sh9PyKrxf83pR8sk950pMVDgvAADAp1FeXoHZs2fbu5dv376d8nIEBAJpADVZhj581vIyu587CgkSmXltd2nVIIbMNwDAZxF0e/hEAf6OebUB+FL2+8CpbLnn3R8lr4KZO5vWjZBH6HwOAPBBBN0ePlGAv6M5GgBfzH5/u+O45OQXyjOfb5X9qbnlZr+fu6qr1IkIk36tEyQlM5/5vwEANYpGagCKoTkaAF9swjakUyNz/ZKujeXrLSlyx1trS91W+67d+/5PxdbR+RwA4A9Ca/oAAFQP7Qas823r3LoagNMdGIAv0b9JgzokSZcm8bLxYJqEaKBdwX208/m8H/bLyB5NTAAPAIAvons55eXwczRHA1Ab/6Ylx0fKnhPZsuNohtw3d70U/DrDWKlCg0X+e1c/adcoTg6l5fLDIgCgWjCmuwJ0L0dtQHM0AIE09jszt0D+778b5HRR6duFhQTJ6UKbyZYvGNufih4AgFcRdHv4RAG+iOZoAAJNZk6+DJ2+TA5WMOf3w8PaS7OEaGlRP5ppxwAAXkEjNSAA0BwNQKCJiQqXxZMvkD/MWi7by5nz+6lPt9qvt06MltnX/47gGwBQIxjTTaYbfj4+mzHdAAJ5zu+J762TzYczXLpPcnyE/G98f0nPLWLcNwCgyigv9/CJAryN8dkAUPngO7+gyAy5mfDeepfud1ZilEwZ1pE5vwEAlUZ5OeBnNMOt098o/VeXWzeIqenDAgCfplVBbRvGmuudmsTLhe0ayIJ1hyQ6LFge/GBjmV3PfzmeI7f/57c5wbskx8mCcQNovgYA8DjX6lcBVNv4bNW1abxZBgC4P+b7xv4t5YrezWX9o0OkRb1Il+638VC6fLbxiCzZetR0SwcAwFMY0015OXwI47MBwDvl52nZp+Waf6ySwnLm+7aEBYvMuq6HDGyXJJHhobwkAIBSMabbRQTdAAAEBs1gL912TJ76ZLPsP5Vb4fYRoUGy9uHBJnsOAIAzgm4XEXTD08hWA4B/ZL9z8gtl3Ns/yP7Usuf8TowOkb9c3kVaNYhhyjEAQDEE3RWYPXu2uRQWFsr27dvpXg6PoAM5APjf3+3FW47KnW/9WOG2jePC5eU/9pROTerScA0AIATdLiLTDU/S6WoGPfeNffnryQPpQA4AfhB4j5i1XDa5ON93q/pRMueGnmS+ASDApbvYH4zuIIAXOpDrlF90IAcA/5l2bOH4c03JeWGRzcz5PWrOijKnG9t9IkeGzVguLRKiZNG4/nIyu8D8/df9AADgjO7ldC+Hh8diM6YbAPxfZk6+XDprhew9ke3S9mcn1ZH/jT+XbucAEEDSXYwlCboJusFYbABAGT+i7kzJlJFzVkrO6cIKz1GDOmHy5aTzpW4d1+YGBwAERixJHRQgYjLcWhKu9F9dBgAENq16at84TtY9MljeHNNbvntooIQGlb39sazT0v2JxbJ2z3ETsAMAoAi6AYex2Iqx2AAAR5HhoTKwXZI0io+R9Y8OkSbxEeWeoCte/l4G/v1r+WTDQdlyKI0AHAACHOXllJfjDMZiAwBckZtfIH+YtVy2p2S5tP1ZDaJl1nW/o9s5ANQyjOn28IkCAABw/KHW6naulxU7j8tfP91a7glqHBchn048lzHfAFBLMKYbtfqLjs6HzXg5AEBNjvdu2zDWjPnu1CRebjm3lXRsFFPufQ6n55kx36t3HZMdRzP4/xgABAi/Ly9PTU2VwYMHS0FBgblMnDhRbr/9dpfvT6bbv2igPWrOyl/nwW4SLx+M7c+8qAAAn/l/1OZD6XLFSyvktAt91HSe748nnCsxUeHVcXgAAA8LmEx3bGysLFu2TNavXy/ff/+9/PWvf5UTJ07U9GHBS+gyDgDw5ex312Z1Zd0jQ6RlQlSF2+89mSOdH/9SPly/34wTBwDUTqHi50JCQiQ6Otpcz8vLE03c+3nyHi50GTeZ7qbxZhkAAF+imeuvJl9gxnzn5BfKhHfXyd5ypqKc8N5PEhr0k/z37n4SHREmrRLrUMUFALVIpTLd+/btk2+//VY+//xz+fHHH02wW1mapR4+fLgkJydLUFCQLFy4sMQ2s2fPlpYtW0pkZKT07dtXVq9eXaLEvFu3btK0aVN54IEHJDExsdLHA9/PImhJ+deTB8oHd1NaDgDw7THfmvlePHmgfHnf+dI6sezsd4FN5PI5q2TIC8vk99OXkfkGgEAMuvfs2SMPPvigtGjRQlq1aiUDBw6UYcOGSa9evUwd+5AhQ2TevHlSVOTCICYHWVlZJmDWwLo0c+fOlUmTJsnUqVNNgK/bDh06VFJSUuzb1K1bVzZs2CC7d++Wd955R44ePerWMcD/vsi0bhBDFgAA4FcB+Cf3nC9tygm8LTuPZcmQ57+RTQdSabgGAIHSSO2ee+6RN9980wS7mpXu06ePyUxHRUXJyZMnZdOmTSbz/d5775ly79dff1169+7t/sEEBcmCBQtkxIgR9nWa2dZ9zZo1yyxrUN+sWTOZMGGCTJkypcQ+xo4dK4MGDZIrr7yy1MfQrLxjZl4Hv+v+mDIMAABU11Rj+QVFJqC+7/0NUtEXMRquAUAANFKrU6eO7Nq1S95//3258cYbpV27dqaBWWhoqCQlJZkgVzPRW7ZskWeffVb279/vkSeRn58va9euNd3J7QccHGyWV61aZZY1q52RkWGu65PVcnU9vrJMmzbNnBjrogE3AABAdWa9dZqxEb9rKgvH9nep4VrPpxZTcg4AfsqloFsD1fr167u0w9///vcyatQo8YTjx49LYWGhNGzYsNh6XT5y5Ii5vnfvXjnvvPNM2bn+qxnwLl26lLnPhx56yATn1sVTPxAAAAC4S4Pvzo1jK/xSlldQJLO+3iFbDqUxvzcA+Bm/716upe46XZirIiIizAUAAMAXMt8Lx59rpsRMiA6V3k8tLnOO71lLd5lLh0YxMuO639HlHABqa9Ddo0cPM/bama7T7uJt2rSRm2++WS688MIqH5x2Idcx4s6N0XS5UaNGVdq3Nm7Ti2bSAQAAarpBqNI5vi+dudyUlJdly5FM0+W8Wd0I+fOlHWVguySJDPf7PAoA1FpuTxmm5eM6vlvHeWtgrZeYmBj55ZdfTMOzw4cPmzHXixYtqvLBhYeHS8+ePWXx4sX2ddpITZf79etXpX2PGzdONm/eLGvWrKnycQIAAHhqju/Fky+QzyaeJ22Tfg3Ey7I/NU/ufHuddH7sczmeUfY84ACAmhVamXHWkydPlkceeaTY+ieffNKMr/7iiy9MU7UnnnhCLr/88gr3l5mZKTt37rQv67RfWi6ekJAgzZs3N9OFjR492kxNpqXk06dPN9OMjRkzxt1DBwAA8IvMd/vGcfLpxPNk6bYUue3fa8vdvqBIpNdTS+SHhy+UxNjoajtOAIAHpwxzpB2/taO4lpE70sBZs9LanGzr1q0m6211FS/P0qVLSy1F10D7jTfeMNd1urBnnnnGNE/r3r27zJgxw0wl5qny8u3btzNlGAAA8Mkpxi6ftVx+Plzxdyo14cKzZHCHJOnUpK4J3gEANT9lmNtBt3YO1wD4pptuKrb+3//+tzzwwANmvLWWbQ8cOFCOHTsmteVEAQAA1PTc3ne9tUb2n8qr8D5N6kbIK3/sKe0bxxN8A0ANx5Jul5frlFx33XWXyXZrNlvpuOjXXntN/vSnP5nlzz//3GSkAQAA4Jm5vdWX910gl89eIduOZpZ7n4OpeXLZrJXStF6kfHbPeWasOACgZrid6VZvv/22Kfnetm2bWW7Xrp0Jxq+//nqznJOTY+9m7qsoL/fsL/A61UnzhGh+TQcAoJr+v6tTjF3y4rdyKD2/3O3Dgn/tik7gDQB+Ul5e21BeXvX/8Y+as1J+OpgmXZvEywdj+xN4AwBQTXLzC2Twc0vkQFr5gXeDOmGy5P4LCLwBoAZiyUp32NDy8rfeestc1q1bV9ndwM/pL+0acCv9V5cBAED10Pm5v5p8obRpUH7X8mNZp6Xz41/KUx9vkg37TpofzQEA1cPtMd0pKSly7bXXmq7jdevWNetSU1NNB/L33ntPGjRo4I3jhI/SknLNcJtMd9N4swwAAKo38P7s3oHmh++kmHBZvvOEPPnRz3IgrWTDtVe/3WsuZyVGy6JxAyQlM5/hYQDgZW6Xl19zzTWya9cu0628Q4cOZp12K9cpvnQasXfffVf8AWO6PYcx3QAA+N7/mz/bdETGv1t2NWJo8K9zfHdJjpPnr+kurRLrMEQMAHxhTLfu9KuvvrJ3LresXr1aLr74YpP19ieM6QYAALXRjqMZMuSFZS5v3y4pRhaNH2Ay5wCAGhzTXVRUJGFhYSXW6zq9DQAAADVPM9edG/861ZgrtqVkysUvLJMth9IY8w0AHuR20D1o0CCZOHGiHDp0yL7u4MGDct9998lFF13kyWMDAABAFeb3Xjj+XPls4nlydsMYl+6z71SODJuxXC6ftZzAGwBqKujW+bk1jd6yZUs566yzzKVVq1Zm3cyZM8Vf6Jjujh07liiTBwAAqE2Bd/vGcfLJPefJ15MHyqKx/Vy638+HM+TrLSkE3gDgAZWap1vvouO6t27dapa1odrgwYPFHzGmGwAABFKDtZGzV8jGQ+kubd88IUo+mXAu83sDQHU2UqttCLoBAECgBd47UzJlwrvrZEdKZoXbh4UEybo/DybwBgBvBt0zZswQV91zzz3iTwi6AQBAoAbfu49nycT31snmwxnlbtugTph8Oel8OZldwLzeAOCNoFvHbLsiKCjIzOHtTwi6AQBAILMy3+PeXiu/HM8uc7sgHWLI1GIAYEd5uQuN1PRSWFgo27dvr/DXCQAAgNoefH+745iMeeOHCrdtXjdCHhneWfq1TpCUzHyy3wACUjpjuj17ogAAAGo7dxutWdnvrk3i5YOx/U23dAAIFOkuxpIu/WV8+umnJTu77HIjR99//718/PHHrh8pAAAAfIIGzQvGDZAv7ztf5t9Z8fRi1hjFnw6myb6Trn1XBIBA41LQvXnzZmnRooWMHTtWPv30Uzl27Jj9toKCAvnpp59kzpw50r9/f7nmmmskNjbWm8cMAAAALwbebRvGSq9WCbJp6hC59ZwWFd4nLFgkKSac1wQAqjJl2IYNG2TWrFkyf/58k0YPCQmRiIgIewa8R48ectttt8nNN98skZGR4i/8obxcS7301+PmCdGUbQEAgGr/HnLZi9/I1pTyM9mNYsNlzg2/k7TcAunXur5EhodW2zECQK0a011UVGQy23v37pWcnBxJTEyU7t27m3/9ka8H3fo/ulFzVpqyLcZLAQCAmrDjaIYMeWGZy9tHhAbL2ocvYm5vALWaq7Gk2z9BBgcHmyBbL/A+zXBrwO04Xqp1gxhOPQAAqDatEuuYH/+t7yQVySsokkHPfyNf3Hsec3sDCHgB22JSpwvr2LGj9O7dW3yZlpTr/+RU16bxZhkAAKC6x3lrd/I3x7j+vSklI1+6P7FYBj33jana0+o9AAhEbpeX1za+Xl6uGNMNAAB8bdibuz6beJ60b+yb37UAoManDEPN/7qsJeXMfQkAAHwh461TinU5U4nXND7MpfteNvNb2bDvJBlvAAGHTLcfZLoBAAB8tRIvv6BIfv/ity7fr1PjWFk0/lySCQD8XrVluvWBFi5cKFu2bKnqrgAAAOBnlXhtkmKkS3Kcfb7uivx8OEPeWrVXthxKI+sNICC4nem++uqr5fzzz5fx48ebKcO6desme/bsEd3Ne++9J1dccYX4EzLdAAAAnsl6J8WEy6iXVsr2lCyX7tc2qY58OP5c5vQG4Je8luletmyZnHfeeeb6ggULTLCdmpoqM2bMkCeffLJqRw0AAAC/zXrHRIXLJxPPN2O+H7m0Q4X325GSJUOeX0LWG0Ct5nbQrVF8QkKCuf7ZZ5+ZzHZ0dLRceumlsmPHDm8cIwAAAPwoAG/bMFZu6NtcIkKCKtx+f2q+DJuxXEbMXkG5OYBaye2gu1mzZrJq1SrJysoyQffFF19s1p86dUoiIyO9cYwAAADwM5HhobJh6sXyxOWdXNp+06F0eXPlnmJZb/1317FMgnEAfi3U3Tvce++9csMNN0hMTIy0aNFCLrjgAnvZeZcuXcRfzJ4921wKCwtr+lAAAABqbeB9XZ/m8s9vd8uek9kVbv/Ex7825m3TIFqmX9NDHlqwSTYeTJOuTeLNVGVMnwogYKYMW7t2rezbt0+GDBligm/18ccfS7169aR///7iT2ikBgAA4F2ZOfnS86nFklfwawa7Mr6ePNCMGweAWt9I7S9/+Yt06NBBRo4caQ+41aBBg+Srr76q/BEDAACgVtIGaxseHSL/Gt1LOp+ZXswdXZvGS/OEaK8cGwD4XKY7JCREDh8+LElJScXWnzhxwqzzt3JtMt0AAADVR8dpbzuSIZfOXO7S9s9f1UX+0L0ppeUAAifTrTF6UFDJTpQbNmywdzUHAAAASqPjsjs1iZePxrs2JHHSvI2Smp0rO45mmIvVZA0Aal0jNR2vrcG2Xs4+++xigbdmtzMzM+Wuu+7y1nECAACgFmnfOF66JMfJxkPpFW476Lllkp77azVlx0Yx8r8J55H5BlD7gu7p06ebLPctt9wijz/+uEmjW8LDw6Vly5bSr18/bx0nAAAAalnGe8G4AbL7eJbsPZElt/17bZnbWgG32nwk05Sna7YcAGpV0D169Gjzb6tWrUyH8rCwMG8eFwAAAAIg8G7bMFZaJdYx04L9dDDNpfvNWLxVBpzVQEb9rqlp0gYAtW7KsKKiItm5c6ekpKSY647OP/988Sc0UgMAAKh5ufkF8vvpy2TPyRyX76ODHTdOHWLmA993Mtt0OGcubwC+Fku6nOm2fPfdd3L99dfL3r17Tbm5Ix3n7W/dywEAAFDzDqXlFgu4NaCuKDOkt7+2bLd8svmIbD+aabLlH4ztT+ANwKe43b1cm6X16tVLNm3aJCdPnpRTp07ZL7oMAAAAuEuz1Bo0q7OT6kj7RjEu3W/6kp0m4FZanr5i53E6nAPw7/LyOnXqmOnB2rRpI75g//79cuONN5pS99DQUHnkkUfkqquucvn+lJcDAAD4Bp0OTMvEC4tsMuSFZW7fPyIkSPIKbdI5OU5euKa7GStOuTkAv5unu2/fvmY8t6/QQFs7q2/evFm++OILuffeeyUrK6umDwsAAABu0gC5dYMYe2M11bFRHQlx8f4acKtNh9JN0D5i9gqy3gBqnNtjuidMmCCTJ0+WI0eOSJcuXUp0Me/atatUp8aNG5uLatSokSQmJpoyd83IAwAAwD+Dbx2bXZWstxV8bz2cLtERoTRZA1Bj3M50X3HFFbJlyxYzX3fv3r2le/fu0qNHD/u/7lq2bJkMHz5ckpOTTSO2hQsXlthm9uzZZh7wyMhIk2lfvXp1qftau3ataeTWrFkzt48DAAAAvp31bl0/0u393PGftTLouW9k5OwVsuNoBplvAL6f6d69e7dHD0BLwbt162aC+FGjRpW4fe7cuTJp0iR5+eWXTcCtpeRDhw6Vbdu2SVJSkn07zW7fdNNN8uqrr3r0+AAAAOAbWe/k+Ei5bOa3svNYtltd0dXGMyXndDgH4BfzdHuLZroXLFggI0aMsK/TQFsz6rNmzTLLOi+4ZrK1zH3KlClmXV5engwZMkRuv/1201StPLqtXhwHv+v+Khr8DgAAAN+Yz/vSF7+RX078GkxXxteTB5osOgD4ZCM19Z///EcGDBhgSsJ1vm6lGehFixaJJ+Xn55uS8cGDB9vXBQcHm+VVq1aZZf3N4Oabb5ZBgwZVGHCradOmmRNjXShFBwAA8B+R4aHy5+GdK33/iNBgkzEHgOridtD90ksvmXLvSy65RFJTU80YalW3bl0TeHvS8ePHzf4bNmxYbL0uayM3tWLFClOCrmPBdVy5XjZu3FjmPh966CHzS4R10SnHAAAA4D/6ta4vkaGVyh1JXkGR7Dnhenk6AFT7mO6ZM2eacdNaAv7000/b1/fq1Uvuv/9+qW7nnnuuKTl3VUREhLlocza9WD8aAAAAwH+y3esfHSIrfzkhdaPC5MqXV4nr3wZFJrz7o8y5oSfzeAOoFsGVaaRWWpdyDWQ9PT+2Tv8VEhIiR48eLbZel3V6sKoYN26cmdt7zZo1VTxKAAAA1ETgPahDQ/ldywT5aeoQSY51PZe0IyXLNFW79MVvJTMnX3Ydy6SrOQDfCbpbtWol69evL7H+s88+kw4dOognhYeHS8+ePWXx4sX2dZrV1uV+/fp59LEAAADgn2KiwuXN2/q7fb9tKZnS/Ykv7VOKFRQWmQtBOIAaLS/X8dyaJc7NzTVNzHTO7Hfffdc0KHvttdfcPoDMzEzZuXNnsUy6BvUJCQnSvHlz83ijR4825et9+vQx48Y1oz5mzBipCsrLAQAAag+dz7tz41jZdDjDrfsVnKlL1ynFdqZkyv/N/0l+OpjG1GIAanbKsLffflsee+wx+eWXX8yydjF//PHH5dZbb3X7AJYuXSoXXnhhifUaaL/xxhvmuk4X9swzz5jmadoobcaMGWYqseps8w4AAADfpllqDZw1Uz32nXVu3//1m3vJmDd+KHNqMd2/zhfePCHazB8OILCluxhLVmme7uzsbJOpTkpKEn9F0A0AAFD7pGblyqUzVsjBtFyXpxJb+/BFct2r35usd5cmcbJg7AB7cK0B96g5K8mCA6ieebot0dHRfhtwa3l5x44dpXfv3jV9KAAAAPCwunUi5Zv/u1Beu6mny1OJLdl6THLP1Jtn5BRIbn6B/XbNcGvZudJ/dRkAXOF20H3ixAkzplsDVu0urmOvHS/+gu7lAAAAtZtmqZvUjXJ5+wlz18uOlExzfc/JbOn51GJ74K0l5V2bxJvrXZvGm2UA8EojtRtvvNE0PtPx2w0bNpSgoCB3dwEAAABUi6qMvdbs9/e7T8qANokms/3+nefIobRcxnQD8G7Q/e2338ry5culW7du7t4VAAAAqPau5i3qRcreU66N7XbWrlG0mU7MjPNOjpMF434b5w0ArnD7L0b79u0lJydH/B1jugEAAGo/DZBn3/C7St9/xKxVJuBW+u/iLUdlx9EM01gNAFzhdvfyNWvWyJQpU+TRRx+Vzp07S1hYWLHb/W3aLbqXAwAA1G4aIF8+a7n87OYc3uXp0iReFoztT9YbCGDpLnYvd7u8vG7dumbngwYNKrZeY3cd311YWFi5IwYAAAC8lO1eNP5c2X08SwqLfs03hQQHSb3oEHl5yS/y2sp9bu9z48E0s7+2DWO9cMQAahO3g+4bbrjBZLffeecdGqkBAADAbwJvxwBZu5J3/8uX9inCKuO+uetlIWO8AXg66N60aZOsW7dO2rVrJ/4+plsvZOYBAAACj3Ylr0rArTYdSifbDcDzjdR69eol+/fvF3/HPN0AAACBq2+rBIkM/e2rcGglZ8HdmZJpb6qm2fNvtqXY5/YGgEo1Ups3b5489thj8sADD0iXLl1KNFLr2rWrX51ZGqkBAAAEJg2OV/5yQhrHR5qpxZZtPy53vLXW7f20bVBH5t11jvR7eqnknC6UiNBgWfvwRRITFe6V4wbgX7Gk20F3cHDJ5Lg2UPPXRmoE3QAAADAdzmd+Kz8fyazUyWgcFyGH0/Psy03rRspnE8+TlMx8aZ4QTZdzoBbyWvfy3bt3V/XYAAAAAJ+y72R2iYC7ad0IOZD6WyBdHseAWx1IzZWeTy2WvIIi6dokXj5gejEgYLkddLdo0cI7RwIAAADUEM1Gd24cK5vOzOWt473jo10PukujAbf66WCaCepbN4gxGXW9TvYbCBxuB93q0KFDsnz5cklJSZGiouJdH++55x7xB3QvBwAAgOOUYgvHn2saox1Oy5FGcZEybMZyj5ygiBCRX1IyJSkmXK5/bbUJwsl+A4HD7THdb7zxhtx5550SHh4u9evXN+O47TsLCpJdu3aJP2FMNwAAABxpNnr38SwzD7dOC9Y0PkIOpFU+420JDwmS/MLfvnp/PXmgyX4D8E9eG9P9yCOPyKOPPioPPfRQqU3VAAAAAH8OuEfNWWmy0REhvyaXjmVWPeBWjgF3lybxpsQcQO3ndtScnZ0t1157LQE3AAAAah0db60Bt8o7EyTneWFynuev7kZHcyBAuB1033rrrWaubgAAAKC20eyzjrcuzdlJdaq079aJv96/ZUK0NIgJk13HMk1mHUDt5vaYbp2H+7LLLpOcnBzp0qWLhIWFFbv9+eefF3/CmG4AAACUN6a7c3KcvHBNd2lWL0queuU72XgmE+6uEP0ufea6Fq7rl/B2STGyaPwAiQyvVH9jALVxTPe0adPk888/l3bt2pll50Zq/oLu5QAAACirk3nbhrGycNyAEtN7zbvzHPnDrOWyPSXL7ZPnWKVuZb22pWTKsBe/lU8nnkfgDdRSbme669WrJy+88ILcfPPNUhuQ6QYAAICrtCR80HPfePyEtWsYIx/fcx7jvIFaGEu6PaY7IiJCBgwYUNXjAwAAAPyOZr27JP/25dpTdZ7bjmaarDqA2sftoHvixIkyc+ZM7xwNAAAA4MO0zPz5a7rbl90qGS1Hp8axJou+5VBaseZqel3X5+YX0HgN8FNuj+levXq1fP311/LRRx9Jp06dSjRS++CDDzx5fAAAAIBP0YZqUWEhknPac3OJ/Xw4Q27791pzXRu36XhyZZ8zPDRY8gqKTGf1D8b2pwwdqM1Bd926dWXUqFHeORoAAADAx+0/lVMi4G5VP1revaO3nPv0N1JQxfS3dky3Ss3tc4YXFNmX9bbWDWKq9iAAfDfofv31171zJAAAAICP03LvSXPX25et6cRaJdYxwXBVA27Vsn60GTsuZ6YU0w7nlnYNY+23AailY7otx44dk+XLl5uLXgcAAABqOw2sNx5Kty9rwK3Ti+lYbw2GOzeOLTYvd4M6+l/3vHdHb/tjzb2zryktV2EhQTL3jj6llpZbY78dx4MD8NOgOysrS2655RZp3LixnH/++eaSnJwst956q2Rn03ERAAAAtZcG1jquWnVtGm8y3BYNhl+4tod9WQvQj2W5P+77kheWyblPLzZTk1318nf20vLThTYZOWeVaapm0SB7x9EMGTlnpdlex4ATeAN+HnRPmjRJvvnmG/nwww8lNTXVXBYtWmTWTZ482TtHCQAAAPgADay1kdnXkwfKB3eXbGimQbjjlGKVcTLXJkcy8s31HceypEndSPttu09kyx9mLTeBtxVsD3lhmWw8M/bbGvMNwHcE2Ww2t0aeJCYmyvz58+WCCy4otn7JkiVy9dVX+02p+ezZs82lsLBQtm/fXuGE5gAAAIArNBjWQNiTQoOk2HjxtkkxssNhrLdFs++l/RgAwPPS09MlPj6+wljS7U+jlpA3bNiwxPqkpCS/Ki8fN26cbN68WdasWVPThwIAAIBaRLPd2gDNk5wbtJUWcH80vj8BN+CD3A66+/XrJ1OnTpXc3Fz7upycHHn88cfNbQAAAEAg0yzzovED5OykOvYsdXU4kXWaDDdQG6YMe/HFF2Xo0KHStGlT6datm1m3YcMGiYyMlM8//9wbxwgAAAD4XeAddqbEW7PU4SEi+YUiESFBklfogXnFSlE3KtSUtlvN3XRstzZ+o9Qc8LMx3UrLyN9++23ZunWrWe7QoYPccMMNEhUVJbW1Dh8AAACoyXHdrtK5w4OCgkxzNe20ro3fCLyBmosl3c50q+joaLn99turcnwAAABAwNLZu92fTMw1mxzmEbe6mbdu4Nkx5gC8OKZ72rRp8q9//avEel33t7/9zd3dAQAAALWOlnh3bhxrX44K+/Vrd3jIrwO8NeBuGhcut/Rv6vHH7tAoRiJDf308/Tc5/rcpx5TO473rWCbzeQO+GnS/8sor0r59+xLrO3XqJC+//LKnjgsAAADwW1rOvXD8ufLlfeeby5o/XSSt6kdLvsN47gPp+fL5z56fbjczt0ByC4rMdf13/6mcYgH3qDkrZdBz35h/dRmAjwXdR44ckcaNG5dY36BBAzl8+LCnjgsAAADw+8C7bcNYc0nJzJfdJ0pOr3swLc/jj7s/9bdZhlR+wW+ZbS0115Jzx9JzMt+AjwXdzZo1kxUrVpRYr+uSk5M9dVwAAABAraFdxLWpmTpTaW4X4eE5xZz3d+XLq+yZbS01t46ja9N4s0zmG/AutxupaQO1e++9V06fPi2DBg0y6xYvXiz/93//J5MnT5aaMHLkSFm6dKlcdNFFMn/+/Bo5BgAAAKC8rLd2EV+x87iMfn1NsdvydE4xD3LeX87pQntm+1BarjkOazox58z37uNZEhIcxFRjQE0G3Q888ICcOHFCxo4dK/n5+WadztH94IMPykMPPSQ1YeLEiXLLLbfIm2++WSOPDwAAALgSeA9ok2gyzRrgRoWFmIC4S5M40Ul8HbuOe4M+nma29TisbuZWBl6PR49j0vsbmGoM8IV5ulVmZqZs2bLFzM3dtm1biYiIkJqkme5Zs2a5nelmnm4AAABUp9z8Avl+90np2byuGeutga/O6z1sxnKvP/bfRnWRoZ2SZMOBdOmUHCOLtxw3yyezC6SwyFZsbnFtAKfj0QOZNQ5eXyPmOkdlY0m3x3RbYmJipHfv3tK5c+cqBdzLli2T4cOHm/HgQUFBsnDhwhLbzJ49W1q2bGky6n379pXVq1dX+vEAAACAmgzirn7lO1Nifv1rq00wpx6Yt6FaHv/BDzZK9ycWm8fv9dQSs9zjicWSFBNupjnrkvxb4KBZ70Dubk6nd3hKpYNuT8nKypJu3bqZwLo0c+fOlUmTJsnUqVPlxx9/NNsOHTpUUlJSqv1YAQAAgKoorXu4XjYdzqixE6tlrwvWHTLjzZ8c0cm+fuOZMd5WALr1cLos2XrUZOoDoeN5aa8VUC1juj1t2LBh5lKW559/3jRvGzNmjFnWucA//vhj+de//iVTpkxx+/Hy8vLMxbEkAAAAAKgOjmOotXu4lenWDPNGL4/pLs9Tn26R3NMlA2jNds+78xy58qWV9h8GIkODpU1SjBmDrs9FG7PVxtLrsl4rwO+C7vJoo7a1a9cWa9AWHBwsgwcPllWrVlVqn9OmTZPHH3/cg0cJAAAAuNfF3Hmc8IJxA+xZ5bzTBXLZrJXVekpLC7itbLeOP3fMxOcWFNmbvlkZYKsxWyC8VoC7fPqdc/z4cSksLJSGDRsWW6/LR44csS9rEH7VVVfJJ598Ik2bNi03INcAXge6W5f9+/d79TkAAAAAjqzu4Y5BnF7XpmV6ad84vtjYas0sW6wZuD0xs7c1X/hZiVES5TR5uLWsGV5t+Na2wW9Z3vCQIOl05vhqewa4tNcKqFWZbld99dVXLm+rTd9qutM6AAAAUBYN8Bwz3w1iwqT3U4tFk9HWtEOemNnbSm7/cjxHOjaKkYmDz5aJc9ebrLfOb/TpPeea5mra+G3HsWxpUz9KTkuQ7D2RbTJ32t1cbycgBfw46E5MTJSQkBA5evRosfW63KhRoyrtWxu36UUz6QAAAIAvsTLf6pttKfYA2Vs2H8mU1OzT9jJzLSFPyciTiLAQezOxnSdy7Nvr+POQ4CACbsAFPl0nER4eLj179pTFixfb1xUVFZnlfv36VWnf48aNk82bN8uaNWs8cKQAAACAd/RtlVCsxNwbWiZEyL4TWRJ5pqw8IiRIcvILJTUrX1okRJl1nZNjpUuTeHtZuU4zpj8IBEo3c8BvM92ZmZmyc+dO+/Lu3btl/fr1kpCQIM2bNzfThY0ePVp69eolffr0kenTp5tpxqxu5gAAAEBtFhkeKj88fJFcOnO57D35a7ZZQ2PH8FbHWecXVr7ofM/JPJn9zS5zffrVXWXKBxvlrrd/LLaNTYJk/p3nyKG0XBNw9/7r15JzujBgupkDfht0//DDD3LhhRfalzXIVhpov/HGG3LNNdfIsWPH5NFHHzXN07p37y6fffZZieZq7qK8HAAAAP4iJTPfHnAr53xyVQJuZ9/uOCG5BSX39/OhdBNwa2MxzXBrwB1I3cyBygqy2bRNQuDSebrj4+NNJ/O4uN+6RAIAAAA1Tcu1NYjVzPKol1bK9pRfm6uFBYmctnku0+3o8/sGyO9fWFGiWZuWmX884VyTed+Zkikj5qwwY8AjQkSa14+RHSmZ0q5hjCwaN8BsA9R26S7GkgTdBN0AAADw0YB71JyVJnscFRZiMstnN6gjz1/T3ZR/a3bZscxch2MHBwVJngez3uq5K7vInxb+LHkFRcVKycVh+jJ9xIjQYLMNJeYIFOkuxpIBO9hCy8s7duwovXv3rulDAQAAAErQDLfVOdwq5d5+LEtOZOXbg17HMnNtPO7pgFv9fCjDBNPOpeQW6xGtbawScwABHnTTvRwAAAC+yOoEnhwfabLGSjPdVtdw7WZudREPd/g2H+y07Cm3nNdcIkKD7I/RvF6kuf7rmt+caXwuXZrEmWPfcTTDXLS7eWmdzel4jkDBYAsAAADAB0vKNeB+/0y3cA1i9d/mCdG/bnimLVO+Qxxb5LTsKYOeXSb5hb89xr5Tub8egtN21lzihUU2ufLlVfaMuFUa71h27vw86XiO2ixgM92UlwMAAMCXS8r1X6tbuDYm0381YNVtNjqVeHuTFXC7avPhjGIl6FZpvGPZufPzpBwdtVnABt2UlwMAAMDXaCbbKinXUnJ7ZruMbapD+K+V7S7r1DhWOif/1lTKsTTeej6uPE+gtqB7Od3LAQAA4IPThGkgqpntiqYSW7XrpOQXFElIcJA0rRdl7qMl3ofTcqRBTIQcTM2Rw2m5Uj86TA6n5sqBtCy5rGuyZOUXSUJ0uKzfnyqn8wvkRE6eFNk0yA6R889uIDuPZUn3ZvHSJilW9pzIlr0nsqSg0Fbm4xzLzJMmdaOkbcNYc4y7j/86vVmzelH20njH5+PK8wRqQyzJmG4AAADAh2gAqqXkrm5zYfskE+BqAGwFwb1b1JOo8BBJiA6Vnw+lS49m8XIsM18a1Y2S7IJCKSoS+W7nMdmekiHnt20gaw+dkvjIcBnVo4mk5xZKak6BtGkQI++u3ictE6Kle/N6svdYluw4nib1oiLkdGFdaZ5QxwT0B0/lyO6jGVJUZJOf9p+SenWaycYDmeZY6tcJl083Hpab+jU3QfaKncelZ/O6cjg9zxx7q8Q65rlos7Xvd580TeKc5/h2NTgniIevItNNphsAAAB+SgPNkbNXlBjjbc2d7Usiw4Il1+q2doZ2YX/3tj7S+69fm7HfWoq+7pHB9sDb1YZrNGZDTWCe7grQSA0AAAD+rqymar4WcCvngFttPJgmH288Ym+2pv9qxtviasM1GrPBlwXs4AkaqQEAAMDfacl1F4emZRbnObR9JdPtTDPdl3ZpZG+2pv9qibnF1YZrNGaDL6O8nPJyAAAA+DEtrXYc052SkWvGdKdk5psx3Z9sPCrtG8WYMd3ZeYWy63imnNMqQZZsPWof071638liY7p1GvC6UWHy4U8H7WO61+1NtY/p7tK0+JhuHSSuY7qzCgrl+nOKj+leteuEGdMdGRZqstiM6UagxZIE3QTdAAAAqGUcm4qpnSmZpvt4cFCQdGkaI++sPCDxdUKlR/N6svt4tnyzI0VGdGssq3edksOZ2ZKRUyBRESGSkXNa8vMLJCoy3DRua5cUJz8fTpWN+05J86QY6d8qUU5lFUhaTp6c3ShOCgpF1h88Jb/v2FB+OZYtCdFhUlAksudkltx4TjM5mn5a1u07JV2axElEWKgJzA+cyjZBvnZEjwgLMd3O92sg79BorbTn5Ty227otOT6y1G7pnjqfdFqHhaDbRQTdAAAAqE0cm4pp6XmRzSY/H84QfxEZGiy5GqmfKT9fcKZ5WnnN0hxv0xJ1HRteXuM1d9CkDWWhkVoFaKQGAACA2sixqZg2WfOngFtZAbfVaM1qnlZeszTH26ymbOU1XnMHTdpQVTRSW7OmyicRAAAA8BWOTcW0jLtT41jxJ5rptmim2yqRL69ZmuNtVlO28hqvuYMmbagqxnQzphsAAAC1DGO6GdMN72NMt4dPFAAAAAAAFsZ0AwAAAABQw0Jr+gAAAAAAVM9UVs7TasVFBss73x2QfmclmKnDPvzpgLRqEC0xYeFyTuv68uWWo9KmQR1Zsfu4xEaESa/m9WTPiWwp1Hm5bTY5kZ1npherExkqIRJkHkOnJUuMiTDzeC/fdUzqx4TJ/hNZkpqZL/XiIqV1Yow0qhMp4WEh0rlJvGw8mC55uadlX3q29GhWT9JyCiVYbBIRGiJfb0+R285vKR0bxcuHG45I/Tph0qRetBxJzzWP07tlXflu1yk5lpknI7snm3Ow8pcT0jg+Uto2jC31nFjzmiudnszT04sBzhjTTXk5AAAA/JC7U1mVNq1WbRMRGiR5BTZzvXNynCwcN6DEPN8jZ68wXd2Vp6cXQ2BJdzGWDNh3FVOGAQAAwJ+5O5VVadNq1TZWwK02HUovcU502Qq4vTG9GFCagA26x40bJ5s3bxamDAMAAIA/cncqq9Km1aqNmW6LZrqdz4kud0n+LSPp6enFgNJQXk55OQAAAPwUY7oZ042aw5RhHj5RAAAAAABYGNMNAAAAAEANC9gx3QAAAAAAeBtBNwAAAAAAXhLqrR0DAAAAqNnmakqvJ8WEy9p9qdK3VYKZi3r38SxzW7N6UXIoLde+ra7PLyiSlIxc6dEsXlbsPCmbDqZKYky4dEqOl6VbU+RoVo6cLiiS1KzT0qdlgkSF/RZS5OcXyg+HTkhefpGc3ThO6oeHm+W0rALp1CxeokJCpchmk2NZuXIiLU/qxoZLdl6hSJBIVHiIpKbnSXRUuHRrHC/Hc3Jl3a7jciIrX4KDQ6RN43i58Owk+flousSFh0q9iDDZeSpDsnKLpGNSrBzOypXmcdFyKi9fMvIKpXvTurLvZI7EhAbLocxcGfW7ptKuYZys3nNKGsdHSqvEOua5J8dHyv5TOeZ5HziVLTabSNN6URIRFmLOz/ajmbJ0W4rc1K+5hAYHy4J1h6R+nTBp1SBG2jaMtZ9jx3OodP/Ot1nXmQ88sNC9nEZqAAAAqEUB96g5K82802ZqrKAg2XgwTWNa0RmsI0OD5awGdeTnwxn2KbN0rmrd1nZmbutAERUWLDmni8w5yS0oKnWbsCCR079N/V1Cp8axEhwcbM6x8znUKcuCzpx/x9dCp237YGx/Au9agO7lFZg9e7a5FBYWyvbt2+leDgAAAL+361imDHrum5o+DFTg68kDpXWDGM6Tn6N7eQXGjRsnmzdvljVr1lTPKwIAAAB4mZYuayZVdWkSJ13OXNdMt9KsrmZnLZrptrbVzGwg0Uy3dU7Kopnu8ui5tM6x8znU6463Wde7No23l5sjMDCmGwAAAKgldKywli4zppsx3fAdjOlmTDcAAAAAwE2UlwMAAAAAUMOYpxsAAAAAAC8h6AYAAAAAwEsIugEAAAAA8BKCbgAAAAAAvISgGwAAAAAALyHoBgAAAACAoLtsH330kbRr107atm0rr732Gm8WAAAAAIBPCBU/V1BQIJMmTZIlS5ZIfHy89OzZU0aOHCn169ev6UMDAAAAAAQ4vy8vX716tXTq1EmaNGkiMTExMmzYMPniiy9q+rAAAAAAAKj5oHvZsmUyfPhwSU5OlqCgIFm4cGGJbWbPni0tW7aUyMhI6du3rwm0LYcOHTIBt0WvHzx4sNqOHwAAAAAAny0vz8rKkm7dusktt9wio0aNKnH73LlzTfn4yy+/bALu6dOny9ChQ2Xbtm2SlJRUI8cMAAAA1Aa5+QXy/e6T0rdVgoSGBMu+k9nSPCFaCgqLzPpuTePkx31pUjcqTH7ce0rSc/PllnNbSWRYqCzekiI/HTglhUVFEhwUJLGhIbL+yCnJLyySnOw8OZKWJ5ER4dK3TaIkhofJ8l0pEh0dJqdPn5atB7MlIkSkKEikWUKUhAUHS1FRkRxLz5ET2SIRwSLZRSJdmtSR3AKb1IsPkx370iQzVyS/SKRenWCpGyGy9USRhJ0JanJEpH2DcPOc0rOLJOO0SFJssASLTU4XiUSG2ORAukh8VJC0bhApe4/lSFaBSKfkOpKdXyThIYWy9kC+RASJtGkQLpn5NmnWIFK27c+Q0JAgiY8Ol7joMKkfFym5+UUSER4s6ZmnpUlipGw/kC7BQUWSmisyoG2CfL8rVf7Yv6W0rBcj/1i2Q2KjwuXei9vKp+uPSmJsuKzcfVw6JsWa530iJ0+Cg4KlfeM4CQsJkfyCItl+NF2S4iJkWJeG8uXPxyUiJEh+PHhKWsRFidhEDmTkyLDOjWXPiRzp0iROIsJCpbDIJruOZcr2oxnSu0U9+XLLUenZoq60SoyVI+m5YrOJNI6PlIOpOXLwVI45L/VjIiQjv1CGdU6Snw9lmtf7u12nzPY9msVLaEiIpGT8et16H2w8mCYJ0WFikyA5lpknSTHhEhwcLCHBQdK0XpR5H1l0XavEOua69d4q67reT993u49nmedi3ddxf/4qyGbT0+8bNNO9YMECGTFihH2dBtq9e/eWWbNmmWX9MDZr1kwmTJggU6ZMkZUrV8ozzzxj7qfuvfde6dOnj1x//fWlPkZeXp65WNLT083+0tLSJC4uzuvPEQAAAPAFGpz2eOIryTldKJGhwdImKUY2HUqXzo1j5Zfj2WZ9WUKDRAp8JoqAL+ucHGfiPA3WuyTHadBX4nrXJvHy/p3nyFUvr5KNh9Lt9+3SJF4WjO3vs4G3xpLaV6yiWNI3j/6M/Px8Wbt2rQwePNi+Tn9F0eVVq1aZZQ2wN23aZErKMzMz5dNPPzWZ8LJMmzbNnBjrogE3AAAAEGg0k20F1rkFRSbgVpsOZ5QbcCsCbrhq06F0E1irjWVc/+lgmnk/OgbcZpuDaSYT7u98Oug+fvy4FBYWSsOGDYut1+UjR46Y66GhofLcc8/JhRdeKN27d5fJkyeX27n8oYceMr9EWJf9+/d7/XkAAAAAvkZLyqPCQsx1zXRrRlJ1To61ry8v0w24onNynMlYKy2FL+1616bx5v1ost8O9HarDN2f1fiYbk/4wx/+YC6uiIiIMBdtzqYXDeoBAACAQBMZHirrHhnMmG7GdPvMmO4F4wYwpru6x3RreXl0dLTMnz+/2Djv0aNHS2pqqixatKja6vABAAAAAKhVY7rDw8OlZ8+esnjxYvs6baSmy/369avRYwMAAAAAwOfLy7X52c6dO+3Lu3fvlvXr10tCQoI0b97cTBemme1evXqZpmk6ZZhOMzZmzJgqPS7l5QAAAACAWj9l2NKlS00TNGcaaL/xxhvmuk4XptOCafM0bZY2Y8YMM5WYJ1BeDgAAAADwVixZ40F3TSPoBgAAAAAE5Jhub9Ly8o4dO0rv3r1r+lAAAAAAALUUmW66lwMAAAAAvBRL1ngjtZpmVdfrCQMAAAAAwBVWDFnRiO2AD7ozMjLMiWjWrJlLJxYAAAAAAMeYUjPeZQn48nKd9/vQoUMSGxsrQUFB4qt07PmaNWvEV1X38Xnr8Ty136rspzL3dec+rm6rv9zpj1H79+8vt1wmUPAZrJ7zwWfwN3wG+QzWxN8kPoN8Bqv7PecpfBf13Pngu6jrNMOtAXdycrIEB5fdLi3gM916cpo2bSq+LiQkxKcDn+o+Pm89nqf2W5X9VOa+7tzH3f3rtr783qsufAar53zwGSyJzyCfwer8m8RnkM+gt98b3sJ3Uc+dD76Luqe8DLcEevdyfzNu3DjxZdV9fN56PE/ttyr7qcx93bmPr7+XfJWvnzc+g547H3wGfROfweo5H/x/EHwGq/ezwmcwMAR8eTmA0tHZH6hZfAYBPoNAIEuvRbNMkekGUKqIiAiZOnWq+RdA9eMzCNQsPoMAn0FPIdMNAAAAAICXkOkGAAAAAMBLCLoBAAAAAPASgm4AAAAAALyEoBsAAAAAAC8h6AbgtpEjR0q9evXkyiuv5OwB1Wz//v1ywQUXSMeOHaVr164yb948XgOgGqWmpkqvXr2ke/fu0rlzZ3n11Vc5/0ANyM7OlhYtWsj999/v8+ef7uUA3LZ06VLJyMiQN998U+bPn88ZBKrR4cOH5ejRo+YL/5EjR6Rnz56yfft2qVOnDq8DUA0KCwslLy9PoqOjJSsrywTeP/zwg9SvX5/zD1Sjhx9+WHbu3CnNmjWTZ5991qfPPZluAG7TLFtsbCxnDqgBjRs3NgG3atSokSQmJsrJkyd5LYBqEhISYgJupcG3zWYzFwDVZ8eOHbJ161YZNmyYX5x2gm4gwCxbtkyGDx8uycnJEhQUJAsXLiyxzezZs6Vly5YSGRkpffv2ldWrV9fIsQK1kSc/g2vXrjVZN/2VH0D1fQa1xLxbt27StGlTeeCBB8yPXwCq7zN4//33y7Rp0/zmlBN0AwFGS+H0i4L+MSvN3LlzZdKkSTJ16lT58ccfzbZDhw6VlJSUaj9WoDby1GdQs9s33XST/OMf/6imIwdqB098BuvWrSsbNmyQ3bt3yzvvvGOGfACons/gokWL5OyzzzYXv2EDELD0T8CCBQuKrevTp49t3Lhx9uXCwkJbcnKybdq0acW2W7Jkie2KK66otmMFaqPKfgZzc3Nt5513nu3f//53tR4vUNtU5f+Dlrvvvts2b948rx8rUBtJJT6DU6ZMsTVt2tTWokULW/369W1xcXG2xx9/3ObLyHQDsMvPzzflqoMHD7avCw4ONsurVq3iTAE+8BnU7yg333yzDBo0SG688UZeE6CaP4Oa1dZmoiotLc2UyrZr147XAaimz+C0adPMTB579uwxDdRuv/12efTRR336/BN0A7A7fvy4GR/asGHDYmdFl7VLskX/8F111VXyySefmPFsBORA9X0GV6xYYUrvdAycNlTTy8aNG3kJgGr6DO7du1fOO+88U/Kq/06YMEG6dOnC+Qeq6TPoj0Jr+gAA+J+vvvqqpg8BCFjnnnuuFBUV1fRhAAGrT58+sn79+po+DAAipvLLH5DpBmCn3Vd1KhTnhjC6rFMTAfAuPoNAzeIzCPAZ9AaCbgB24eHh0rNnT1m8eLF9nWbUdLlfv36cKcDL+AwCNYvPIMBn0BsoLwcCTGZmpuzcudO+rNOdaJlcQkKCNG/e3EzRMHr0aOnVq5cpoZs+fbqZ2mHMmDE1etxAbcFnEOAzCASyzED8LlrT7dMBVC+d6ks/+s6X0aNH27eZOXOmrXnz5rbw8HAzbcN3333HywTwGQRqBf4/CPAZrG5B+p+aDvwBAAAAAKiNGNMNAAAAAICXEHQDAAAAAOAlBN0AAAAAAHgJQTcAAAAAAF5C0A0AAAAAgJcQdAMAAAAA4CUE3QAAAAAAeAlBNwAAAAAAXkLQDQAAAACAlxB0AwBqpQsuuEDuvfdej+/3jTfekLp161ZpHy1btpTp06eLL/DE86nI0qVLJSgoSFJTU8UX5OfnS5s2bWTlypVmec+ePeb41q9f79HHOeecc+S///2vR/cJAPA/BN0AAAQIXwr2a9LLL78srVq1kv79+3v1cf785z/LlClTpKioyKuPAwDwbQTdAADAL2nG2l02m01mzZolt956q3jbsGHDJCMjQz799FOvPxYAwHcRdAMAaq2CggIZP368xMfHS2JiojzyyCMm6LKcOnVKbrrpJqlXr55ER0ebIGnHjh0lyq+bN29ubh85cqScOHHCfpuWJQcHB8sPP/xQ7D6aTW7RooXLGU4tu77tttukQYMGEhcXJ4MGDZINGzbYb3/ssceke/fu8p///Mdkq/X5XHvttSags+j1G264QerUqSONGzeWF154oViJvV7fu3ev3HfffaaUWi+OPv/8c+nQoYPExMTI73//ezl8+LC4Iy8vTx588EFp1qyZREREmPLtf/7zn8W2Wbt2rfTq1cucS80yb9u2zX7bL7/8Ipdffrk0bNjQHEPv3r3lq6++KnZ/fe5PPPGEec30PN1xxx0m8NbXWJ9zZGSkOe/Tpk0r8zj1GPSxLr300nKfzzfffCN9+vQxz0X3rRlrfT+5er5VSEiIXHLJJfLee++5dS4BALULQTcAoNZ68803JTQ0VFavXi0vvviiPP/88/Laa6/Zb7/55ptNwPy///1PVq1aZQJyDZJOnz5tbv/+++9NRlSDOh3ve+GFF8qTTz5ZLAgcPHiwvP7668UeV5d13xqQu+Kqq66SlJQUkxHVoPB3v/udXHTRRXLy5En7NhooLly4UD766CNz0aDw6aeftt8+adIkWbFihXkuX375pXz77bfy448/2m//4IMPpGnTpvKXv/zFBNSOQXV2drY8++yzJqhftmyZ7Nu3T+6//363zrUGwu+++67MmDFDtmzZIq+88ooJnh09/PDD8txzz5lzrq/LLbfcYr8tMzPTnPvFixfLunXrTOA/fPhwcyyO9Di7detmttEfUfTx9Dm///77Joh/++23zetSFj0vZ599tsTGxpa5zcGDB82xaOCvP3689NJL5gcEx9e+ovNt0cBdbwMABDAbAAC10MCBA20dOnSwFRUV2dc9+OCDZp3avn27prxtK1assN9+/PhxW1RUlO399983y9ddd53tkksuKbbfa665xhYfH29fnjt3rq1evXq23Nxcs7x27VpbUFCQbffu3WUeW4sWLWwvvPCCuf7tt9/a4uLi7Pe3nHXWWbZXXnnFXJ86daotOjralp6ebr/9gQcesPXt29dc1/VhYWG2efPm2W9PTU0195k4cWKpj2t5/fXXzXnYuXOnfd3s2bNtDRs2tLlq27ZtZh9ffvllqbcvWbLE3P7VV1/Z13388cdmXU5OTpn77dSpk23mzJnFjn/EiBHFtpkwYYJt0KBBxV7n8uj50O0d6Wulx7Ju3Tqz/Kc//cnWrl27YvvUcxITE2MrLCx0+XyrRYsW2YKDg839AACBiUw3AKDW0u7RjmXU/fr1M+XjhYWFJhur2da+ffvab69fv760a9fO3Kb0X8fbrX04GjFihCkjXrBggb0cXTPi5WVbHWkmVbO8+tiaGbYuu3fvNtlti+7PMTurJc2aHVe7du0y2XnNqlq0BF2fiyu03Puss84qdd+u0CoAPQcDBw4sd7uuXbsWewxlPY6eA82ua4m7dlPXc6Dn3znTreXpjrSiQB9fn+s999wjX3zxRbnHkJOTY8rQy6OPq6+z43tnwIAB5hgPHDjg1vmOiooywwy0/B4AEJhCa/oAAADwZ+Hh4aa0WkvKR40aJe+8844pZXeVBnIagOq0Ws4cp/IKCwsrdpsGhJ7qil3avh3HvldEA0t3H8cKaK3noAG3lmlr+biOB9d9XnnllSWapekYakdaiq8/UGhpvo4Bv/rqq03J//z580s9Bh3bv3HjRqkuOkRAj9nVcwQAqH3IdAMAai0dk+3ou+++k7Zt25qsrGZUtTGW4zbaJE3HBXfs2NEs6zal7cOZNkHTgG/OnDlmnxp8u0qDxiNHjpisuwabjhcNEF3RunVrE9CuWbPGvi4tLU22b99e4gcCzfJ7WpcuXUzwrOPMK0vHR2vWWpvV6f4aNWpkGtW5QpuqXXPNNfLqq6/K3LlzzdzYjuPhHfXo0UO2bt1a7o8K+rpbY/wdj08rDXRcvKvnW23atMk8JgAgcBF0AwBqLS1N1oZXGkhrk6+ZM2fKxIkTzW0afGu37Ntvv12WL19uyrz/+Mc/SpMmTcx6peXKn332mcm+alm6TjWly6UFaVrKrt27r7vuOreympqV1VJmLVPX0mgNNFeuXGmajjl3RS+LBoOjR4+WBx54QJYsWSI///yzaQCnjdwcS6S1RF0bpWmjsOPHj4un6H718bUxmjZ708yzZu61uZmr9PXQZm9aKq6vxfXXX+9SJl+b4+lrq4G0Br3z5s0zAbtjlYAjLf3X6gI9R2UZO3as7N+/XyZMmGD2u2jRIpk6dap5L+k5dfV8K22idvHFF7t8HgAAtQ9BNwCg1tKybx3Dq2Nvx40bZwJunWbKoiXhPXv2lMsuu8wEvprZ/OSTT+xl0BpIa/ZUy8W1Y7YGxX/+859LfSwNurQU2rEjtys0SNPHPP/882XMmDGms7ZOB6bTe+n0Wa7S4FOfgz4XDeR1DLL+GOA4flk7l2tQr+O3dXoyV2kArcdZXuZZO3xrObgGrO3btzc/ZmRlZbl1/Dp1m04lpl3Lhw4daqoAKqIB8N///ncz1lu7jesx6vksq3O8jp3XbLp2OS+L/vCi+9Cu9/q633XXXeb1dXztXTnf+uOG/oCirysAIHAFaTe1mj4IAAD8nc4frVnWn376SXyBBrwaPOoUXRowVoX+OPHXv/5VNm/eXGL8tz/S12jIkCGmUZ3ztGaePN9a+aBzwf/jH//wyGMAAPwTjdQAAKgCLVXW7KqWnjvO41zddN5qLYXWrL6OL9astrJK5atCs74adNeGgNvqov63v/3NlMHr+HFvne+kpCRTkg4ACGxkugEAqAJt/qVjinVMtnYu1yZtNUGDQG3opuPXtWGals1rCXRlg0pwvgEAnkHQDQAAAACAl9BIDQAAAAAALyHoBgAAAADASwi6AQAAAADwEoJuAAAAAAC8hKAbAAAAAAAvIegGAAAAAMBLCLoBAAAAAPASgm4AAAAAALyEoBsAAAAAAPGO/we450f4MmLNCwAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1000x350 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# §5 scan — the ONE body pass. strlen computed inside the scan; the body value\n",
+    "# itself never leaves the reader.\n",
+    "LENGTHS_PQ = COVERAGE_DIR / \"body_length_distribution.parquet\"\n",
+    "\n",
+    "if not LENGTHS_PQ.exists():\n",
+    "    duckdb.sql(f\"\"\"\n",
+    "        COPY (\n",
+    "            SELECT strlen(body) AS n_chars, count(*) AS n\n",
+    "            FROM read_ndjson('{MENTIONS_RAW}',\n",
+    "                format = 'newline_delimited',\n",
+    "                columns = {{body: 'VARCHAR'}})\n",
+    "            GROUP BY n_chars\n",
+    "        ) TO '{LENGTHS_PQ}' (FORMAT parquet)\n",
+    "    \"\"\")\n",
+    "    print(\"scanned mentions file; body-length distribution persisted\")\n",
+    "else:\n",
+    "    print(\"reusing persisted length distribution (no rescan)\")\n",
+    "warn_if_stale(LENGTHS_PQ, MENTIONS_RAW)\n",
+    "\n",
+    "lengths = pl.read_parquet(LENGTHS_PQ).sort(\"n_chars\")\n",
+    "# Cross-pass consistency stays HARD.\n",
+    "assert lengths[\"n\"].sum() == M_TOTAL, \"length-scan rows != 03 census rows\"\n",
+    "\n",
+    "TOTAL_BODY_CHARS = (lengths[\"n_chars\"] * lengths[\"n\"]).sum()\n",
+    "_cum = lengths.with_columns(pl.col(\"n\").cum_sum().alias(\"cum\"))\n",
+    "\n",
+    "\n",
+    "def chars_pctile(q: float) -> int:\n",
+    "    \"\"\"Exact weighted percentile from the grouped length distribution.\"\"\"\n",
+    "    return _cum.filter(pl.col(\"cum\") >= q / 100 * M_TOTAL)[\"n_chars\"][0]\n",
+    "\n",
+    "\n",
+    "print(f\"total body chars: {TOTAL_BODY_CHARS:,}\")\n",
+    "print(f\"mean {TOTAL_BODY_CHARS / M_TOTAL:,.0f} | median {chars_pctile(50):,} | \"\n",
+    "      f\"p95 {chars_pctile(95):,} | p99 {chars_pctile(99):,} | max {lengths['n_chars'].max():,}\")\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(10, 3.5))\n",
+    "ax.scatter(lengths[\"n_chars\"], lengths[\"n\"], s=2)\n",
+    "ax.set_xscale(\"log\")\n",
+    "ax.set_yscale(\"log\")\n",
+    "ax.set_xlabel(\"body length, chars (log)\")\n",
+    "ax.set_ylabel(\"comments (log)\")\n",
+    "ax.set_title(\"Body length distribution — the classify population\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "1556d522",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T19:06:48.460529Z",
+     "iopub.status.busy": "2026-07-09T19:06:48.460457Z",
+     "iopub.status.idle": "2026-07-09T19:06:48.465672Z",
+     "shell.execute_reply": "2026-07-09T19:06:48.465348Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "prompt template overhead: 215 chars/comment (measured)\n",
+      "total input chars:        810,723,352\n",
+      "model: claude-haiku-4-5-20251001  |  batch pricing: $0.5/MTok in, $2.5/MTok out\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (9, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>chars/token</th><th>out tok/comment</th><th>input MTok</th><th>output MTok</th><th>cost</th></tr><tr><td>f64</td><td>i64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>3.5</td><td>10</td><td>231.6</td><td>21.5</td><td>169.69</td></tr><tr><td>3.5</td><td>15</td><td>231.6</td><td>32.3</td><td>196.63</td></tr><tr><td>3.5</td><td>20</td><td>231.6</td><td>43.1</td><td>223.57</td></tr><tr><td>4.0</td><td>10</td><td>202.7</td><td>21.5</td><td>155.21</td></tr><tr><td>4.0</td><td>15</td><td>202.7</td><td>32.3</td><td>182.15</td></tr><tr><td>4.0</td><td>20</td><td>202.7</td><td>43.1</td><td>209.09</td></tr><tr><td>4.5</td><td>10</td><td>180.2</td><td>21.5</td><td>143.95</td></tr><tr><td>4.5</td><td>15</td><td>180.2</td><td>32.3</td><td>170.89</td></tr><tr><td>4.5</td><td>20</td><td>180.2</td><td>43.1</td><td>197.83</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (9, 5)\n",
+       "┌─────────────┬─────────────────┬────────────┬─────────────┬────────┐\n",
+       "│ chars/token ┆ out tok/comment ┆ input MTok ┆ output MTok ┆ cost   │\n",
+       "│ ---         ┆ ---             ┆ ---        ┆ ---         ┆ ---    │\n",
+       "│ f64         ┆ i64             ┆ f64        ┆ f64         ┆ f64    │\n",
+       "╞═════════════╪═════════════════╪════════════╪═════════════╪════════╡\n",
+       "│ 3.5         ┆ 10              ┆ 231.6      ┆ 21.5        ┆ 169.69 │\n",
+       "│ 3.5         ┆ 15              ┆ 231.6      ┆ 32.3        ┆ 196.63 │\n",
+       "│ 3.5         ┆ 20              ┆ 231.6      ┆ 43.1        ┆ 223.57 │\n",
+       "│ 4.0         ┆ 10              ┆ 202.7      ┆ 21.5        ┆ 155.21 │\n",
+       "│ 4.0         ┆ 15              ┆ 202.7      ┆ 32.3        ┆ 182.15 │\n",
+       "│ 4.0         ┆ 20              ┆ 202.7      ┆ 43.1        ┆ 209.09 │\n",
+       "│ 4.5         ┆ 10              ┆ 180.2      ┆ 21.5        ┆ 143.95 │\n",
+       "│ 4.5         ┆ 15              ┆ 180.2      ┆ 32.3        ┆ 170.89 │\n",
+       "│ 4.5         ┆ 20              ┆ 180.2      ┆ 43.1        ┆ 197.83 │\n",
+       "└─────────────┴─────────────────┴────────────┴─────────────┴────────┘"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "=== THE NUMBER ===\n",
+      "submitting 2,154,982 comments → expect ≈ $182.15 (band $143.95–$223.57)\n",
+      "(#63's summarize_actual_usage reconciles this against actuals after the run)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# §5 cost — production constants + measured prompt overhead + sensitivity band.\n",
+    "PROMPT_OVERHEAD_CHARS = len(build_prompt(\"\"))  # measured from the production template\n",
+    "TOTAL_INPUT_CHARS = TOTAL_BODY_CHARS + PROMPT_OVERHEAD_CHARS * M_TOTAL\n",
+    "\n",
+    "print(f\"prompt template overhead: {PROMPT_OVERHEAD_CHARS} chars/comment (measured)\")\n",
+    "print(f\"total input chars:        {TOTAL_INPUT_CHARS:,}\")\n",
+    "print(f\"model: {MODEL}  |  batch pricing: ${INPUT_COST_PER_MTOK}/MTok in, \"\n",
+    "      f\"${OUTPUT_COST_PER_MTOK}/MTok out\\n\")\n",
+    "\n",
+    "_rows = []\n",
+    "for _cpt in (3.5, 4.0, 4.5):\n",
+    "    _in_mtok = TOTAL_INPUT_CHARS / _cpt / 1e6\n",
+    "    for _out_tok in (10, 15, 20):\n",
+    "        _out_mtok = M_TOTAL * _out_tok / 1e6\n",
+    "        _rows.append({\n",
+    "            \"chars/token\": _cpt,\n",
+    "            \"out tok/comment\": _out_tok,\n",
+    "            \"input MTok\": round(_in_mtok, 1),\n",
+    "            \"output MTok\": round(_out_mtok, 1),\n",
+    "            \"cost\": round(calculate_cost(int(_in_mtok * 1e6), int(_out_mtok * 1e6)), 2),\n",
+    "        })\n",
+    "scenarios = pl.DataFrame(_rows)\n",
+    "with pl.Config(tbl_rows=-1):\n",
+    "    display(scenarios)\n",
+    "\n",
+    "_expected = scenarios.filter(\n",
+    "    (pl.col(\"chars/token\") == 4.0) & (pl.col(\"out tok/comment\") == 15)\n",
+    ")[\"cost\"][0]\n",
+    "_lo, _hi = scenarios[\"cost\"].min(), scenarios[\"cost\"].max()\n",
+    "print(f\"\\n=== THE NUMBER ===\")\n",
+    "print(f\"submitting {M_TOTAL:,} comments → expect ≈ ${_expected:,.2f} \"\n",
+    "      f\"(band ${_lo:,.2f}–${_hi:,.2f})\")\n",
+    "print(\"(#63's summarize_actual_usage reconciles this against actuals after the run)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7b76e916",
+   "metadata": {},
+   "source": "## 6. Conclusions — the quotables\n\n**The population:** **2,154,982 comments** — 29.6% of the 7.28M corpus, **+32.9% above\nthe v1-rate floor** (that gap *is* the config broadening, measured), and **+11.1% YoY**\nagainst v1's like-for-like filter stage (1,939,290 — incidentally confirming the docs'\n\"1.93M classified\" as a filter-stage count).\n\n**The price:** ≈ **$182** (band $144–$224) to classify everything —\n`claude-haiku-4-5` at batch pricing ($0.50/$2.50 per MTok), ~203 MTok input at\n4 chars/token, 15 output tokens/comment. One structural observation for the classifier\nstrategy: the 215-char prompt template is **57% of total input chars** (the median\ncomment is only 99 chars) — template length, not comment length, is the dominant cost\nlever. #63's `summarize_actual_usage` reconciles all of this against actuals after the\nfirst batch.\n\n**The shape:** 71.3% of kept comments mention exactly one player (mean 1.46, max 107 —\nthe list-every-player copypasta tail). **105 of 223 players qualify** at the 5,000 bar,\nand the median player sits at 4,482 — the bar lands almost exactly on the median.\nDiscourse is a star economy: **top 10 players hold 40.0% of all mentions**, top 25 hold\n60.7%. Wemby is #1 at 242,687 — v1's \"pre-arc OKC frozen in time\" read aged well: the\nFinals run made him the most-discussed player in the sub.\n\n**The denominator:** **64.5% of the classify population wears a flair** (+1.7 pp vs\nthe 62.9% corpus rate — team-affiliated users engage *more* in player discourse), and\n≈**60.2% resolves to a fan_team** — the denominator behind every fanbase view.\n\n**Hand-off:** batch prep is unblocked — population final (03), cost estimated (here),\nretry + actual-cost machinery landed (#63). Next stop: `prepare_batches` →\n`submit_batches`."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "nba-hate-tracker",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

`notebooks/2025-26/04_filtered_baseline.ipynb` — the pre-batch decision document ("submitting N comments, expect $X") and future launch-methodology source, computed on the final config v4.1 population. Completes the notebook sequence 02 (corpus) → 03 (coverage/verdicts) → 04 (filtered baseline). With #63 merged, batch submission is now fully unblocked.

## The quotables

| Question | Number |
|---|---|
| Classify population | **2,154,982** (29.6% of the 7.28M corpus) |
| vs v1-rate floor | **+32.9%** — the measured value of config broadening |
| YoY vs v1 filter stage | **+11.1%** (v1 filtered file counts to 1,939,290 — confirming the docs' "1.93M classified" as a filter-stage number) |
| Expected classification cost | **≈ $182** (band $144–$224) — `claude-haiku-4-5` batch pricing, verified current |
| Qualified players | **105 of 223** at the 5,000 bar (median player: 4,482 — the bar sits on the median) |
| Concentration | top 10 players = **40.0%** of all mentions; Wemby #1 at 242,687 |
| fan_team denominator | **64.5% flaired** (+1.7 pp vs corpus), **≈60.2% resolvable** |

## Notable findings

- **The prompt template is 57% of input chars** (215 chars vs 99-char median comment) — template length, not comment length, is the dominant cost lever. Flagged for the Classifier Strategy page.
- Flaired users engage measurably more in player discourse (+1.7 pp vs corpus rate).
- v1-04's token measurements describe the old verbose prompt (209-token overhead) — deliberately not used as calibration; the estimate uses the measured current template + a 3.5–4.5 chars/token sensitivity band. #63's `summarize_actual_usage` reconciles against actuals after the first batch.

## Design notes

- **Reuse-first:** §1–§3 run zero new scans (they read 03's post-re-filter artifacts + 02's corpus census). Three new passes total: flair, body length, v1 filtered count (once).
- **`body` never materializes** — the §5 pass computes `strlen(body)` inside the DuckDB scan.
- Cost machinery is imported from `pipeline/batch.py` (MODEL, batch prices, `build_prompt`, `calculate_cost`) — repricing there reprices the notebook.

## Testing

- `uv run pytest` — 379 passed (incl. #64's expanded suite) / `uv run ruff check .` clean
- Notebook fully executed; all cross-pass asserts green