### PR TITLE
feat(pipeline): roster snapshot acquisition (nba_stats.py + both season snapshots)

### DIFF
--- a/notebooks/2025-26/01_player_coverage.ipynb
+++ b/notebooks/2025-26/01_player_coverage.ipynb
@@ -583,7 +583,9 @@
     "- 2.1 — pull and cache the roster snapshot\n",
     "- 2.2 — reconcile carry-overs (same / moved / off-roster)\n",
     "- 2.3 — additions (mined + rookies/young + veterans)\n",
-    "- 2.4 — assemble and write the config"
+    "- 2.4 — assemble and write the config\n",
+    "\n",
+    "> **Superseded (2026-07-29):** the §2.1 acquisition cell below is kept as historical record; the roster snapshot is now fetched by `uv run python -m scripts.fetch_rosters` (`pipeline/nba_stats.py`, #39), which also captures `height`/`weight`."
    ]
   },
   {
@@ -2406,7 +2408,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "nba-hate-tracker",
+   "display_name": "nba-hate-tracker (3.11.13)",
    "language": "python",
    "name": "python3"
   },

--- a/pipeline/nba_stats.py
+++ b/pipeline/nba_stats.py
@@ -53,6 +53,18 @@ _RENAME = {
     "SCHOOL": "school",
 }
 
+# Endpoint columns that must land as strings (birth_date included: it is
+# parsed from string downstream). The endpoint serves these as strings
+# today, but they are semantically numeric-ish (EXP "5"/"R", NUM "00"),
+# so a serialization change to raw JSON numbers would hand pandas a
+# mixed str/int object column that pl.from_pandas cannot convert —
+# coercing in pandas first makes the fetch immune to that drift.
+_STRING_SOURCE_COLUMNS = [
+    raw
+    for raw, col in _RENAME.items()
+    if col == "birth_date" or ROSTERS_SCHEMA[col] == pl.String
+]
+
 
 def _call_with_retries(
     make_request: Callable[[], pl.DataFrame],
@@ -115,7 +127,13 @@ def _fetch_team_roster(team_id: int, season: str, timeout: int) -> pl.DataFrame:
         team_id=team_id, season=season, timeout=timeout
     ).get_data_frames()[0]
     cols = [c for c in _RENAME if c in raw.columns]
