### PR TITLE
fix(app): serve published_season so pipeline flips can't break the dashboard

### DIFF
--- a/app/utils/data.py
+++ b/app/utils/data.py
@@ -59,7 +59,13 @@ METRIC_CONFIG: dict[str, dict[str, Any]] = {
 
 
 def _get_data_path() -> Path:
-    """Resolve the aggregates.json path for the active season."""
+    """Resolve the aggregates.json path for the published season.
+
+    The dashboard serves `published_season`, decoupled from `season` (the
+    pipeline's operational pointer), so flipping the active season for
+    pipeline work cannot break the deployed app. Falls back to `season`
+    when `published_season` is absent.
+    """
     if not _SEASON_CONFIG_PATH.exists():
         st.error(
             f"Season config not found: {_SEASON_CONFIG_PATH}. "
@@ -68,7 +74,8 @@ def _get_data_path() -> Path:
         st.stop()
 
     with open(_SEASON_CONFIG_PATH) as f:
-        season = yaml.safe_load(f)["season"]
+        config = yaml.safe_load(f)
+    season = config.get("published_season") or config["season"]
 
     return _REPO_ROOT / "data" / season / "dashboard" / "aggregates.json"
 

--- a/config/season.yaml
+++ b/config/season.yaml
@@ -1,4 +1,8 @@
 season: "2025-26"
+# What the deployed dashboard serves — decoupled from `season` (the pipeline's
+# operational pointer) so a season flip for pipeline work cannot take the
+# public app down. Flipping this line IS the v2 dashboard launch.
+published_season: "2024-25"
 start_date: "2025-10-01"
 end_date: "2026-06-30"
 subreddits:

--- a/tests/unit/test_dashboard_data.py
+++ b/tests/unit/test_dashboard_data.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
+from app.utils import data
 from app.utils.data import (
     enrich_with_metadata,
     filter_by_threshold,
@@ -334,3 +335,27 @@ class TestEnrichWithMetadata:
         """Row count is unchanged after enrichment (left join)."""
         result = enrich_with_metadata(sample_player_df, sample_metadata)
         assert len(result) == len(sample_player_df)
+
+
+class TestGetDataPath:
+    """Tests for published-season resolution in _get_data_path."""
+
+    def test_serves_published_season(self, tmp_path, monkeypatch) -> None:
+        """Dashboard path should come from published_season, not the active season."""
+        cfg = tmp_path / "season.yaml"
+        cfg.write_text('season: "2025-26"\npublished_season: "2024-25"\n')
+        monkeypatch.setattr(data, "_SEASON_CONFIG_PATH", cfg)
+
+        path = data._get_data_path()
+
+        assert path == data._REPO_ROOT / "data" / "2024-25" / "dashboard" / "aggregates.json"
+
+    def test_falls_back_to_active_season(self, tmp_path, monkeypatch) -> None:
+        """Without published_season, the active season keeps working (pre-hotfix behavior)."""
+        cfg = tmp_path / "season.yaml"
+        cfg.write_text('season: "2025-26"\n')
+        monkeypatch.setattr(data, "_SEASON_CONFIG_PATH", cfg)
+
+        path = data._get_data_path()
+
+        assert path == data._REPO_ROOT / "data" / "2025-26" / "dashboard" / "aggregates.json"


### PR DESCRIPTION
## What broke

The deployed Streamlit app has shown "Data file not found: data/2025-26/dashboard/aggregates.json" since **2026-07-03**, when the season activation (#48) flipped `config/season.yaml`'s `season` pointer to 2025-26. The app resolves its data path from that pointer (`app/utils/data.py`), and 2025-26 has no aggregates until the v2 classification run (in flight now) completes. The public v1 dashboard — the artifact the launch post links to — has been down ~3 weeks.

## The fix

`season` is the pipeline's operational pointer; what the public app serves is a separate concern that was silently coupled to it. This PR:

- adds `published_season: "2024-25"` to `config/season.yaml`
- `_get_data_path()` resolves from `published_season`, falling back to `season` when absent
- pipeline untouched (`load_season_config` validation only checks required keys; the extra key is inert)

Flipping `published_season` becomes the deliberate v2 dashboard launch — decoupled from pipeline operations, so this failure class is closed.

## Verification

- Drove all three data-backed pages headlessly via `streamlit.testing.v1.AppTest` with deploy-like `sys.path`: **Leaderboard, Flair View, Player Detail all render with zero `st.error` blocks**, resolving to `data/2024-25/dashboard/aggregates.json`
- New tests pin both resolution paths (published-season used; fallback to active season when key absent)
- 381 tests pass, `ruff check` clean

## Relation to #52

Deliberately **not** #52 (splitting season facts into `config/<season>/season.yaml`) — that restructure stays whole in its scheduled slot. This just adds a second pointer; after this merges, the top-level file is visibly a two-pointer file, which is #52's end state anyway. Comment forthcoming on #52 noting its updated starting state.

Merging this auto-redeploys Streamlit Cloud and restores the public dashboard within minutes.