### PR TITLE
feat(pipeline): re-derive mentioned_players at assembly (#54)

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -2,7 +2,7 @@
 
 **Purpose:** The shared conceptual vocabulary for V2 dashboard design. A new dashboard view is a question asked against this model; having the model written down is what lets you tell at a glance whether a question is **cheap** (already in an aggregate), **needs a join** (a dimension lookup, no new pipeline output), or **expensive** (a new aggregate view the pipeline must produce).
 
-**How to read it:** The core model below — the ER diagram, the entity key, and the view-lineage table — is the authoritative *"is"*: what the pipeline produces today (plus the one dimension #39 materializes). The single fenced section at the very end, **Forward look (v3)**, is *"will be"* — direction, not built. Nothing in that section touches the core diagram or the present-now key.
+**How to read it:** The core model below — the ER diagram, the entity key, and the view-lineage table — is the authoritative *"is"*: what the pipeline produces today (plus the planned standalone Player dimension file). The single fenced section at the very end, **Forward look (v3)**, is *"will be"* — direction, not built. Nothing in that section touches the core diagram or the present-now key.
 
 `pipeline/schemas.py` is the source of truth for column *structure* (names + dtypes). This doc is the source of truth for the *relationships* between those structures.
 
@@ -52,7 +52,7 @@ The four aggregate views (`player_overall`, `player_temporal`, `player_team`, `t
 | `body`, `author`, `created_utc`, `score` | event attributes |
 | `sentiment` | categorical attribute (junk-dimension candidate) — you group by it; the `neg_count` / `pos_count` / `neu_count` rollups derived from it are the measures |
 | `confidence` | numeric measure |
-| `mentioned_players[]` | → **Player**, M:N — raw substring matches, *pre-resolution* |
+| `mentioned_players[]` | → **Player**, M:N — substring matches re-derived from `body` at assembly time under the active `players.yaml`, *pre-resolution* |
 | `sentiment_player` | the classifier's single pick — a disambiguation input |
 | `attributed_player` | → **Player**, the *resolved* single FK the aggregate views key on |
 | `author_flair_text` → `fan_team` | → **Team** (fan role), 0-or-1 (flair may not resolve) |
@@ -60,11 +60,18 @@ The four aggregate views (`player_overall`, `player_temporal`, `player_team`, `t
 
 **The player FK is resolved, not raw.** `mentioned_players[]` (M:N) and `sentiment_player` are the *inputs*; `resolve_player()` collapses them to a single `attributed_player` (or null). The fact tables join on `attributed_player`. ~1.57M of ~1.93M classified rows resolve to a player.
 
+**Two provenance layers on the fact.** The fact's attributes split into two classes with opposite change semantics:
+
+- **Population + event/classification fields** — frozen at filter/classification time: `body`, `author`, `created_utc`, `score`, `link_id`, `sentiment`, `confidence`, `sentiment_player`. Re-running assembly never changes them; which comments exist in the fact (the population) is part of this frozen layer.
+- **Config-versioned derivations** — `mentioned_players`, and therefore `attributed_player`: caches of `f(body, players.yaml@version)`, re-derived at every assembly and stamped with the config `version` into the parquet's file metadata. The stamp is checked at aggregation read time (drift → WARNING) — the config `version` field (major = roster, minor = alias) is load-bearing lineage metadata, not documentation.
+
+The distinction matters because the two layers age differently: frozen fields stay correct forever, while a stored derivation is only as current as the config it was derived under — copying it forward through a rebuild silently reintroduces every alias fix made since. `fan_team` = `f(author_flair_text, teams.yaml)` is the **same attribute class** (a config-derived attribute, currently unversioned) — a future team-alias fix is this same problem and gets this same treatment, not a rediscovery.
+
 > `link_id` — decided V2 addition for the v3 bridge; pending, must land before the classify run (see Forward look).
 
 ### `Player` — dimension
 
-**Grain:** one canonical player. Sourced from `config/<season>/players.yaml`; #39 materializes it as `player_metadata.parquet` (today it ships as a nested dict inside `aggregates.json`).
+**Grain:** one canonical player. Sourced from `config/<season>/players.yaml`; today it ships as a nested dict inside `aggregates.json`, with a standalone Player-dimension parquet planned.
 
 | Field | Notes |
 |---|---|
@@ -136,7 +143,7 @@ All four views are **fact tables** (rollups of `ClassifiedComment`); `Player` an
 | `player_team` | Player × `fan_team` | fact → Player, Team(fan) | "Lakers fans about Draymond" |
 | `team_overall` | `fan_team` | fact → Team(fan) | "Which fanbase is saltiest" |
 
-**Needs a join** (no new pipeline output — cheap once #39 materializes the Player dimension): any *roster-level* question — "OKC's roster sentiment over time," "own-fans vs. rivals" — joins a player-keyed view to `Player.roster_team`. Today that means JSON-key gymnastics against `aggregates.json`; #39 turns it into a clean `USING (attributed_player)` join.
+**Needs a join** (no new pipeline output — cheap once the Player dimension is materialized as its own parquet): any *roster-level* question — "OKC's roster sentiment over time," "own-fans vs. rivals" — joins a player-keyed view to `Player.roster_team`. Today that means JSON-key gymnastics against `aggregates.json`; the dimension file turns it into a clean `USING (attributed_player)` join.
 
 **Expensive** (a new aggregate view the pipeline must produce): "How Lakers fans' sentiment toward Draymond moved *week over week*" needs a `player_team_temporal` view (Player × `fan_team` × Week) that doesn't exist. A new grain ⇒ a new pipeline output.
 

--- a/pipeline/aggregation.py
+++ b/pipeline/aggregation.py
@@ -19,6 +19,7 @@ from pipeline.schemas import (
 )
 from utils.player_config import (
     build_alias_to_player_map,
+    load_player_config_version,
     load_player_metadata,
     resolve_sentiment_player,
 )
@@ -159,6 +160,24 @@ def aggregate_sentiment(input_path: Path) -> dict:
     logger.info(f"Loading sentiment data from {input_path}")
     df = pl.read_parquet(input_path)
     validate_schema(df, SENTIMENT_SCHEMA, str(input_path))
+
+    # Config-lineage check (#54): mentioned_players in the parquet reflects
+    # the players.yaml it was assembled under; stale attribution is
+    # legitimate to read, just not silently.
+    stamped = pl.read_parquet_metadata(input_path).get("players_config_version")
+    active = load_player_config_version()
+    if stamped is None:
+        logger.warning(
+            f"{input_path} carries no players_config_version stamp (written "
+            f"before #54) - config lineage cannot be verified"
+        )
+    elif stamped != active:
+        logger.warning(
+            f"{input_path}: players_config_version drift - parquet assembled "
+            f"with config {stamped!r} but active config is {active!r}; "
+            f"mentioned_players may not reflect the current players.yaml"
+        )
+
     total_rows = len(df)
     logger.info(f"Loaded {total_rows:,} rows")
 

--- a/pipeline/results.py
+++ b/pipeline/results.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import polars as pl
 
 from pipeline.batch import parse_response
+from pipeline.processors import find_player_mentions
 from pipeline.schemas import (
     COMMENT_INPUT_SCHEMA,
     RESULTS_SCHEMA,
@@ -27,6 +28,14 @@ def build_sentiment_dataframe(
 ) -> tuple[pl.DataFrame, list[dict]]:
     """
     Build sentiment DataFrame by joining results with comment metadata.
+
+    mentioned_players is re-derived from body at assembly time under the
+    active (or --season override) season's config (#54) — the filtered
+    NDJSON's filter-time copy is ignored, so alias fixes reach the parquet
+    on any rebuild. Rows whose body no longer matches any tracked player
+    are kept with an empty list: population selection stays frozen at
+    filter time, only the derivation tracks config. Error-sentiment rows
+    get mentions derived too (harmless; aggregation filters them).
 
     Token and cost accounting happens per batch at download time (see
     summarize_actual_usage in pipeline.batch); this function is a pure
@@ -107,6 +116,11 @@ def build_sentiment_dataframe(
     joined_df = (
         comments_df.join(results_df.lazy(), on="id", how="inner")
         .rename({"id": "comment_id"})
+        .with_columns(
+            pl.col("body")
+            .map_elements(find_player_mentions, return_dtype=pl.List(pl.String))
+            .alias("mentioned_players")
+        )
         .select(SENTIMENT_SCHEMA.names())
         .collect()
     )

--- a/pipeline/schemas.py
+++ b/pipeline/schemas.py
@@ -31,6 +31,8 @@ SENTIMENT_SCHEMA = pl.Schema(
         "created_utc": pl.Int64,  # epoch seconds
         "score": pl.Int64,
         "link_id": pl.String,  # post fullname (t3_...), the v3 comment->game bridge
+        # Re-derived from body at assembly under the active players.yaml
+        # (pipeline/results.py) - NOT projected from the filtered NDJSON
         "mentioned_players": pl.List(pl.String),
         "sentiment": pl.String,  # "pos" | "neg" | "neu" | "error"
         "confidence": pl.Float64,
@@ -41,7 +43,9 @@ SENTIMENT_SCHEMA = pl.Schema(
 )
 
 # --- Construction-side schemas, derived from SENTIMENT_SCHEMA ---------------
-# The joined frame is assembled from two inputs. Deriving their schemas from
+# The joined frame is assembled from two file inputs plus one assembly-derived
+# column: mentioned_players is recomputed from body at assembly time (#54), so
+# neither input schema carries it. Deriving the input schemas from
 # SENTIMENT_SCHEMA means a dtype change happens in exactly one place and the
 # strict boundary check can never drift from construction.
 
@@ -54,7 +58,6 @@ _COMMENT_SIDE_COLUMNS = [
     "created_utc",
     "score",
     "link_id",
-    "mentioned_players",
 ]
 _RESULTS_SIDE_COLUMNS = [
     "sentiment",
@@ -66,7 +69,9 @@ _RESULTS_SIDE_COLUMNS = [
 
 # Filtered-comments NDJSON: comment-side columns. The key column is "id"
 # here because the rename to "comment_id" happens after the join in
-# pipeline/results.py. Doubles as a projection — extra input keys dropped.
+# pipeline/results.py. Doubles as a projection — extra input keys dropped,
+# including the NDJSON's filter-time mentioned_players copy (kept in the
+# filtered file only as a debugging record of what the filter matched).
 COMMENT_INPUT_SCHEMA = pl.Schema(
     {
         ("id" if col == "comment_id" else col): SENTIMENT_SCHEMA[col]

--- a/scripts/collect_results.py
+++ b/scripts/collect_results.py
@@ -47,7 +47,9 @@ from pipeline.batch import (
     summarize_actual_usage,
 )
 from pipeline.results import build_sentiment_dataframe
+from pipeline.schemas import SCHEMA_VERSION
 from utils.paths import get_batches_dir, get_filtered_dir, get_processed_dir
+from utils.player_config import load_player_config_version
 from utils.season_config import set_season_override
 
 # -----------------------------------------------------------------------------
@@ -388,9 +390,16 @@ def main() -> None:
             responses_dir, filtered_path
         )
 
-        # Save parquet
+        # Save parquet with config-lineage stamp (#54): mentioned_players
+        # was re-derived under this config version at assembly
         processed_dir.mkdir(parents=True, exist_ok=True)
-        sentiment_df.write_parquet(output_path)
+        sentiment_df.write_parquet(
+            output_path,
+            metadata={
+                "players_config_version": load_player_config_version(),
+                "schema_version": str(SCHEMA_VERSION),
+            },
+        )
         logger.info(f"Wrote {len(sentiment_df)} rows to {output_path}")
 
         # Save failed requests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -529,6 +529,7 @@ def season_override() -> Callable[[str], None]:
     from utils.player_config import (
         build_alias_to_player_map,
         load_player_config,
+        load_player_config_version,
         load_player_metadata,
     )
     from utils.season_config import clear_season_override, set_season_override
@@ -538,6 +539,7 @@ def season_override() -> Callable[[str], None]:
             load_player_config,
             build_alias_to_player_map,
             load_player_metadata,
+            load_player_config_version,
         ):
             fn.cache_clear()
         # cache_clear() is a side door the override's warm-cache guard

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -5,6 +5,8 @@ Tests cover the pure functions resolve_player, extract_team_from_flair,
 and compute_metrics from the aggregation pipeline.
 """
 
+import logging
+
 import polars as pl
 import pytest
 
@@ -18,6 +20,7 @@ from pipeline.aggregation import (
     resolve_player,
 )
 from pipeline.schemas import AGGREGATE_VIEW_SCHEMAS, SCHEMA_VERSION, SENTIMENT_SCHEMA
+from utils.player_config import load_player_config_version
 
 
 class TestResolvePlayer:
@@ -211,11 +214,15 @@ class TestComputeMetrics:
         assert result["player"].to_list() == ["A", "B", "C"]
 
 
-def _make_test_parquet(tmp_path, rows):
-    """Create a SENTIMENT_SCHEMA-conforming parquet for testing aggregate_sentiment."""
+def _make_test_parquet(tmp_path, rows, metadata=None):
+    """Create a SENTIMENT_SCHEMA-conforming parquet for testing aggregate_sentiment.
+
+    metadata, when given, is written as file-level key-value metadata
+    (the config-lineage stamp from scripts/collect_results.py).
+    """
     df = pl.DataFrame(rows, schema=SENTIMENT_SCHEMA)
     path = tmp_path / "test_sentiment.parquet"
-    df.write_parquet(path)
+    df.write_parquet(path, metadata=metadata)
     return path
 
 
@@ -300,6 +307,88 @@ class TestAggregatePlayerMetadata:
         # Only LeBron attributed — Giannis should not be in metadata
         assert "LeBron James" in meta
         assert "Giannis Antetokounmpo" not in meta
+
+
+class TestConfigVersionLineage:
+    """Tests for the players_config_version drift warning (#54)."""
+
+    ROWS = {
+        "comment_id": ["c1", "c2"],
+        "body": ["LeBron is great", "LeBron is washed"],
+        "author": ["u1", "u2"],
+        "author_flair_text": [":lal-1: Lakers", ":bos-1: Celtics"],
+        "author_flair_css_class": ["lakers", "celtics"],
+        "created_utc": [1704067200, 1704153600],
+        "score": [10, 5],
+        "link_id": ["t3_post123", "t3_post456"],
+        "mentioned_players": [["LeBron James"], ["LeBron James"]],
+        "sentiment": ["pos", "neg"],
+        "confidence": [0.9, 0.8],
+        "sentiment_player": ["LeBron James", "LeBron James"],
+        "input_tokens": [100, 100],
+        "output_tokens": [20, 20],
+    }
+
+    def _lineage_warnings(self, caplog) -> list[str]:
+        """Extract WARNING messages about the config-version stamp."""
+        return [
+            record.message
+            for record in caplog.records
+            if record.levelno == logging.WARNING
+            and "players_config_version" in record.message
+        ]
+
+    def test_matching_stamp_emits_no_lineage_warning(self, tmp_path, caplog):
+        """A stamp matching the on-disk config version stays silent."""
+        # Arrange
+        path = _make_test_parquet(
+            tmp_path,
+            self.ROWS,
+            metadata={"players_config_version": load_player_config_version()},
+        )
+
+        # Act
+        with caplog.at_level(logging.WARNING, logger="pipeline.aggregation"):
+            aggregate_sentiment(path)
+
+        # Assert
+        assert self._lineage_warnings(caplog) == []
+
+    def test_stamp_drift_warns_naming_both_versions(self, tmp_path, caplog):
+        """A stamp differing from the on-disk config warns, naming both."""
+        # Arrange
+        path = _make_test_parquet(
+            tmp_path, self.ROWS, metadata={"players_config_version": "0.1"}
+        )
+
+        # Act
+        with caplog.at_level(logging.WARNING, logger="pipeline.aggregation"):
+            aggregate_sentiment(path)
+
+        # Assert
+        warnings = self._lineage_warnings(caplog)
+        assert len(warnings) == 1
+        assert "0.1" in warnings[0]
+        assert load_player_config_version() in warnings[0]
+
+    def test_absent_stamp_warns_distinctly(self, tmp_path, caplog):
+        """An unstamped parquet (pre-#54 legacy) warns with its own message.
+
+        Absent is not drift: the message must say lineage cannot be
+        verified, not claim a version mismatch.
+        """
+        # Arrange
+        path = _make_test_parquet(tmp_path, self.ROWS)
+
+        # Act
+        with caplog.at_level(logging.WARNING, logger="pipeline.aggregation"):
+            aggregate_sentiment(path)
+
+        # Assert
+        warnings = self._lineage_warnings(caplog)
+        assert len(warnings) == 1
+        assert "no players_config_version" in warnings[0]
+        assert "drift" not in warnings[0]
 
 
 class TestAggregateTeamConference:

--- a/tests/unit/test_player_config.py
+++ b/tests/unit/test_player_config.py
@@ -4,9 +4,15 @@ Tests for player configuration loading.
 Tests cover loading from YAML, alias map building, and caching behavior.
 """
 
+import re
+
+import pytest
+import yaml
+
 from utils.player_config import (
     build_alias_to_player_map,
     load_player_config,
+    load_player_config_version,
     load_player_metadata,
     resolve_sentiment_player,
 )
@@ -206,3 +212,66 @@ class TestLoadPlayerMetadata:
         players, _ = load_player_config()
         metadata = load_player_metadata()
         assert len(metadata) == len(players)
+
+
+class TestLoadPlayerConfigVersion:
+    """Tests for load_player_config_version function."""
+
+    @pytest.fixture
+    def cold_version_cache(self):
+        """Clear the version loader's cache before and after the test.
+
+        The missing-version test monkeypatches the config path; a warm
+        cache would return the real config's version and never consult
+        the patched path.
+        """
+        load_player_config_version.cache_clear()
+        yield
+        load_player_config_version.cache_clear()
+
+    def test_returns_version_string(self):
+        """Version is a MAJOR.MINOR string (format pinned, not the value —
+        the active-season version bumps on every roster/alias change)."""
+        version = load_player_config_version()
+        assert re.fullmatch(r"\d+\.\d+", version)
+
+    def test_caching_returns_same_object(self):
+        """Multiple calls return the same cached object."""
+        result1 = load_player_config_version()
+        result2 = load_player_config_version()
+        assert result1 is result2
+
+    def test_missing_version_raises(self, tmp_path, monkeypatch, cold_version_cache):
+        """A players.yaml without a version key raises ValueError with context."""
+        config_path = tmp_path / "players.yaml"
+        config_path.write_text(yaml.safe_dump({"players": {}}))
+        monkeypatch.setattr(
+            "utils.player_config._get_players_path", lambda: config_path
+        )
+
+        with pytest.raises(ValueError, match="version"):
+            load_player_config_version()
+
+    def test_unquoted_version_raises(self, tmp_path, monkeypatch, cold_version_cache):
+        """An unquoted YAML version (parsed as float) raises ValueError.
+
+        Floats silently lose trailing zeros (4.10 -> "4.1"), which would
+        mis-stamp lineage; the loader demands a quoted string instead.
+        """
+        config_path = tmp_path / "players.yaml"
+        config_path.write_text("version: 4.10\nplayers: {}\n")
+        monkeypatch.setattr(
+            "utils.player_config._get_players_path", lambda: config_path
+        )
+
+        with pytest.raises(ValueError, match="quoted string"):
+            load_player_config_version()
+
+    def test_honors_season_override(self, season_override):
+        """Assembly under --season resolves the override season's version.
+
+        Pins the archived 2024-25 config's version exactly — frozen
+        config, safe to pin (unlike the active season's).
+        """
+        season_override("2024-25")
+        assert load_player_config_version() == "2.0"

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -48,11 +48,13 @@ def filtered_comments_file(
     Two filtered comments as JSONL (ids abc123 and def456).
 
     Composes the conftest raw-comment fixtures with mentioned_players,
-    the field the filter stage appends before classification.
+    the field the filter stage appends before classification. The values
+    are deliberately wrong (pre-#54 stale-provenance simulation): assembly
+    must ignore them and re-derive from body.
     """
     comments = [
-        {**valid_nba_comment, "mentioned_players": ["LeBron James"]},
-        {**valid_team_subreddit_comment, "mentioned_players": ["Jayson Tatum"]},
+        {**valid_nba_comment, "mentioned_players": ["Michael Jordan"]},
+        {**valid_team_subreddit_comment, "mentioned_players": ["Stale Player"]},
     ]
     path = tmp_path / "filtered.jsonl"
     path.write_text("\n".join(json.dumps(comment) for comment in comments) + "\n")
@@ -118,6 +120,99 @@ class TestBuildSentimentDataframe:
         link_ids = dict(zip(df["comment_id"].to_list(), df["link_id"].to_list()))
         assert link_ids == {"abc123": "t3_post123", "def456": "t3_post456"}
         assert df["link_id"].null_count() == 0
+
+    def test_mentions_rederived_from_body_not_ndjson(
+        self, responses_dir, filtered_comments_file
+    ):
+        """Verify mentioned_players comes from body, not the NDJSON copy (#54).
+
+        The fixture NDJSON carries deliberately wrong mentions; the
+        assembled values must reflect the assembly-time season config.
+        Real-config dependent: the fixture bodies must keep matching
+        "LeBron James" / "Jayson Tatum" under the active players.yaml.
+        """
+        # Act
+        df, _ = build_sentiment_dataframe(responses_dir, filtered_comments_file)
+
+        # Assert
+        mentions = dict(
+            zip(df["comment_id"].to_list(), df["mentioned_players"].to_list())
+        )
+        assert mentions == {
+            "abc123": ["LeBron James"],
+            "def456": ["Jayson Tatum"],
+        }
+
+    def test_zero_mention_rows_kept_with_empty_list(
+        self, tmp_path, valid_nba_comment, valid_team_subreddit_comment,
+        valid_sentiment_responses,
+    ):
+        """Verify rows with no re-derived mentions stay in the frame (#54).
+
+        Population is frozen at filter time ($-backed classifications);
+        a row whose only filter-time match was contamination re-derives
+        to an empty list, never drops.
+        """
+        # Arrange
+        comments = [
+            {**valid_nba_comment, "mentioned_players": ["Michael Jordan"]},
+            {**valid_team_subreddit_comment, "mentioned_players": ["Stale Player"]},
+            {
+                **valid_nba_comment,
+                "id": "ghi789",
+                "body": "the refs decided this game",
+                "mentioned_players": ["LeBron James"],  # contamination-only match
+            },
+        ]
+        filtered_path = tmp_path / "filtered.jsonl"
+        filtered_path.write_text(
+            "\n".join(json.dumps(comment) for comment in comments) + "\n"
+        )
+        raw_responses = [raw for raw, _ in valid_sentiment_responses]
+        directory = tmp_path / "responses"
+        _write_results_file(
+            directory,
+            [
+                _succeeded("abc123", raw_responses[0]),
+                _succeeded("def456", raw_responses[2]),
+                _succeeded("ghi789", raw_responses[2]),
+            ],
+        )
+
+        # Act
+        df, _ = build_sentiment_dataframe(directory, filtered_path)
+
+        # Assert
+        assert df.height == 3
+        row = df.filter(df["comment_id"] == "ghi789").to_dicts()[0]
+        assert row["mentioned_players"] == []
+
+    def test_null_body_yields_null_mentions(
+        self, tmp_path, valid_nba_comment, valid_sentiment_responses
+    ):
+        """Verify a null body maps to null mentions, not a crash.
+
+        Polars map_elements skips nulls. Filtered data cannot contain
+        null bodies (the filter stage requires a valid body); this test
+        exists so a Polars behavior change is noticed, not to bless
+        null bodies.
+        """
+        # Arrange
+        comments = [{**valid_nba_comment, "body": None, "mentioned_players": []}]
+        filtered_path = tmp_path / "filtered.jsonl"
+        filtered_path.write_text(
+            "\n".join(json.dumps(comment) for comment in comments) + "\n"
+        )
+        raw_responses = [raw for raw, _ in valid_sentiment_responses]
+        directory = tmp_path / "responses"
+        _write_results_file(directory, [_succeeded("abc123", raw_responses[0])])
+
+        # Act
+        df, _ = build_sentiment_dataframe(directory, filtered_path)
+
+        # Assert
+        assert df.height == 1
+        assert df["mentioned_players"].to_list() == [None]
 
     def test_empty_results_yield_empty_conformant_frame(
         self, tmp_path, filtered_comments_file

--- a/tests/unit/test_season_config.py
+++ b/tests/unit/test_season_config.py
@@ -14,6 +14,7 @@ from utils.paths import get_data_dir
 from utils.player_config import (
     build_alias_to_player_map,
     load_player_config,
+    load_player_config_version,
     load_player_metadata,
 )
 from utils.season_config import (
@@ -31,7 +32,12 @@ def _clear_player_caches() -> None:
     cache_clear() bypasses the override's warm-cache guard, which
     normally subsumes that global via load_player_config().
     """
-    for fn in (load_player_config, build_alias_to_player_map, load_player_metadata):
+    for fn in (
+        load_player_config,
+        build_alias_to_player_map,
+        load_player_metadata,
+        load_player_config_version,
+    ):
         fn.cache_clear()
     pipeline.processors._player_patterns = None
 
@@ -161,12 +167,18 @@ class TestSeasonOverride:
         with pytest.raises(ValueError, match="YYYY-YY"):
             set_season_override("2024-2025")
 
-    def test_raises_if_caches_already_warm(self):
+    @pytest.mark.parametrize(
+        "warming_call",
+        [load_player_config, load_player_config_version],
+        ids=["player_config", "config_version"],
+    )
+    def test_raises_if_caches_already_warm(self, warming_call):
         """Setting the override after config loading fails loud.
 
         A silent cache clear could mask early code having already acted
-        on the wrong season, so the guard raises instead.
+        on the wrong season, so the guard raises instead. Every
+        season-derived cache must trip it.
         """
-        load_player_config()
+        warming_call()
         with pytest.raises(RuntimeError, match="script entry"):
             set_season_override("2024-25")

--- a/utils/player_config.py
+++ b/utils/player_config.py
@@ -1,8 +1,9 @@
 """
 Player configuration loading from YAML.
 
-This module provides cached access to player aliases and short alias lists
-from config/{season}/players.yaml for player mention detection.
+This module provides cached access to player aliases, short alias lists,
+player metadata, and the config version string from
+config/{season}/players.yaml.
 
 Note: Config is cached per process invocation via @lru_cache. One season
 per process — the season is resolved through get_active_season() at first
@@ -117,6 +118,43 @@ def resolve_sentiment_player(
     if not name:
         return None
     return alias_map.get(_normalize_player_name(name))
+
+
+@lru_cache(maxsize=1)
+def load_player_config_version() -> str:
+    """
+    Load the config version string from config/{season}/players.yaml.
+
+    The version (MAJOR = roster add/drop, MINOR = alias-only change) is
+    lineage metadata: it is stamped into sentiment.parquet at assembly
+    and checked against the on-disk config at aggregation read time.
+
+    Returns:
+        Version string, e.g. "4.2".
+
+    Raises:
+        FileNotFoundError: If config file doesn't exist.
+        yaml.YAMLError: If config file is invalid YAML.
+        ValueError: If the config has no 'version' key, or the value is
+            not a quoted string (an unquoted version parses as a YAML
+            float and would silently mis-stamp, e.g. 4.10 -> "4.1").
+    """
+    path = _get_players_path()
+    with open(path) as f:
+        config = yaml.safe_load(f)
+
+    version = config.get("version")
+    if version is None:
+        raise ValueError(
+            f"players.yaml for season {get_active_season()!r} has no "
+            f"'version' key: {path}"
+        )
+    if not isinstance(version, str):
+        raise ValueError(
+            f"players.yaml version must be a quoted string, got "
+            f"{version!r} ({type(version).__name__}) in {path}"
+        )
+    return version
 
 
 @lru_cache(maxsize=1)

--- a/utils/season_config.py
+++ b/utils/season_config.py
@@ -126,12 +126,18 @@ def _ensure_season_caches_cold() -> None:
     from utils.player_config import (
         build_alias_to_player_map,
         load_player_config,
+        load_player_config_version,
         load_player_metadata,
     )
 
     warm = [
         fn.__name__
-        for fn in (load_player_config, build_alias_to_player_map, load_player_metadata)
+        for fn in (
+            load_player_config,
+            build_alias_to_player_map,
+            load_player_metadata,
+            load_player_config_version,
+        )
         if fn.cache_info().currsize > 0
     ]
     if warm:


### PR DESCRIPTION
Closes #54. Design per the ticket + its 2026-07-27 amendment (all seven items implemented).

## What

`mentioned_players` is a cache of `f(body, players.yaml)`; the old assembly projected it from the filtered NDJSON, freezing matcher output at filter time — the mechanism behind the #47 near-miss (contaminated January matches resurrected on rebuild; crown would have flipped to Embiid). This PR makes rebuilds config-pure:

1. **Re-derivation** — `build_sentiment_dataframe` recomputes `mentioned_players` from `body` via `find_player_mentions` under the active/override season's config. `COMMENT_INPUT_SCHEMA` drops the column (its scan-projection role means the NDJSON copy is simply never read; it stays in the filtered file as a filter-time debugging record). Population preserved: zero-mention rows keep an empty list. `SENTIMENT_SCHEMA` unchanged, no version bump.
2. **Lineage stamp** — `collect_results` writes `players_config_version` + `schema_version` into parquet file metadata. New `load_player_config_version()` loader (third `@lru_cache` sibling in `utils/player_config.py`); rejects unquoted YAML versions (floats silently mis-stamp: `4.10` → `"4.1"`).
3. **Drift warning** — `aggregate_sentiment` warns on stamp≠on-disk-config and, distinctly, on absent stamp (every pre-#54 parquet). Warning, never an error — stale attribution is legitimate to read, just not silently.

## Registry note

The new loader joins the season-cache registry in all three places that enumerate it (`_ensure_season_caches_cold`, conftest `season_override` fixture, `test_season_config._clear_player_caches`). That list is now duplicated 3× — candidate future refactor to a shared tuple.

## Testing

TDD throughout; 405 passed, ruff clean. Code review: zero must-fix, LOW risk; should-fix (path in drift message) + two considerations (strict version string, doc pending-marker) folded in.

Real-data verification lands post-merge in this session: #47 clean rebuild (`collect_results --season 2024-25 --no-wait`) with a stashed-copy row-level diff — expected zero diff (the stash is the remediated artifact) — then the 2025-26 re-assembly (expected delta: stamp only).