-    return pl.from_pandas(raw[cols]).rename({c: _RENAME[c] for c in cols})
+    selected = raw[cols].copy()
+    for col in _STRING_SOURCE_COLUMNS:
+        if col in selected.columns:
+            # pandas "string" dtype stringifies elements but keeps NA as
+            # NA (plain astype(str) would turn None into the string "None")
+            selected[col] = selected[col].astype("string")
+    return pl.from_pandas(selected).rename({c: _RENAME[c] for c in cols})
 
 
 def fetch_rosters(

--- a/pipeline/nba_stats.py
+++ b/pipeline/nba_stats.py
@@ -187,8 +187,9 @@ def fetch_rosters(
         logger.debug(f"{team['abbreviation']}: {frame.height} players")
         time.sleep(delay)
 
+    combined = pl.concat(frames, how="diagonal")
     rosters = (
-        pl.concat(frames, how="diagonal")
+        combined
         # nba_api serves "MAR 03, 1998"; titlecase so %b parses.
         .with_columns(
             pl.col("birth_date")
@@ -198,6 +199,17 @@ def fetch_rosters(
         .select(list(ROSTERS_SCHEMA.names()))
         .cast(dict(ROSTERS_SCHEMA))
     )
+    # strict=False nulls unparseable dates silently; surface the ones the
+    # parse nulled (as opposed to endpoint-supplied nulls) so a format
+    # drift can't degrade the column while the run reports success.
+    parse_failures = (
+        rosters["birth_date"].null_count() - combined["birth_date"].null_count()
+    )
+    if parse_failures:
+        logger.warning(
+            f'{parse_failures} birth_date value(s) did not match "%b %d, %Y" '
+            f"and were nulled"
+        )
     logger.info(
         f"Fetched {rosters.height} players across "
         f"{rosters['team_abbr'].n_unique()} teams"

--- a/pipeline/nba_stats.py
+++ b/pipeline/nba_stats.py
@@ -1,0 +1,187 @@
+"""
+NBA Stats API (stats.nba.com) acquisition via the nba_api package.
+
+Source-named acquisition module: everything fetched from stats.nba.com
+lives here (v3 game data is the anticipated second caller). Function-
+shaped rather than a client class — nba_api manages its own HTTP per
+call, so there is no session state to hold.
+
+stats.nba.com adds no retry handling of its own and its characteristic
+failure mode is hanging; every endpoint call runs through a bounded
+retry loop with exponential backoff.
+
+Usage:
+    from pipeline.nba_stats import fetch_rosters
+
+    rosters = fetch_rosters("2025-26")
+"""
+
+import logging
+import time
+from collections.abc import Callable
+from functools import partial
+
+import polars as pl
+import requests
+from nba_api.stats.endpoints import commonteamroster
+from nba_api.stats.static import teams as static_teams
+
+from pipeline.schemas import ROSTERS_SCHEMA
+from utils.constants import (
+    NBA_STATS_MAX_ATTEMPTS,
+    NBA_STATS_REQUEST_DELAY,
+    NBA_STATS_RETRY_BACKOFF,
+    NBA_STATS_TIMEOUT,
+)
+
+logger = logging.getLogger(__name__)
+
+# Raw endpoint column -> snapshot column. The selection half of
+# ROSTERS_SCHEMA: endpoint columns absent here (SEASON, LeagueID,
+# PLAYER_SLUG, TeamID) are dropped; team_name/team_abbr are added per
+# team from the static team list, not the endpoint payload.
+_RENAME = {
+    "PLAYER_ID": "player_id",
+    "PLAYER": "player_name",
+    "NUM": "jersey_number",
+    "POSITION": "position",
+    "HEIGHT": "height",
+    "WEIGHT": "weight",
+    "AGE": "age",
+    "EXP": "experience",
+    "BIRTH_DATE": "birth_date",
+    "SCHOOL": "school",
+}
+
+
+def _call_with_retries(
+    make_request: Callable[[], pl.DataFrame],
+    *,
+    label: str,
+    max_attempts: int,
+    retry_backoff: float,
+) -> pl.DataFrame:
+    """
+    Run an endpoint call through a bounded retry loop.
+
+    Connection errors and timeouts are transient by nature on
+    stats.nba.com; anything else indicates a real problem with the
+    request and propagates immediately.
+
+    Args:
+        make_request: Zero-arg callable performing one endpoint call.
+        label: Human-readable request name for retry log lines.
+        max_attempts: Total attempts (1 initial + retries).
+        retry_backoff: Base seconds for exponential backoff between retries.
+
+    Returns:
+        The callable's result from the first successful attempt.
+
+    Raises:
+        requests.ConnectionError | requests.Timeout: The last transient
+            error, after max_attempts is exhausted.
+    """
+    last_error: requests.RequestException | None = None
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return make_request()
+        except (requests.ConnectionError, requests.Timeout) as e:
+            last_error = e
+            if attempt < max_attempts:
+                wait = retry_backoff * (2 ** (attempt - 1))
+                logger.warning(
+                    f"Transient stats.nba.com error on {label} "
+                    f"(attempt {attempt}/{max_attempts}), retrying in {wait:.0f}s: {e}"
+                )
+                time.sleep(wait)
+
+    raise last_error  # type: ignore[misc]  # loop always sets it before exiting
+
+
+def _fetch_team_roster(team_id: int, season: str, timeout: int) -> pl.DataFrame:
+    """
+    Fetch one team's roster and normalize to snapshot column names.
+
+    Args:
+        team_id: nba_api static team id.
+        season: Season identifier the endpoint expects (e.g. "2025-26").
+        timeout: Per-request timeout in seconds.
+
+    Returns:
+        Frame with the renamed endpoint columns (team literals not yet added).
+    """
+    raw = commonteamroster.CommonTeamRoster(
+        team_id=team_id, season=season, timeout=timeout
+    ).get_data_frames()[0]
+    cols = [c for c in _RENAME if c in raw.columns]
+    return pl.from_pandas(raw[cols]).rename({c: _RENAME[c] for c in cols})
+
+
+def fetch_rosters(
+    season: str,
+    *,
+    delay: float = NBA_STATS_REQUEST_DELAY,
+    timeout: int = NBA_STATS_TIMEOUT,
+    max_attempts: int = NBA_STATS_MAX_ATTEMPTS,
+    retry_backoff: float = NBA_STATS_RETRY_BACKOFF,
+) -> pl.DataFrame:
+    """
+    Fetch all 30 team rosters for a season as one ROSTERS_SCHEMA frame.
+
+    Strict by design: a team that exhausts its retries fails the whole
+    fetch rather than producing a silently incomplete snapshot — the
+    snapshot feeds the Player dimension, where a missing team would
+    surface as unexplained join gaps.
+
+    Args:
+        season: Season identifier (e.g. "2025-26"). The CommonTeamRoster
+            endpoint is season-parameterized, so past seasons are
+            retro-fetchable.
+        delay: Seconds to wait after each team request.
+        timeout: Per-request timeout in seconds.
+        max_attempts: Total attempts per team request (1 initial + retries).
+        retry_backoff: Base seconds for exponential backoff between retries.
+
+    Returns:
+        One row per rostered player, conforming to ROSTERS_SCHEMA.
+
+    Raises:
+        requests.RequestException: If any team's roster cannot be fetched.
+    """
+    teams = static_teams.get_teams()
+    logger.info(f"Fetching {len(teams)} team rosters for {season} from stats.nba.com")
+
+    frames: list[pl.DataFrame] = []
+    for team in teams:
+        frame = _call_with_retries(
+            partial(_fetch_team_roster, team["id"], season, timeout),
+            label=f"{team['abbreviation']} roster",
+            max_attempts=max_attempts,
+            retry_backoff=retry_backoff,
+        )
+        frames.append(
+            frame.with_columns(
+                pl.lit(team["full_name"]).alias("team_name"),
+                pl.lit(team["abbreviation"]).alias("team_abbr"),
+            )
+        )
+        logger.debug(f"{team['abbreviation']}: {frame.height} players")
+        time.sleep(delay)
+
+    rosters = (
+        pl.concat(frames, how="diagonal")
+        # nba_api serves "MAR 03, 1998"; titlecase so %b parses.
+        .with_columns(
+            pl.col("birth_date")
+            .str.to_titlecase()
+            .str.to_date("%b %d, %Y", strict=False)
+        )
+        .select(list(ROSTERS_SCHEMA.names()))
+        .cast(dict(ROSTERS_SCHEMA))
+    )
+    logger.info(
+        f"Fetched {rosters.height} players across "
+        f"{rosters['team_abbr'].n_unique()} teams"
+    )
+    return rosters

--- a/pipeline/schemas.py
+++ b/pipeline/schemas.py
@@ -1,5 +1,5 @@
 """
-Schema contracts for produced data files.
+Schema contracts for produced data files and cached reference assets.
 
 Single source of truth for column names and dtypes of every file the
 pipeline produces. Data dictionary first, enforcement second:
@@ -10,6 +10,9 @@ pipeline produces. Data dictionary first, enforcement second:
 - The four aggregate-view schemas describe the tabular sections of
   aggregates.json in their parquet-ready shape; they are enforced in
   aggregate_sentiment() before the views are returned for writing.
+- ROSTERS_SCHEMA describes the season roster snapshot — a reference
+  asset (pipeline ingredient, not a published output) enforced at the
+  fetch write boundary (scripts/fetch_rosters.py).
 
 This module must not import from other pipeline modules (it is imported
 by them).
@@ -85,6 +88,31 @@ RESULTS_SCHEMA = pl.Schema(
     {
         "id": SENTIMENT_SCHEMA["comment_id"],
         **{col: SENTIMENT_SCHEMA[col] for col in _RESULTS_SIDE_COLUMNS},
+    }
+)
+
+# --- Reference assets (enforced at the fetch write site) --------------------
+
+# data/<season>/reference/rosters.parquet — one row per rostered player, the
+# season roster snapshot from stats.nba.com (pipeline/nba_stats.py). A faithful
+# capture of the endpoint: columns the Player-dimension build ignores
+# (player_name, team_name/team_abbr, age) stay here deliberately — the
+# dimension, not the snapshot, decides what ships. Roster team is
+# point-in-time (season-end); see docs/data-model.md §3.
+ROSTERS_SCHEMA = pl.Schema(
+    {
+        "player_id": pl.Int64,
+        "player_name": pl.String,
+        "team_name": pl.String,
+        "team_abbr": pl.String,
+        "jersey_number": pl.String,  # string on purpose: "00" is a real number
+        "position": pl.String,
+        "height": pl.String,  # feet-inches format ("6-8"); bio-line only
+        "weight": pl.String,  # pounds-as-string; bio-line only
+        "age": pl.Int64,  # frozen at fetch; consumers derive age from birth_date
+        "experience": pl.String,  # "R" for rookies, else years as string
+        "birth_date": pl.Date,
+        "school": pl.String,
     }
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "plotly>=6.5.2",
     "pandas>=2.3.3",
     "duckdb>=1.5.4",
+    "nba-api>=1.11.4",
 ]
 
 [tool.ruff]

--- a/scripts/fetch_rosters.py
+++ b/scripts/fetch_rosters.py
@@ -1,0 +1,109 @@
+"""
+Fetch and cache the season roster snapshot from stats.nba.com.
+
+Writes data/<season>/reference/rosters.parquet — the reference asset the
+Player-dimension build joins factual fields from. Refuses to overwrite an
+existing snapshot unless --force: replacing a snapshot is a deliberate
+act, so archive the old file first if it should survive.
+
+Usage:
+    uv run python -m scripts.fetch_rosters
+    uv run python -m scripts.fetch_rosters --season 2024-25
+    uv run python -m scripts.fetch_rosters --force
+"""
+
+import argparse
+import logging
+import sys
+from datetime import datetime, timezone
+
+from pipeline.nba_stats import fetch_rosters
+from pipeline.schemas import ROSTERS_SCHEMA, SCHEMA_VERSION, validate_schema
+from utils.paths import get_reference_dir
+from utils.season_config import get_active_season, set_season_override
+
+# -----------------------------------------------------------------------------
+# Logging setup
+# -----------------------------------------------------------------------------
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s | %(levelname)-8s | %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+
+# -----------------------------------------------------------------------------
+# Default filenames (directories come from utils/paths)
+# -----------------------------------------------------------------------------
+
+OUTPUT_FILENAME = "rosters.parquet"
+
+
+# -----------------------------------------------------------------------------
+# CLI
+# -----------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Main entry point for roster snapshot fetching."""
+    parser = argparse.ArgumentParser(
+        description="Fetch and cache the season roster snapshot from stats.nba.com"
+    )
+    parser.add_argument(
+        "--season",
+        default=None,
+        metavar="YYYY-YY",
+        help='Override the active season (e.g. "2024-25"); the roster '
+        "endpoint query and the output path both resolve to it for this run",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an existing snapshot",
+    )
+    args = parser.parse_args()
+
+    if args.season:
+        set_season_override(args.season)
+
+    # Resolves after the override: one source for both the endpoint
+    # season parameter and the season-scoped output directory.
+    season = get_active_season()
+    output_path = get_reference_dir() / OUTPUT_FILENAME
+
+    if output_path.exists() and not args.force:
+        logger.error(
+            f"{output_path} already exists - move it aside to archive it, "
+            "or pass --force to overwrite"
+        )
+        sys.exit(1)
+
+    logger.info("=" * 60)
+    logger.info(f"Roster snapshot: {season}")
+    logger.info("=" * 60)
+
+    rosters = fetch_rosters(season)
+    validate_schema(rosters, ROSTERS_SCHEMA, OUTPUT_FILENAME)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    # Lineage metadata: a snapshot must carry its own fetch date and
+    # season to stay diffable against later re-fetches.
+    rosters.write_parquet(
+        output_path,
+        metadata={
+            "season": season,
+            "fetched_at": datetime.now(timezone.utc).date().isoformat(),
+            "schema_version": str(SCHEMA_VERSION),
+        },
+    )
+
+    logger.info(
+        f"Wrote {rosters.height} players / "
+        f"{rosters['team_abbr'].n_unique()} teams to {output_path}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_nba_stats.py
+++ b/tests/unit/test_nba_stats.py
@@ -1,5 +1,6 @@
 """Tests for pipeline/nba_stats.py roster snapshot acquisition."""
 
+import logging
 from datetime import date
 from unittest.mock import Mock, call, patch
 
@@ -122,6 +123,34 @@ class TestFetchRosters:
         by_player = {r["player_name"]: r for r in df.to_dicts()}
         assert by_player["Player One"]["birth_date"] == date(1998, 3, 3)
         assert by_player["Rookie One"]["birth_date"] == date(2005, 6, 26)
+
+    def test_warns_on_unparseable_birth_date(self, caplog):
+        """A birth date that doesn't match the format nulls with a warning."""
+        frames = _two_team_frames()
+        frames[2] = pd.DataFrame(
+            [
+                _raw_row(
+                    TeamID=2,
+                    PLAYER="Player Two",
+                    PLAYER_ID=200,
+                    BIRTH_DATE="1998-03-03",
+                )
+            ]
+        )
+
+        with caplog.at_level(logging.WARNING, logger="pipeline.nba_stats"):
+            df, _, _ = _fetch_with_mocks(_endpoint_returning(frames))
+
+        by_player = {r["player_name"]: r for r in df.to_dicts()}
+        assert by_player["Player Two"]["birth_date"] is None
+        assert "1 birth_date value(s)" in caplog.text
+
+    def test_no_warning_when_all_birth_dates_parse(self, caplog):
+        """Endpoint-supplied nulls don't trigger the parse-failure warning."""
+        with caplog.at_level(logging.WARNING, logger="pipeline.nba_stats"):
+            _fetch_with_mocks(_endpoint_returning(_two_team_frames()))
+
+        assert "birth_date" not in caplog.text
 
     def test_null_school_survives_as_null(self):
         """A missing SCHOOL value lands as null, not the string 'None'."""

--- a/tests/unit/test_nba_stats.py
+++ b/tests/unit/test_nba_stats.py
@@ -67,9 +67,29 @@ def _fetch_with_mocks(
 
 
 def _two_team_frames() -> dict[int, pd.DataFrame]:
-    """Raw frames for the two fake teams, one player each."""
+    """Raw frames for the two fake teams: a vet + a rookie, then one player.
+
+    Team 1 mixes a veteran and a rookie so fixtures carry the endpoint's
+    real shape heterogeneity (EXP "5" vs "R", NUM "23" vs "00", a null
+    SCHOOL) instead of homogeneous single-row frames.
+    """
     return {
-        1: pd.DataFrame([_raw_row()]),
+        1: pd.DataFrame(
+            [
+                _raw_row(),
+                _raw_row(
+                    PLAYER="Rookie One",
+                    PLAYER_ID=101,
+                    NUM="00",
+                    HEIGHT="7-1",
+                    WEIGHT="232",
+                    BIRTH_DATE="JUN 26, 2005",
+                    AGE=21.0,
+                    EXP="R",
+                    SCHOOL=None,
+                ),
+            ]
+        ),
         2: pd.DataFrame(
             [_raw_row(TeamID=2, PLAYER="Player Two", PLAYER_ID=200, NUM="0")]
         ),
@@ -89,14 +109,26 @@ class TestFetchRosters:
         """HEIGHT/WEIGHT survive normalization (the notebook capture dropped them)."""
         df, _, _ = _fetch_with_mocks(_endpoint_returning(_two_team_frames()))
 
-        assert df["height"].to_list() == ["6-8", "6-8"]
-        assert df["weight"].to_list() == ["230", "230"]
+        by_player = {r["player_name"]: r for r in df.to_dicts()}
+        assert by_player["Player One"]["height"] == "6-8"
+        assert by_player["Player One"]["weight"] == "230"
+        assert by_player["Rookie One"]["height"] == "7-1"
+        assert by_player["Rookie One"]["weight"] == "232"
 
     def test_parses_birth_date(self):
         """The endpoint's 'MAR 03, 1998' string lands as a real Date."""
         df, _, _ = _fetch_with_mocks(_endpoint_returning(_two_team_frames()))
 
-        assert df["birth_date"].to_list() == [date(1998, 3, 3)] * 2
+        by_player = {r["player_name"]: r for r in df.to_dicts()}
+        assert by_player["Player One"]["birth_date"] == date(1998, 3, 3)
+        assert by_player["Rookie One"]["birth_date"] == date(2005, 6, 26)
+
+    def test_null_school_survives_as_null(self):
+        """A missing SCHOOL value lands as null, not the string 'None'."""
+        df, _, _ = _fetch_with_mocks(_endpoint_returning(_two_team_frames()))
+
+        by_player = {r["player_name"]: r for r in df.to_dicts()}
+        assert by_player["Rookie One"]["school"] is None
 
     def test_adds_team_literals_from_static_data(self):
         """team_name/team_abbr come from the static team list, one pair per team."""
@@ -104,9 +136,29 @@ class TestFetchRosters:
 
         by_player = {r["player_name"]: r for r in df.to_dicts()}
         assert by_player["Player One"]["team_name"] == "Atlanta Hawks"
-        assert by_player["Player One"]["team_abbr"] == "ATL"
+        assert by_player["Rookie One"]["team_abbr"] == "ATL"
         assert by_player["Player Two"]["team_name"] == "Boston Celtics"
         assert by_player["Player Two"]["team_abbr"] == "BOS"
+
+    def test_coerces_numeric_serialized_string_columns(self):
+        """Raw JSON ints in string-typed columns coerce instead of crashing.
+
+        The endpoint serves EXP/NUM as strings today; if that serialization
+        ever drifts to raw numbers, the mixed str/int object column must
+        still convert (pl.from_pandas would otherwise raise ArrowInvalid).
+        """
+        frames = {
+            1: pd.DataFrame([_raw_row(EXP=5, NUM=0), _raw_row(PLAYER_ID=101)]),
+            2: pd.DataFrame(
+                [_raw_row(TeamID=2, PLAYER="Player Two", PLAYER_ID=200, NUM="00")]
+            ),
+        }
+
+        df, _, _ = _fetch_with_mocks(_endpoint_returning(frames))
+
+        assert df.schema == ROSTERS_SCHEMA
+        assert sorted(df["experience"].to_list()) == ["5", "5", "5"]
+        assert sorted(df["jersey_number"].to_list()) == ["0", "00", "23"]
 
     def test_passes_season_and_timeout_to_endpoint(self):
         """Every endpoint call carries the requested season and timeout."""
@@ -148,7 +200,7 @@ class TestRetry:
         df, mock_endpoint, _ = _fetch_with_mocks(_flaky)
 
         assert mock_endpoint.call_count == 3  # team 1 twice, team 2 once
-        assert df.height == 2
+        assert df.height == 3
 
     def test_exhaustion_raises_with_backoff_schedule(self):
         """Persistent timeouts raise after max_attempts, backing off exponentially."""

--- a/tests/unit/test_nba_stats.py
+++ b/tests/unit/test_nba_stats.py
@@ -1,0 +1,207 @@
+"""Tests for pipeline/nba_stats.py roster snapshot acquisition."""
+
+from datetime import date
+from unittest.mock import Mock, call, patch
+
+import pandas as pd
+import polars as pl
+import pytest
+import requests
+
+from pipeline.nba_stats import fetch_rosters
+from pipeline.schemas import ROSTERS_SCHEMA
+
+FAKE_TEAMS = [
+    {"id": 1, "full_name": "Atlanta Hawks", "abbreviation": "ATL"},
+    {"id": 2, "full_name": "Boston Celtics", "abbreviation": "BOS"},
+]
+
+
+def _raw_row(**overrides) -> dict:
+    """One endpoint-shaped raw roster row (uppercase nba_api columns)."""
+    row = {
+        "TeamID": 1,
+        "SEASON": "2025-26",
+        "LeagueID": "00",
+        "PLAYER": "Player One",
+        "PLAYER_SLUG": "player-one",
+        "NUM": "23",
+        "POSITION": "F",
+        "HEIGHT": "6-8",
+        "WEIGHT": "230",
+        "BIRTH_DATE": "MAR 03, 1998",
+        "AGE": 27.0,
+        "EXP": "5",
+        "SCHOOL": "Duke",
+        "PLAYER_ID": 100,
+    }
+    row.update(overrides)
+    return row
+
+
+def _endpoint_returning(frames_by_team: dict[int, pd.DataFrame]):
+    """Build a CommonTeamRoster stand-in serving one raw frame per team_id."""
+
+    def _make(team_id: int, season: str, timeout: int) -> Mock:
+        endpoint = Mock()
+        endpoint.get_data_frames.return_value = [frames_by_team[team_id]]
+        return endpoint
+
+    return _make
+
+
+def _fetch_with_mocks(
+    endpoint_side_effect, teams=FAKE_TEAMS, **fetch_kwargs
+) -> tuple[pl.DataFrame, Mock, Mock]:
+    """Run fetch_rosters with the endpoint, static teams, and sleep mocked."""
+    with (
+        patch("pipeline.nba_stats.static_teams.get_teams", return_value=teams),
+        patch(
+            "pipeline.nba_stats.commonteamroster.CommonTeamRoster",
+            side_effect=endpoint_side_effect,
+        ) as mock_endpoint,
+        patch("pipeline.nba_stats.time.sleep") as mock_sleep,
+    ):
+        df = fetch_rosters("2025-26", **fetch_kwargs)
+    return df, mock_endpoint, mock_sleep
+
+
+def _two_team_frames() -> dict[int, pd.DataFrame]:
+    """Raw frames for the two fake teams, one player each."""
+    return {
+        1: pd.DataFrame([_raw_row()]),
+        2: pd.DataFrame(
+            [_raw_row(TeamID=2, PLAYER="Player Two", PLAYER_ID=200, NUM="0")]
+        ),
+    }
+
+
+class TestFetchRosters:
+    """Tests for endpoint normalization into the snapshot contract."""
+
+    def test_conforms_to_rosters_schema(self):
+        """The returned frame matches ROSTERS_SCHEMA exactly (names, dtypes, order)."""
+        df, _, _ = _fetch_with_mocks(_endpoint_returning(_two_team_frames()))
+
+        assert df.schema == ROSTERS_SCHEMA
+
+    def test_keeps_height_and_weight(self):
+        """HEIGHT/WEIGHT survive normalization (the notebook capture dropped them)."""
+        df, _, _ = _fetch_with_mocks(_endpoint_returning(_two_team_frames()))
+
+        assert df["height"].to_list() == ["6-8", "6-8"]
+        assert df["weight"].to_list() == ["230", "230"]
+
+    def test_parses_birth_date(self):
+        """The endpoint's 'MAR 03, 1998' string lands as a real Date."""
+        df, _, _ = _fetch_with_mocks(_endpoint_returning(_two_team_frames()))
+
+        assert df["birth_date"].to_list() == [date(1998, 3, 3)] * 2
+
+    def test_adds_team_literals_from_static_data(self):
+        """team_name/team_abbr come from the static team list, one pair per team."""
+        df, _, _ = _fetch_with_mocks(_endpoint_returning(_two_team_frames()))
+
+        by_player = {r["player_name"]: r for r in df.to_dicts()}
+        assert by_player["Player One"]["team_name"] == "Atlanta Hawks"
+        assert by_player["Player One"]["team_abbr"] == "ATL"
+        assert by_player["Player Two"]["team_name"] == "Boston Celtics"
+        assert by_player["Player Two"]["team_abbr"] == "BOS"
+
+    def test_passes_season_and_timeout_to_endpoint(self):
+        """Every endpoint call carries the requested season and timeout."""
+        _, mock_endpoint, _ = _fetch_with_mocks(
+            _endpoint_returning(_two_team_frames()), timeout=45
+        )
+
+        assert mock_endpoint.call_count == len(FAKE_TEAMS)
+        for call_args in mock_endpoint.call_args_list:
+            assert call_args.kwargs["season"] == "2025-26"
+            assert call_args.kwargs["timeout"] == 45
+
+    def test_sleeps_between_teams(self):
+        """The politeness delay runs once per team request."""
+        _, _, mock_sleep = _fetch_with_mocks(
+            _endpoint_returning(_two_team_frames()), delay=0.6
+        )
+
+        assert mock_sleep.call_args_list == [call(0.6), call(0.6)]
+
+
+class TestRetry:
+    """Tests for the bounded retry loop around endpoint calls."""
+
+    def test_transient_timeout_then_success(self):
+        """A timeout is retried and the fetch still completes."""
+        frames = _two_team_frames()
+        make = _endpoint_returning(frames)
+        attempts = iter([requests.Timeout("hang"), make(1, "2025-26", 30)])
+
+        def _flaky(team_id: int, season: str, timeout: int) -> Mock:
+            if team_id == 1:
+                result = next(attempts)
+                if isinstance(result, Exception):
+                    raise result
+                return result
+            return make(team_id, season, timeout)
+
+        df, mock_endpoint, _ = _fetch_with_mocks(_flaky)
+
+        assert mock_endpoint.call_count == 3  # team 1 twice, team 2 once
+        assert df.height == 2
+
+    def test_exhaustion_raises_with_backoff_schedule(self):
+        """Persistent timeouts raise after max_attempts, backing off exponentially."""
+
+        def _always_timeout(team_id: int, season: str, timeout: int) -> Mock:
+            raise requests.Timeout("hang")
+
+        with pytest.raises(requests.Timeout):
+            _fetch_with_mocks(_always_timeout, max_attempts=4, retry_backoff=2.0)
+
+        # Re-run capturing sleep to assert the schedule (no delay sleeps: the
+        # first team never succeeds, so only backoff sleeps happen).
+        with (
+            patch("pipeline.nba_stats.static_teams.get_teams", return_value=FAKE_TEAMS),
+            patch(
+                "pipeline.nba_stats.commonteamroster.CommonTeamRoster",
+                side_effect=_always_timeout,
+            ),
+            patch("pipeline.nba_stats.time.sleep") as mock_sleep,
+        ):
+            with pytest.raises(requests.Timeout):
+                fetch_rosters("2025-26", max_attempts=4, retry_backoff=2.0)
+
+        assert mock_sleep.call_args_list == [call(2.0), call(4.0), call(8.0)]
+
+    def test_non_retryable_error_raises_immediately(self):
+        """A non-transient error propagates without retries."""
+
+        def _http_error(team_id: int, season: str, timeout: int) -> Mock:
+            raise requests.HTTPError("400 Client Error")
+
+        with (
+            patch("pipeline.nba_stats.static_teams.get_teams", return_value=FAKE_TEAMS),
+            patch(
+                "pipeline.nba_stats.commonteamroster.CommonTeamRoster",
+                side_effect=_http_error,
+            ) as mock_endpoint,
+            patch("pipeline.nba_stats.time.sleep"),
+        ):
+            with pytest.raises(requests.HTTPError):
+                fetch_rosters("2025-26")
+
+        assert mock_endpoint.call_count == 1
+
+    def test_failed_team_kills_the_whole_fetch(self):
+        """A team that exhausts retries fails the fetch — no partial snapshot."""
+        frames = _two_team_frames()
+        make = _endpoint_returning(frames)
+
+        def _second_team_down(team_id: int, season: str, timeout: int) -> Mock:
+            if team_id == 2:
+                raise requests.ConnectionError("down")
+            return make(team_id, season, timeout)
+
+        with pytest.raises(requests.ConnectionError):
+            _fetch_with_mocks(_second_team_down, max_attempts=2)

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -19,6 +19,7 @@ from utils.paths import (
     get_filtered_dir,
     get_processed_dir,
     get_raw_dir,
+    get_reference_dir,
 )
 
 PINNED_SEASON = "2098-99"
@@ -96,3 +97,9 @@ class TestLeafPathFunctions:
         result = get_dashboard_dir()
         assert result.parent.name == pinned_season
         assert result.name == "dashboard"
+
+    def test_reference_dir_is_season_scoped(self, pinned_season):
+        """Reference dir is under the season directory."""
+        result = get_reference_dir()
+        assert result.parent.name == pinned_season
+        assert result.name == "reference"

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -1,9 +1,16 @@
 """Tests for pipeline/schemas.py schema validation."""
 
+from datetime import date
+
 import polars as pl
 import pytest
 
-from pipeline.schemas import COMMENT_INPUT_SCHEMA, SENTIMENT_SCHEMA, validate_schema
+from pipeline.schemas import (
+    COMMENT_INPUT_SCHEMA,
+    ROSTERS_SCHEMA,
+    SENTIMENT_SCHEMA,
+    validate_schema,
+)
 
 
 @pytest.fixture
@@ -42,6 +49,47 @@ class TestLinkIdContract:
     def test_comment_input_schema_reads_link_id(self):
         """Verify the filtered-NDJSON projection carries link_id."""
         assert COMMENT_INPUT_SCHEMA["link_id"] == pl.String
+
+
+@pytest.fixture
+def roster_frame() -> pl.DataFrame:
+    """One-row DataFrame conforming exactly to ROSTERS_SCHEMA."""
+    return pl.DataFrame(
+        [
+            {
+                "player_id": 2544,
+                "player_name": "LeBron James",
+                "team_name": "Los Angeles Lakers",
+                "team_abbr": "LAL",
+                "jersey_number": "23",
+                "position": "F",
+                "height": "6-9",
+                "weight": "250",
+                "age": 40,
+                "experience": "21",
+                "birth_date": date(1984, 12, 30),
+                "school": "St. Vincent-St. Mary HS (OH)",
+            }
+        ],
+        schema=ROSTERS_SCHEMA,
+    )
+
+
+class TestRostersContract:
+    """Contract guards for the roster snapshot reference asset."""
+
+    def test_conforming_frame_passes(self, roster_frame):
+        """Verify a frame matching ROSTERS_SCHEMA validates without raising."""
+        validate_schema(roster_frame, ROSTERS_SCHEMA, "rosters.parquet")
+
+    def test_pins_height_and_weight(self):
+        """Verify the bio columns are in the contract (the re-snapshot's point)."""
+        assert ROSTERS_SCHEMA["height"] == pl.String
+        assert ROSTERS_SCHEMA["weight"] == pl.String
+
+    def test_birth_date_is_date_typed(self):
+        """Verify birth_date lands as a real Date, not the endpoint's raw string."""
+        assert ROSTERS_SCHEMA["birth_date"] == pl.Date
 
 
 class TestValidateSchema:

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -4,6 +4,7 @@ Constants for the NBA Hate Tracker project.
 This module contains:
 - Data validation constants
 - Arctic Shift API configuration
+- NBA Stats API configuration
 - Season date boundaries
 """
 
@@ -81,6 +82,27 @@ ARCTIC_SHIFT_RETRYABLE_STATUSES = frozenset(
 )
 
 
+# =============================================================================
+# NBA STATS API CONFIGURATION (stats.nba.com via nba_api)
+# =============================================================================
+
+# Delay between per-team roster requests in seconds (be polite to
+# stats.nba.com — it rate-limits aggressively and bans are opaque)
+NBA_STATS_REQUEST_DELAY = 0.6
+
+# Per-request timeout in seconds. stats.nba.com's characteristic failure
+# mode is hanging, not erroring — a bounded timeout is what converts a
+# hang into a retryable Timeout.
+NBA_STATS_TIMEOUT = 30
+
+# Total attempts per endpoint call (1 initial + retries). The full fetch
+# is only 30 requests, so unlike the Arctic Shift download there is no
+# long burst to ride out: 4 attempts -> 2+4+8 = 14s of coverage per call.
+NBA_STATS_MAX_ATTEMPTS = 4
+
+# Base seconds for exponential backoff between retries (2s -> 4s -> 8s)
+NBA_STATS_RETRY_BACKOFF = 2.0
+
 
 # =============================================================================
 # FILE PATHS (relative subdirectories - root comes from environment)
@@ -92,3 +114,4 @@ PROGRESS_FILENAME = ".progress.json"
 BATCHES_DATA_SUBDIR = "batches"
 PROCESSED_DATA_SUBDIR = "processed"
 DASHBOARD_DATA_SUBDIR = "dashboard"
+REFERENCE_DATA_SUBDIR = "reference"

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -22,6 +22,7 @@ from utils.constants import (
     BATCHES_DATA_SUBDIR,
     PROCESSED_DATA_SUBDIR,
     DASHBOARD_DATA_SUBDIR,
+    REFERENCE_DATA_SUBDIR,
 )
 from utils.season_config import get_active_season
 
@@ -95,3 +96,13 @@ def get_dashboard_dir() -> Path:
         Path to dashboard directory (e.g., data/2024-25/dashboard/).
     """
     return get_data_dir() / DASHBOARD_DATA_SUBDIR
+
+
+def get_reference_dir() -> Path:
+    """
+    Get reference directory for cached external snapshots (e.g. rosters).
+
+    Returns:
+        Path to reference directory (e.g., data/2024-25/reference/).
+    """
+    return get_data_dir() / REFERENCE_DATA_SUBDIR

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,8 @@ revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version < '3.12'",
 ]
 
@@ -1655,6 +1656,20 @@ wheels = [
 ]
 
 [[package]]
+name = "nba-api"
+version = "1.11.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/f8/761434ce98e39d6bdd1b98611102fdc054920e330a5b5194464cb340adf8/nba_api-1.11.4.tar.gz", hash = "sha256:1dccd70b78f36f64260e1f353c4a02c1644147c4a2a5ce42fbd9f637d70bad3e", size = 177323, upload-time = "2026-02-20T07:02:39.61Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/c2/17c805220de846ea9280f62a003c0cdebddf1de3d387614162891502a3a6/nba_api-1.11.4-py3-none-any.whl", hash = "sha256:f489b2a1d67ee4298f5173775b335d0e43e63455ed157a5612b542094b9f1963", size = 322583, upload-time = "2026-02-20T07:02:36.578Z" },
+]
+
+[[package]]
 name = "nba-hate-tracker"
 version = "0.1.0"
 source = { virtual = "." }
@@ -1665,6 +1680,7 @@ dependencies = [
     { name = "duckdb" },
     { name = "jupyter" },
     { name = "matplotlib" },
+    { name = "nba-api" },
     { name = "pandas" },
     { name = "plotly" },
     { name = "polars" },
@@ -1695,6 +1711,7 @@ requires-dist = [
     { name = "duckdb", specifier = ">=1.5.4" },
     { name = "jupyter" },
     { name = "matplotlib", specifier = ">=3.10.8" },
+    { name = "nba-api", specifier = ">=1.11.4" },
     { name = "pandas", specifier = ">=2.3.3" },
     { name = "plotly", specifier = ">=6.5.2" },
     { name = "polars" },


### PR DESCRIPTION
Part 1 of 2 for #39 (acquisition PR per the ticket's suggested split; the dimension build follows). Refs #39 — does not close it.

## What

Promotes the roster snapshot from a notebook ritual (`01_player_coverage.ipynb` §2.1) to a pipeline citizen, and front-loads the two time-sensitive live fetches:

- **`pipeline/nba_stats.py`** — source-named acquisition module, function-shaped (`fetch_rosters(season, *, delay, timeout, max_attempts, retry_backoff)`). Every endpoint call runs a bounded retry loop with exponential backoff (nba_api has no retry handling of its own; stats.nba.com hangs rather than errors). Strict per-team: a team that exhausts retries fails the fetch — no silently incomplete snapshots.
- **`scripts/fetch_rosters.py --season [--force]`** — thin CLI wrapper; refuses to overwrite an existing snapshot without `--force`; stamps `season` + `fetched_at` + `schema_version` into parquet metadata so snapshots stay diffable.
- **`ROSTERS_SCHEMA`** in `pipeline/schemas.py` (2026-07-29 ticket amendment) — the notebook column set plus `height`/`weight`, which the endpoint returns natively but the notebook never selected. Deliberately widens schemas.py's charter to produced + reference assets.
- **`get_reference_dir()`** in `utils/paths.py` + `NBA_STATS_*` constants block mirroring the Arctic Shift one.
- `nba-api` declared (1.11.4); notebook §2 marked superseded (cell kept as record).

## Live-fetch verification (2026-07-29)

**2025-26 re-snapshot** (June-30 cache archived as `rosters.2026-06-30.parquet`, kept on disk):
- 530 players / 30 teams, identical membership: 0 added, 0 removed, **0 team changes** (Jaylen Brown → BOS, confirming the endpoint serves season-scoped truth despite active free agency)
- `height`/`weight` captured, 0 nulls
- Only drift: `school` on 3 rookies (two upstream backfills; one upstream error — Johni Broome's school now reads "Philadelphia 76ers"). Treat `school` as a low-trust cosmetic column.

**2024-25 retro-snapshot**: 534 players / 30 teams. Luka Dončić → LAL (season-end team; trade correctly reflected, per the data-model §3 point-in-time convention).

**Coverage baseline for the dimension PR**: of the v1 config's 111 tracked players (all carrying `player_id`), exactly **1** is missing from the retro-snapshot: Patrick Beverley (201976), who left the NBA mid-season — the expected LEFT JOIN + baked-config-fallback case. Note the snapshot stores diacritic names ("Dončić"); the dimension joins on `player_id`, so name spelling is irrelevant to the build.

`data/` is gitignored — both snapshots are cached artifacts on disk, not committed.

## Test plan

- `tests/unit/test_nba_stats.py`: normalization (schema conformance, birth-date parse, team literals, season/timeout passthrough, politeness delay) + retry behavior (transient-then-success, backoff schedule, non-retryable immediate raise, failed-team-kills-fetch)
- `tests/unit/test_schemas.py` / `test_paths.py`: `ROSTERS_SCHEMA` contract guards, `get_reference_dir()` season scoping
- `uv run pytest` (419 passed) and `uv run ruff check .` green; pre-commit gate passed per commit