### PR TITLE
fix(pipeline): normalize list-valued p and gate build on request files

### DIFF
--- a/pipeline/batch.py
+++ b/pipeline/batch.py
@@ -73,6 +73,9 @@ def parse_response(text: str) -> dict:
 
     Returns:
         Success: {"s": "pos|neg|neu", "c": float, "p": str|None}
+        A rare list-valued "p" (#71) is normalized — a single-string list
+        unwraps, anything else becomes None — and the original list is
+        preserved under "p_raw" so callers can log the occurrence.
         Error: {"s": "error", "c": 0.0, "p": None, "raw": str}
     """
     if not text or not text.strip():
@@ -109,11 +112,25 @@ def parse_response(text: str) -> dict:
         if sentiment not in ("pos", "neg", "neu"):
             return {"s": "error", "c": 0.0, "p": None, "raw": text}
 
-        return {
+        parsed = {
             "s": result["s"],
             "c": float(result.get("c", 0.0)),
             "p": result.get("p"),
         }
+
+        # Normalize rare list-valued player field (#71): unwrap a
+        # single-string list, drop anything else; keep the original
+        # under p_raw so callers can log the occurrence.
+        if isinstance(parsed["p"], list):
+            raw_list = parsed["p"]
+            parsed["p_raw"] = raw_list
+            parsed["p"] = (
+                raw_list[0]
+                if len(raw_list) == 1 and isinstance(raw_list[0], str)
+                else None
+            )
+
+        return parsed
     except (json.JSONDecodeError, ValueError, TypeError):
         return {"s": "error", "c": 0.0, "p": None, "raw": text}
 
@@ -302,6 +319,31 @@ def get_missing_results(state: dict) -> list[dict]:
         if not b.get("results_downloaded", False)
         and not (b.get("failed", False) and b.get("status") != "ended")
     ]
+
+
+def get_unsubmitted_request_files(state: dict, requests_dir: Path) -> list[str]:
+    """
+    Get request files on disk that have no corresponding state entry.
+
+    This reconciles state against the requests directory — the ground
+    truth of the run's population (#71). Mid-run, state only knows about
+    batches submitted so far, so the parquet build must not proceed while
+    any request file is still unsubmitted. Submission-failure entries
+    carry request_file too, so they correctly count as submitted.
+
+    Args:
+        state: Current state dict.
+        requests_dir: Directory containing batch_NNN.jsonl request files.
+
+    Returns:
+        Sorted request filenames with no state entry. A missing or empty
+        requests directory yields an empty list (the gate falls through
+        to the state-based checks).
+    """
+    submitted = {b.get("request_file") for b in state.get("batches", [])}
+    return sorted(
+        f.name for f in requests_dir.glob("batch_*.jsonl") if f.name not in submitted
+    )
 
 
 def is_wholesale_failure(batch: dict) -> bool:

--- a/pipeline/results.py
+++ b/pipeline/results.py
@@ -53,6 +53,7 @@ def build_sentiment_dataframe(
 
     all_results = []
     failed_requests = []
+    normalized_count = 0
 
     for results_file in results_files:
         with open(results_file) as f:
@@ -68,6 +69,12 @@ def build_sentiment_dataframe(
 
                 if result["result_type"] == "succeeded":
                     parsed = parse_response(result["content"])
+                    if "p_raw" in parsed:
+                        normalized_count += 1
+                        logger.warning(
+                            f"Normalized list-valued p {parsed['p_raw']!r} -> "
+                            f"{parsed['p']!r} for {result['custom_id']}"
+                        )
                     all_results.append(
                         {
                             "id": result["custom_id"],
@@ -82,6 +89,8 @@ def build_sentiment_dataframe(
                     failed_requests.append(result)
 
     logger.info(f"Loaded {len(all_results)} successful results")
+    if normalized_count:
+        logger.warning(f"Normalized {normalized_count} list-valued p field(s)")
     if failed_requests:
         logger.warning(f"Found {len(failed_requests)} failed requests")
 

--- a/scripts/collect_results.py
+++ b/scripts/collect_results.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from dotenv import load_dotenv
 
 from pipeline.batch import (
+    REQUESTS_SUBDIR,
     RESPONSES_SUBDIR,
     STATE_FILENAME,
     compute_run_totals,
@@ -39,6 +40,7 @@ from pipeline.batch import (
     get_downloadable_batches,
     get_missing_results,
     get_pending_batches,
+    get_unsubmitted_request_files,
     is_wholesale_failure,
     load_state,
     save_state,
@@ -270,6 +272,7 @@ def main() -> None:
     # Setup paths
     batches_dir = get_batches_dir()
     state_path = batches_dir / STATE_FILENAME
+    requests_dir = batches_dir / REQUESTS_SUBDIR
     responses_dir = batches_dir / RESPONSES_SUBDIR
     filtered_path = get_filtered_dir() / FILTERED_FILENAME
     processed_dir = get_processed_dir()
@@ -331,6 +334,17 @@ def main() -> None:
         )
         if not completed:
             logger.warning("Exiting with pending batches due to timeout")
+
+    # Mid-run guard (#71): state only knows about submitted batches; the
+    # requests directory is the ground truth of the full population.
+    unsubmitted = get_unsubmitted_request_files(state, requests_dir)
+    if unsubmitted:
+        total = len(list(requests_dir.glob("batch_*.jsonl")))
+        logger.info(
+            f"{total - len(unsubmitted)}/{total} request files submitted - "
+            f"downloading available results, skipping parquet build"
+        )
+        sys.exit(0)
 
     # Check if we can build the final output
     pending = get_pending_batches(state)

--- a/scripts/run_batches.py
+++ b/scripts/run_batches.py
@@ -35,6 +35,7 @@ from pipeline.batch import (
     get_exhausted_batches,
     get_pending_batches,
     get_retryable_batches,
+    get_unsubmitted_request_files,
     load_state,
 )
 from utils.paths import get_batches_dir
@@ -138,8 +139,7 @@ def run_loop(
 
         pending = get_pending_batches(state)
         retryable = get_retryable_batches(state, max_retries)
-        submitted_files = {b.get("request_file") for b in state.get("batches", [])}
-        all_submitted = all(f.name in submitted_files for f in batch_files)
+        all_submitted = not get_unsubmitted_request_files(state, requests_dir)
 
         if not pending:
             if all_submitted and not retryable:

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -1,6 +1,7 @@
 """Tests for pipeline.batch module."""
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -19,6 +20,7 @@ from pipeline.batch import (
     get_missing_results,
     get_pending_batches,
     get_retryable_batches,
+    get_unsubmitted_request_files,
     init_state,
     is_wholesale_failure,
     load_state,
@@ -138,6 +140,45 @@ class TestParseResponse:
         assert result["s"] == "error"
         assert result["c"] == 0.0
         assert result["p"] is None
+
+    @pytest.mark.parametrize(
+        "raw_response,expected_p,expected_p_raw",
+        [
+            (
+                '{"s": "neg", "c": 0.85, "p": ["Keldon Johnson"]}',
+                "Keldon Johnson",
+                ["Keldon Johnson"],
+            ),
+            (
+                '{"s": "neg", "c": 0.85, "p": ["Julian", "Keldon"]}',
+                None,
+                ["Julian", "Keldon"],
+            ),
+            ('{"s": "neu", "c": 0.5, "p": []}', None, []),
+            ('{"s": "neg", "c": 0.85, "p": [42]}', None, [42]),
+        ],
+    )
+    def test_list_valued_p_normalized(
+        self,
+        raw_response: str,
+        expected_p: str | None,
+        expected_p_raw: list,
+    ):
+        """Verify list-valued p unwraps singleton strings, nulls the rest (#71).
+
+        Every list shape must set p_raw so the caller can log and count
+        the normalization — including unwrapped singletons.
+        """
+        result = parse_response(raw_response)
+
+        assert result["p"] == expected_p
+        assert result["p_raw"] == expected_p_raw
+
+    def test_non_list_p_has_no_p_raw(self):
+        """Verify a normal string p leaves the success dict unmarked."""
+        result = parse_response('{"s": "pos", "c": 0.9, "p": "LeBron James"}')
+
+        assert result == {"s": "pos", "c": 0.9, "p": "LeBron James"}
 
 
 class TestCalculateCost:
@@ -496,6 +537,66 @@ class TestGetMissingResults:
         missing = get_missing_results(state)
 
         assert [b["batch_num"] for b in missing] == [1]
+
+
+def _make_requests_dir(tmp_path: Path, names: list[str]) -> Path:
+    """Create a requests dir containing empty request files."""
+    requests_dir = tmp_path / "requests"
+    requests_dir.mkdir()
+    for name in names:
+        (requests_dir / name).touch()
+    return requests_dir
+
+
+def _state_with_request_files(names: list[str]) -> dict:
+    """Build a state whose batch entries cover the given request files."""
+    state = init_state()
+    state["batches"] = [{"request_file": name} for name in names]
+    return state
+
+
+class TestGetUnsubmittedRequestFiles:
+    """Tests for get_unsubmitted_request_files function."""
+
+    def test_returns_files_missing_from_state(self, tmp_path: Path):
+        """Verify request files with no state entry are returned sorted."""
+        requests_dir = _make_requests_dir(
+            tmp_path, ["batch_003.jsonl", "batch_001.jsonl", "batch_002.jsonl"]
+        )
+        state = _state_with_request_files(["batch_002.jsonl"])
+
+        unsubmitted = get_unsubmitted_request_files(state, requests_dir)
+
+        assert unsubmitted == ["batch_001.jsonl", "batch_003.jsonl"]
+
+    def test_empty_when_state_covers_disk(self, tmp_path: Path):
+        """Verify no files are returned when every request file is in state."""
+        names = ["batch_001.jsonl", "batch_002.jsonl"]
+        requests_dir = _make_requests_dir(tmp_path, names)
+        state = _state_with_request_files(names)
+
+        assert get_unsubmitted_request_files(state, requests_dir) == []
+
+    def test_empty_when_requests_dir_missing(self, tmp_path: Path):
+        """Verify a nonexistent requests dir yields no unsubmitted files."""
+        state = _state_with_request_files(["batch_001.jsonl"])
+
+        missing_dir = tmp_path / "does_not_exist"
+
+        assert get_unsubmitted_request_files(state, missing_dir) == []
+
+    def test_empty_when_requests_dir_empty(self, tmp_path: Path):
+        """Verify an empty requests dir yields no unsubmitted files."""
+        requests_dir = _make_requests_dir(tmp_path, [])
+
+        assert get_unsubmitted_request_files(init_state(), requests_dir) == []
+
+    def test_extra_state_entry_not_on_disk_is_ignored(self, tmp_path: Path):
+        """Verify state entries without a matching file don't affect the result."""
+        requests_dir = _make_requests_dir(tmp_path, ["batch_001.jsonl"])
+        state = _state_with_request_files(["batch_001.jsonl", "batch_099.jsonl"])
+
+        assert get_unsubmitted_request_files(state, requests_dir) == []
 
 
 class TestIsWholesaleFailure:

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -155,6 +155,36 @@ class TestBuildSentimentDataframe:
         assert len(failed) == 1
         assert failed[0]["custom_id"] == "def456"
 
+    def test_list_valued_p_normalizes_to_null_player(
+        self, tmp_path, filtered_comments_file
+    ):
+        """Verify a list-valued p row assembles with a null sentiment_player (#71).
+
+        The schema equality also pins the explicit row projection: the
+        p_raw signal from parse_response must never reach the frame.
+        """
+        # Arrange
+        directory = tmp_path / "responses"
+        _write_results_file(
+            directory,
+            [
+                _succeeded(
+                    "abc123", '{"s": "neg", "c": 0.85, "p": ["Julian", "Keldon"]}'
+                )
+            ],
+        )
+
+        # Act
+        df, failed = build_sentiment_dataframe(directory, filtered_comments_file)
+
+        # Assert
+        assert df.height == 1
+        row = df.to_dicts()[0]
+        assert row["sentiment"] == "neg"
+        assert row["sentiment_player"] is None
+        assert df.schema == SENTIMENT_SCHEMA
+        assert failed == []
+
     def test_missing_results_files_raise_file_not_found(
         self, tmp_path, filtered_comments_file
     ):

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -1,6 +1,7 @@
 """Tests for pipeline/results.py sentiment frame assembly."""
 
 import json
+import logging
 from pathlib import Path
 
 import polars as pl
@@ -184,6 +185,47 @@ class TestBuildSentimentDataframe:
         assert row["sentiment_player"] is None
         assert df.schema == SENTIMENT_SCHEMA
         assert failed == []
+
+    def test_list_valued_p_normalization_logged(
+        self, tmp_path, filtered_comments_file, caplog
+    ):
+        """Verify each normalization warns with custom_id and a count is logged.
+
+        The WARNING lines are the observability channel for #71 (and the
+        raw material for the #62 item-4 record), so their presence is
+        pinned, not just the normalized values.
+        """
+        # Arrange
+        directory = tmp_path / "responses"
+        _write_results_file(
+            directory,
+            [
+                _succeeded(
+                    "abc123", '{"s": "neg", "c": 0.85, "p": ["Julian", "Keldon"]}'
+                ),
+                _succeeded("def456", '{"s": "pos", "c": 0.9, "p": ["Chet Holmgren"]}'),
+            ],
+        )
+
+        # Act
+        with caplog.at_level(logging.WARNING, logger="pipeline.results"):
+            build_sentiment_dataframe(directory, filtered_comments_file)
+
+        # Assert
+        warnings = [
+            record.message
+            for record in caplog.records
+            if record.levelno == logging.WARNING
+        ]
+        assert any(
+            "abc123" in message and "['Julian', 'Keldon']" in message
+            for message in warnings
+        )
+        assert any(
+            "def456" in message and "'Chet Holmgren'" in message
+            for message in warnings
+        )
+        assert any("Normalized 2 list-valued p field(s)" in m for m in warnings)
 
     def test_missing_results_files_raise_file_not_found(
         self, tmp_path, filtered_comments_file


### PR DESCRIPTION
Refs #71 (not auto-closing: the last acceptance criterion — a clean 22/22 build overwriting the mid-run partial — is verifiable only after the live run completes).

## Defect A — list-valued `p`

`parse_response` now normalizes a list-valued `p` on the success path: a single-string list unwraps, anything else (len 0, len ≥2, singleton non-string) becomes `None`. The original list is preserved under a conditional `p_raw` key — mirroring the error path's conditional `raw` — and the function stays **pure** with an unchanged signature (shared with the eval harness; logging there would spray warnings through every suite run).

`build_sentiment_dataframe` consumes `p_raw` at the call site: WARNING per occurrence with custom_id, original list, and normalized value, plus a summary count. The row append remains an explicit six-key projection, so `p_raw` never reaches `RESULTS_SCHEMA`/parquet — pinned by a schema-equality test.

Bonus: this also fixes a latent eval crash (`evaluation.py` feeds `result["p"]` into `.strip()`-based attribution matching, which would AttributeError on a list).

## Defect B — build gate vs. reality

New `get_unsubmitted_request_files(state, requests_dir)` in `pipeline/batch.py` reconciles state against the requests directory. `collect_results` checks it before the existing state-based gate and skips the build with exit 0 while any request file is unsubmitted:

```
14/22 request files submitted - downloading available results, skipping parquet build
```

Exit 0 matches the orchestrator's expectation (nonzero = precondition failure only). `run_batches`' inline `all_submitted` reconciliation now reuses the same helper (single source of truth). No counts persisted to `state.json` — derived data, per the `compute_run_totals` recompute-don't-store precedent.

## Evidence correction

Spot check streamed **all 15 downloaded batches (~1.5M succeeded rows)** through the new `parse_response`: exactly **one** list-`p` row exists — `batch_006`, custom_id `nx0ue6s`, `["Julian","Keldon"]` → `None` (s=pos, c=0.95). The ticket's "one each in batch_005/006" was off; measured rate so far is ~0.67/M, not ~1.7/M. An assert also confirmed no list shape survives normalization anywhere in the real data.

## Tests

- `TestParseResponse`: parametrized list-`p` cases (singleton unwrap, multi → null, empty → null, singleton non-string → null), each asserting `p_raw` presence; non-list case asserts no `p_raw`.
- `TestGetUnsubmittedRequestFiles`: state short of disk, state covers disk, missing dir, empty dir, stale state entry.
- `test_results.py`: end-to-end list-`p` assembly — null `sentiment_player`, exact `SENTIMENT_SCHEMA` equality.

`uv run pytest` 392 passed; `uv run ruff check .` clean. Pre-existing `ruff format` drift in touched files left alone (kept the diff minimal for #54's rebase).