### PR TITLE
feat(pipeline): build players.parquet — the Player dimension (#39)

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -2,7 +2,7 @@
 
 **Purpose:** The shared conceptual vocabulary for V2 dashboard design. A new dashboard view is a question asked against this model; having the model written down is what lets you tell at a glance whether a question is **cheap** (already in an aggregate), **needs a join** (a dimension lookup, no new pipeline output), or **expensive** (a new aggregate view the pipeline must produce).
 
-**How to read it:** The core model below — the ER diagram, the entity key, and the view-lineage table — is the authoritative *"is"*: what the pipeline produces today (plus the planned standalone Player dimension file). The single fenced section at the very end, **Forward look (v3)**, is *"will be"* — direction, not built. Nothing in that section touches the core diagram or the present-now key.
+**How to read it:** The core model below — the ER diagram, the entity key, and the view-lineage table — is the authoritative *"is"*: what the pipeline produces today. The single fenced section at the very end, **Forward look (v3)**, is *"will be"* — direction, not built. Nothing in that section touches the core diagram or the present-now key.
 
 `pipeline/schemas.py` is the source of truth for column *structure* (names + dtypes). This doc is the source of truth for the *relationships* between those structures.
 
@@ -71,14 +71,15 @@ The distinction matters because the two layers age differently: frozen fields st
 
 ### `Player` — dimension
 
-**Grain:** one canonical player. Sourced from `config/<season>/players.yaml`; today it ships as a nested dict inside `aggregates.json`, with a standalone Player-dimension parquet planned.
+**Grain:** one canonical player. Materialized as `players.parquet`: the curated layer from `config/<season>/players.yaml` LEFT JOINed on `player_id` with the season roster snapshot (`data/<season>/reference/rosters.parquet`) — a snapshot gap nulls the snapshot attributes, it never drops the row. The nested `player_metadata` dict inside `aggregates.json` is a legacy serialization of the same dimension (curated attributes only).
 
 | Field | Notes |
 |---|---|
 | `player` | canonical name (PK) |
-| `roster_team` | → **Team** (roster role). **Point-in-time** — see §3 |
-| `conference`, `player_id`, `headshot_url` | descriptive attributes |
-| `aliases[]` | the substring fragments feeding `mentioned_players` matching |
+| `roster_team` | → **Team** (roster role), from config. **Point-in-time** — see §3 |
+| `conference`, `player_id`, `headshot_url` | curated attributes (config) |
+| `position`, `birth_date`, `experience`, `school`, `jersey_number`, `height`, `weight` | snapshot attributes (roster snapshot, joined on `player_id`). Age is derived from `birth_date` at read time — a stored age is frozen at fetch |
+| `aliases[]` | the substring fragments feeding `mentioned_players` matching. **Config-only, never materialized**: the dimension describes and slices; it does not select the population (selection = config tracked set + fact-side qualification) |
 
 ### `Team` — dimension (role-playing)
 
@@ -114,21 +115,24 @@ The atomic fact stays at `created_utc` (seconds) and serves the replay directly;
 
 **Decided convention:** mark the role everywhere as `roster_team` / `fan_team`.
 
-**Current-column map** (the physical columns are both literally named `team` today):
+**Current-column map:**
 
 | Physical column | Role |
 |---|---|
-| `player_metadata.team` | `roster_team` |
+| `players.parquet.roster_team` | `roster_team` (role-marked physical name) |
+| `player_metadata.team` (legacy JSON only) | `roster_team` |
 | `player_team.team` | `fan_team` |
 | `team_overall.team` | `fan_team` |
 
-The physical column rename is a **pending follow-up** (a separate ticket), not planned here. This doc records the concept and the mapping so the model and the code don't read as contradictory in the meantime.
+The fan-team columns still carry the unmarked physical name `team`; their rename is a **pending follow-up** (a separate ticket), not planned here. This doc records the concept and the mapping so the model and the code don't read as contradictory in the meantime.
 
 ---
 
 ## 3. Roster team is point-in-time
 
-The `Player → Team (roster)` edge carries a fidelity ceiling worth stating plainly: **roster team is point-in-time, not static.** A traded player has different roster teams across weeks, but the season config and `player_metadata` carry a single **season-end** team. So roster-keyed temporal and cross-season analysis mis-homes traded players (e.g. Luka). A trade-aware (slowly-changing) mapping is a future refinement; the model only flags the ceiling.
+The `Player → Team (roster)` edge carries a fidelity ceiling worth stating plainly: **roster team is point-in-time, not static.** A traded player has different roster teams across weeks, but the season config and the Player dimension carry a single **season-end** team. So roster-keyed temporal and cross-season analysis mis-homes traded players (e.g. Luka). A trade-aware (slowly-changing) mapping is a future refinement; the model only flags the ceiling.
+
+`jersey_number` sits under the same ceiling: it can change mid-season, and the dimension carries the snapshot's single value. The consequence class is cosmetic, which is why the ceiling is accepted rather than engineered around.
 
 ---
 
@@ -143,7 +147,7 @@ All four views are **fact tables** (rollups of `ClassifiedComment`); `Player` an
 | `player_team` | Player × `fan_team` | fact → Player, Team(fan) | "Lakers fans about Draymond" |
 | `team_overall` | `fan_team` | fact → Team(fan) | "Which fanbase is saltiest" |
 
-**Needs a join** (no new pipeline output — cheap once the Player dimension is materialized as its own parquet): any *roster-level* question — "OKC's roster sentiment over time," "own-fans vs. rivals" — joins a player-keyed view to `Player.roster_team`. Today that means JSON-key gymnastics against `aggregates.json`; the dimension file turns it into a clean `USING (attributed_player)` join.
+**Needs a join** (no new pipeline output): any *roster-level* question — "OKC's roster sentiment over time," "own-fans vs. rivals" — joins a player-keyed view to `players.parquet` with `USING (attributed_player)` and groups by `roster_team` (or any other dimension attribute: position, experience, school).
 
 **Expensive** (a new aggregate view the pipeline must produce): "How Lakers fans' sentiment toward Draymond moved *week over week*" needs a `player_team_temporal` view (Player × `fan_team` × Week) that doesn't exist. A new grain ⇒ a new pipeline output.
 

--- a/pipeline/aggregation.py
+++ b/pipeline/aggregation.py
@@ -386,7 +386,12 @@ def _build_players_dimension(
     # just not silently.
     stamped_season = pl.read_parquet_metadata(snapshot_path).get("season")
     active_season = get_active_season()
-    if stamped_season is not None and stamped_season != active_season:
+    if stamped_season is None:
+        logger.warning(
+            f"{snapshot_path} carries no season stamp - snapshot lineage "
+            f"cannot be verified"
+        )
+    elif stamped_season != active_season:
         logger.warning(
             f"{snapshot_path}: season stamp {stamped_season!r} does not match "
             f"active season {active_season!r}; snapshot facts may be stale"

--- a/pipeline/aggregation.py
+++ b/pipeline/aggregation.py
@@ -402,7 +402,28 @@ def _build_players_dimension(
             f"snapshot (snapshot columns null): "
             f"{unmatched['attributed_player'].to_list()}"
         )
-    return config_side.join(snapshot, on="player_id", how="left", maintain_order="left")
+    players = config_side.join(
+        snapshot, on="player_id", how="left", maintain_order="left"
+    )
+    # Grain guard: a duplicate player_id in the snapshot would fan the LEFT
+    # JOIN out to multiple rows per player - silent corruption downstream
+    # (double-counted view joins, shim rows dropped by last-key-wins), so
+    # it fails loudly here instead. validate_schema can't catch this: it
+    # checks columns, not row grain.
+    if players.height != config_side.height:
+        duplicated = (
+            snapshot.group_by("player_id")
+            .len()
+            .filter(pl.col("len") > 1)
+            .get_column("player_id")
+            .to_list()
+        )
+        raise ValueError(
+            f"Player dimension fan-out: roster snapshot carries duplicate "
+            f"player_id(s) {duplicated}; the dimension's grain is one row "
+            f"per player - fix the snapshot (re-run scripts.fetch_rosters)"
+        )
+    return players
 
 
 def players_to_metadata_dict(df: pl.DataFrame) -> dict[str, dict]:

--- a/pipeline/aggregation.py
+++ b/pipeline/aggregation.py
@@ -12,11 +12,15 @@ from pathlib import Path
 import polars as pl
 
 from pipeline.schemas import (
-    AGGREGATE_VIEW_SCHEMAS,
+    DASHBOARD_OUTPUT_SCHEMAS,
+    PLAYERS_CONFIG_COLUMNS,
+    PLAYERS_SCHEMA,
+    PLAYERS_SNAPSHOT_COLUMNS,
     SCHEMA_VERSION,
     SENTIMENT_SCHEMA,
     validate_schema,
 )
+from utils.paths import get_reference_dir
 from utils.player_config import (
     build_alias_to_player_map,
     load_player_config_version,
@@ -112,9 +116,18 @@ def compute_metrics(df: pl.DataFrame, group_cols: list[str]) -> pl.DataFrame:
     grouped = (
         df.group_by(group_cols)
         .agg(
-            pl.col("sentiment").filter(pl.col("sentiment") == "neg").len().alias("neg_count"),
-            pl.col("sentiment").filter(pl.col("sentiment") == "pos").len().alias("pos_count"),
-            pl.col("sentiment").filter(pl.col("sentiment") == "neu").len().alias("neu_count"),
+            pl.col("sentiment")
+            .filter(pl.col("sentiment") == "neg")
+            .len()
+            .alias("neg_count"),
+            pl.col("sentiment")
+            .filter(pl.col("sentiment") == "pos")
+            .len()
+            .alias("pos_count"),
+            pl.col("sentiment")
+            .filter(pl.col("sentiment") == "neu")
+            .len()
+            .alias("neu_count"),
             pl.len().alias("comment_count"),
         )
         .with_columns(
@@ -126,12 +139,12 @@ def compute_metrics(df: pl.DataFrame, group_cols: list[str]) -> pl.DataFrame:
         .with_columns(
             (pl.col("neg_count") / pl.col("comment_count")).round(4).alias("neg_rate"),
             (pl.col("pos_count") / pl.col("comment_count")).round(4).alias("pos_rate"),
-            (
-                (pl.col("pos_count") - pl.col("neg_count")) / pl.col("comment_count")
-            ).round(4).alias("net_sentiment"),
-            (
-                (pl.col("pos_count") + pl.col("neg_count")) / pl.col("comment_count")
-            ).round(4).alias("polarization"),
+            ((pl.col("pos_count") - pl.col("neg_count")) / pl.col("comment_count"))
+            .round(4)
+            .alias("net_sentiment"),
+            ((pl.col("pos_count") + pl.col("neg_count")) / pl.col("comment_count"))
+            .round(4)
+            .alias("polarization"),
         )
     )
 
@@ -149,13 +162,15 @@ def aggregate_sentiment(input_path: Path) -> dict:
         input_path: Path to sentiment.parquet file.
 
     Returns:
-        Dict where player_overall, player_temporal, player_team, and
-        team_overall hold pl.DataFrames conforming to
-        AGGREGATE_VIEW_SCHEMAS; player_metadata and metadata are dicts.
+        Dict where player_overall, player_temporal, player_team,
+        team_overall, and players hold pl.DataFrames conforming to
+        DASHBOARD_OUTPUT_SCHEMAS; metadata is a dict. The legacy
+        player_metadata dict is reconstructed at serialization time via
+        players_to_metadata_dict().
 
     Raises:
         ValueError: If the input parquet does not match SENTIMENT_SCHEMA,
-            or a computed view does not match its schema contract.
+            or a computed output does not match its schema contract.
     """
     logger.info(f"Loading sentiment data from {input_path}")
     df = pl.read_parquet(input_path)
@@ -229,11 +244,7 @@ def aggregate_sentiment(input_path: Path) -> dict:
     logger.info(f"Matched {team_count:,} comments to team flairs")
 
     # Temporal prep: convert created_utc to datetime, truncate to week (Monday)
-    df = df.with_columns(
-        pl.from_epoch("created_utc")
-        .dt.truncate("1w")
-        .alias("week")
-    )
+    df = df.with_columns(pl.from_epoch("created_utc").dt.truncate("1w").alias("week"))
 
     # --- Aggregation views ---
 
@@ -301,35 +312,125 @@ def aggregate_sentiment(input_path: Path) -> dict:
         "generated_at": datetime.now(timezone.utc).isoformat(),
     }
 
-    # Filter player metadata to only players in player_overall
-    # and enrich with team logo_url
+    # Player dimension: config curation joined with snapshot facts, one
+    # row per attributed player in players.yaml order
     attributed_players = set(player_overall.get_column("attributed_player").to_list())
-    filtered_player_metadata = {}
-    for player, meta in player_metadata.items():
-        if player in attributed_players:
-            enriched = dict(meta)
-            team_info = team_config.get(enriched.get("team", ""), {})
-            enriched["logo_url"] = team_info.get("logo_url")
-            filtered_player_metadata[player] = enriched
+    players = _build_players_dimension(player_metadata, attributed_players)
 
     logger.info(
         f"Aggregation complete: {unique_players} players, "
         f"{unique_teams} teams, {unique_weeks} weeks"
     )
 
-    views = {
+    outputs = {
         "player_overall": player_overall,
         "player_temporal": player_temporal,
         "player_team": player_team,
         "team_overall": team_overall,
+        "players": players,
     }
-    for view_name, schema in AGGREGATE_VIEW_SCHEMAS.items():
-        validate_schema(views[view_name], schema, view_name)
+    for name, schema in DASHBOARD_OUTPUT_SCHEMAS.items():
+        validate_schema(outputs[name], schema, name)
 
     return {
-        **views,
-        "player_metadata": filtered_player_metadata,
+        **outputs,
         "metadata": metadata,
+    }
+
+
+def _build_players_dimension(
+    player_metadata: dict[str, dict], attributed_players: set[str]
+) -> pl.DataFrame:
+    """
+    Build the Player dimension: config curation joined with snapshot facts.
+
+    Config side: one row per attributed player, in players.yaml order,
+    with the roster team role-marked as roster_team. Snapshot side: LEFT
+    JOIN on player_id from the season's rosters.parquet — a missing
+    snapshot row (or the whole snapshot file) degrades to null snapshot
+    columns, never dropped rows.
+
+    Args:
+        player_metadata: Per-player config dict from load_player_metadata().
+        attributed_players: Players present in player_overall.
+
+    Returns:
+        Frame conforming to PLAYERS_SCHEMA.
+    """
+    config_rows = [
+        {
+            "attributed_player": player,
+            "roster_team": meta.get("team"),
+            "conference": meta.get("conference"),
+            "player_id": meta.get("player_id"),
+            "headshot_url": meta.get("headshot_url"),
+        }
+        for player, meta in player_metadata.items()
+        if player in attributed_players
+    ]
+    config_side = pl.DataFrame(config_rows, schema=PLAYERS_CONFIG_COLUMNS)
+
+    snapshot_path = get_reference_dir() / "rosters.parquet"
+    if not snapshot_path.exists():
+        logger.warning(
+            f"{snapshot_path} not found (run scripts.fetch_rosters) - "
+            f"snapshot columns will be null"
+        )
+        return config_side.with_columns(
+            pl.lit(None, dtype=PLAYERS_SCHEMA[col]).alias(col)
+            for col in PLAYERS_SNAPSHOT_COLUMNS
+        )
+
+    # Snapshot-lineage check, same spirit as the players_config_version
+    # stamp: a snapshot fetched for another season is legitimate to read,
+    # just not silently.
+    stamped_season = pl.read_parquet_metadata(snapshot_path).get("season")
+    active_season = get_active_season()
+    if stamped_season is not None and stamped_season != active_season:
+        logger.warning(
+            f"{snapshot_path}: season stamp {stamped_season!r} does not match "
+            f"active season {active_season!r}; snapshot facts may be stale"
+        )
+
+    snapshot = pl.read_parquet(snapshot_path).select(
+        ["player_id", *PLAYERS_SNAPSHOT_COLUMNS]
+    )
+    unmatched = config_side.join(snapshot, on="player_id", how="anti")
+    if unmatched.height:
+        logger.info(
+            f"{unmatched.height} attributed player(s) missing from the roster "
+            f"snapshot (snapshot columns null): "
+            f"{unmatched['attributed_player'].to_list()}"
+        )
+    return config_side.join(snapshot, on="player_id", how="left", maintain_order="left")
+
+
+def players_to_metadata_dict(df: pl.DataFrame) -> dict[str, dict]:
+    """
+    Reconstruct the legacy aggregates.json player_metadata dict.
+
+    Keys the dict by player name; values carry the config-side columns
+    under their legacy JSON names (roster_team serializes as `team`).
+    Snapshot columns don't ship in the JSON — the legacy consumers never
+    knew them. Row order is preserved.
+
+    Args:
+        df: Player dimension frame conforming to PLAYERS_SCHEMA.
+
+    Returns:
+        Dict mapping player name to the legacy metadata fields, in
+        frame-row order.
+    """
+    legacy_names = {
+        col: ("team" if col == "roster_team" else col)
+        for col in PLAYERS_CONFIG_COLUMNS
+        if col != "attributed_player"
+    }
+    return {
+        row["attributed_player"]: {
+            legacy: row[col] for col, legacy in legacy_names.items()
+        }
+        for row in df.select(list(PLAYERS_CONFIG_COLUMNS)).iter_rows(named=True)
     }
 
 
@@ -360,9 +461,7 @@ def compute_cumulative_metrics(player_temporal: list[dict]) -> pl.DataFrame:
     df = pl.DataFrame(player_temporal)
 
     # Parse week strings to Date and exclude stub week
-    df = df.with_columns(
-        pl.col("week").str.to_datetime().cast(pl.Date)
-    )
+    df = df.with_columns(pl.col("week").str.to_datetime().cast(pl.Date))
     stub_week = df["week"].max()
     df = df.filter(pl.col("week") != stub_week)
 
@@ -397,7 +496,9 @@ def compute_cumulative_metrics(player_temporal: list[dict]) -> pl.DataFrame:
         )
     )
 
-    return df.select("attributed_player", "week", "cum_neg", "cum_total", "cum_neg_rate")
+    return df.select(
+        "attributed_player", "week", "cum_neg", "cum_total", "cum_neg_rate"
+    )
 
 
 def mask_below_threshold(
@@ -503,11 +604,13 @@ def pivot_bar_race_wide(
 
     # Reorder: Label, Category, Image, then week columns sorted chronologically
     week_cols = sorted(
-        [c for c in wide.columns if c not in {"attributed_player", "Label", "Category", "Image"}]
+        [
+            c
+            for c in wide.columns
+            if c not in {"attributed_player", "Label", "Category", "Image"}
+        ]
     )
-    wide = wide.with_columns(
-        [(pl.col(c) * 100).round(2) for c in week_cols]
-    )
+    wide = wide.with_columns([(pl.col(c) * 100).round(2) for c in week_cols])
     wide = wide.select(["Label", "Category", "Image"] + week_cols)
 
     return wide

--- a/pipeline/schemas.py
+++ b/pipeline/schemas.py
@@ -13,6 +13,9 @@ pipeline produces. Data dictionary first, enforcement second:
 - ROSTERS_SCHEMA describes the season roster snapshot — a reference
   asset (pipeline ingredient, not a published output) enforced at the
   fetch write boundary (scripts/fetch_rosters.py).
+- PLAYERS_SCHEMA describes the Player dimension (players.parquet),
+  config curation joined with snapshot facts; enforced in
+  aggregate_sentiment() via the unified DASHBOARD_OUTPUT_SCHEMAS loop.
 
 This module must not import from other pipeline modules (it is imported
 by them).
@@ -21,7 +24,7 @@ by them).
 import polars as pl
 
 # Bump on any breaking change to a produced-file contract.
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 # data/<season>/processed/sentiment.parquet — one row per classified comment.
 SENTIMENT_SCHEMA = pl.Schema(
@@ -154,15 +157,65 @@ TEAM_OVERALL_SCHEMA = pl.Schema(
     }
 )
 
-# View name -> schema, shared by aggregate_sentiment()'s validation loop
-# and the aggregation script's parquet write loop. Keys match the
-# aggregate_sentiment() return-dict keys and the parquet filenames
-# (<view>.parquet).
+# View name -> schema for the four aggregate *views* (fact-table rollups).
+# Keys match aggregate_sentiment() return-dict keys and parquet filenames.
+# Deliberately fact-only: the aggregation script keys its JSON
+# record-shaping predicate ("is this a list of records?") off this
+# mapping, so the Player dimension below must NOT live here — it
+# serializes to a nested dict.
 AGGREGATE_VIEW_SCHEMAS: dict[str, pl.Schema] = {
     "player_overall": PLAYER_OVERALL_SCHEMA,
     "player_temporal": PLAYER_TEMPORAL_SCHEMA,
     "player_team": PLAYER_TEAM_SCHEMA,
     "team_overall": TEAM_OVERALL_SCHEMA,
+}
+
+# --- Player dimension (enforced in pipeline/aggregation.py) ------------------
+# One row per attributed player — the Player dimension the views'
+# attributed_player FK references. Materialized as players.parquet; also
+# re-serialized to the legacy nested {player: {...}} player_metadata dict in
+# aggregates.json (players_to_metadata_dict). The config side is curated in
+# config/<season>/players.yaml; the snapshot side LEFT JOINs from the season's
+# rosters.parquet on player_id, so snapshot gaps surface as nulls, never
+# dropped rows.
+# NOTE: roster_team is the *roster* role (who the player plays for),
+# role-marked from birth — distinct from the fan-role `team` in
+# player_team/team_overall. See docs/data-model.md §2.
+
+PLAYERS_CONFIG_COLUMNS: dict[str, pl.DataType] = {
+    "attributed_player": pl.String,
+    "roster_team": pl.String,
+    "conference": pl.String,
+    "player_id": pl.Int64,
+    "headshot_url": pl.String,
+}
+
+# Joined from ROSTERS_SCHEMA columns of the same name (dtypes derived so
+# snapshot and dimension can never drift).
+PLAYERS_SNAPSHOT_COLUMNS = [
+    "position",
+    "birth_date",
+    "experience",
+    "school",
+    "jersey_number",
+    "height",
+    "weight",
+]
+
+PLAYERS_SCHEMA = pl.Schema(
+    {
+        **PLAYERS_CONFIG_COLUMNS,
+        **{col: ROSTERS_SCHEMA[col] for col in PLAYERS_SNAPSHOT_COLUMNS},
+    }
+)
+
+# Every table the aggregation stage produces -> its schema: the four fact
+# views plus the Player dimension. Single source for aggregate_sentiment()'s
+# unified validation loop and the script's parquet write loop
+# (<name>.parquet).
+DASHBOARD_OUTPUT_SCHEMAS: dict[str, pl.Schema] = {
+    **AGGREGATE_VIEW_SCHEMAS,
+    "players": PLAYERS_SCHEMA,
 }
 
 

--- a/scripts/aggregate_sentiment.py
+++ b/scripts/aggregate_sentiment.py
@@ -4,8 +4,8 @@ Aggregate sentiment data into dashboard-ready outputs.
 Reads classified sentiment parquet, computes player rankings,
 flair segmentation, and temporal trends. Writes the nested
 aggregates.json for the Streamlit dashboard plus one parquet per
-tabular view (player_overall, player_temporal, player_team,
-team_overall) alongside it for ad-hoc DuckDB queries.
+produced table (the four fact views and the players dimension)
+alongside it for ad-hoc DuckDB queries and the v2 frontend.
 
 Usage:
     uv run python -m scripts.aggregate_sentiment
@@ -18,9 +18,14 @@ import logging
 import sys
 from pathlib import Path
 
-from pipeline.aggregation import aggregate_sentiment
-from pipeline.schemas import AGGREGATE_VIEW_SCHEMAS
+from pipeline.aggregation import aggregate_sentiment, players_to_metadata_dict
+from pipeline.schemas import (
+    AGGREGATE_VIEW_SCHEMAS,
+    DASHBOARD_OUTPUT_SCHEMAS,
+    SCHEMA_VERSION,
+)
 from utils.paths import get_dashboard_dir, get_processed_dir
+from utils.player_config import load_player_config_version
 from utils.season_config import set_season_override
 
 # -----------------------------------------------------------------------------
@@ -103,21 +108,37 @@ def main() -> None:
     # Ensure output directory exists
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Write JSON output: frame views -> records, key order preserved;
+    # Write JSON output: the four record-shaped views -> lists of dicts;
+    # the players dimension -> the legacy nested player_metadata dict
+    # (consumer-safe shim); the metadata scalar passes through.
     # default=str keeps week datetimes serialized exactly as before.
-    serializable = {
-        key: (value.to_dicts() if key in AGGREGATE_VIEW_SCHEMAS else value)
-        for key, value in result.items()
-    }
+    serializable = {}
+    for key, value in result.items():
+        if key in AGGREGATE_VIEW_SCHEMAS:
+            serializable[key] = value.to_dicts()
+        elif key == "players":
+            serializable["player_metadata"] = players_to_metadata_dict(value)
+        else:
+            serializable[key] = value
     with open(output_path, "w") as f:
         json.dump(serializable, f, indent=2, default=str)
 
     logger.info(f"Wrote aggregates to {output_path}")
 
-    # Write one parquet per tabular view next to the JSON
-    for view_name in AGGREGATE_VIEW_SCHEMAS:
-        parquet_path = output_path.parent / f"{view_name}.parquet"
-        result[view_name].write_parquet(parquet_path)
+    # Write one parquet per produced table (four views + the players
+    # dimension). players.parquet carries the config-version stamp so
+    # fact<->dimension drift is checkable (same mechanism as
+    # sentiment.parquet's stamp in collect_results).
+    players_stamp = {
+        "players_config_version": load_player_config_version(),
+        "schema_version": str(SCHEMA_VERSION),
+    }
+    for name in DASHBOARD_OUTPUT_SCHEMAS:
+        parquet_path = output_path.parent / f"{name}.parquet"
+        result[name].write_parquet(
+            parquet_path,
+            metadata=players_stamp if name == "players" else None,
+        )
         logger.info(f"Wrote {parquet_path}")
 
     # Log metadata summary

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ into test functions by name — pytest handles the wiring automatically.
 """
 
 import json
+from datetime import date
 from typing import Callable
 from unittest.mock import Mock
 
@@ -506,6 +507,36 @@ def team_alias_map() -> dict[str, str]:
         "charlotte hornets": "Charlotte Hornets",
         "cha": "Charlotte Hornets",
         "hornets": "Charlotte Hornets",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Roster snapshot (issue #39)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def lebron_roster_row() -> dict:
+    """
+    One ROSTERS_SCHEMA-shaped snapshot row (LeBron James, player_id 2544).
+
+    player_id matches the real config entry, so tests that resolve
+    attribution against the on-disk players.yaml line up with the
+    snapshot join.
+    """
+    return {
+        "player_id": 2544,
+        "player_name": "LeBron James",
+        "team_name": "Los Angeles Lakers",
+        "team_abbr": "LAL",
+        "jersey_number": "23",
+        "position": "F",
+        "height": "6-9",
+        "weight": "250",
+        "age": 40,
+        "experience": "21",
+        "birth_date": date(1984, 12, 30),
+        "school": "St. Vincent-St. Mary HS (OH)",
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,8 @@ into test functions by name — pytest handles the wiring automatically.
 """
 
 import json
+from collections.abc import Callable, Generator
 from datetime import date
-from typing import Callable
 from unittest.mock import Mock
 
 import pytest
@@ -546,7 +546,7 @@ def lebron_roster_row() -> dict:
 
 
 @pytest.fixture
-def season_override() -> Callable[[str], None]:
+def season_override() -> Generator[Callable[[str], None], None, None]:
     """
     Set a process-level season override with cold caches; restores after.
 

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -6,6 +6,7 @@ and compute_metrics from the aggregation pipeline.
 """
 
 import logging
+from datetime import date
 
 import polars as pl
 import pytest
@@ -17,10 +18,18 @@ from pipeline.aggregation import (
     extract_team_from_flair,
     mask_below_threshold,
     pivot_bar_race_wide,
+    players_to_metadata_dict,
     resolve_player,
 )
-from pipeline.schemas import AGGREGATE_VIEW_SCHEMAS, SCHEMA_VERSION, SENTIMENT_SCHEMA
+from pipeline.schemas import (
+    AGGREGATE_VIEW_SCHEMAS,
+    PLAYERS_SCHEMA,
+    ROSTERS_SCHEMA,
+    SCHEMA_VERSION,
+    SENTIMENT_SCHEMA,
+)
 from utils.player_config import load_player_config_version
+from utils.season_config import get_active_season
 
 
 class TestResolvePlayer:
@@ -28,9 +37,7 @@ class TestResolvePlayer:
 
     def test_single_player_returns_it(self, player_alias_map):
         """Single player in mentioned_players is returned directly."""
-        result = resolve_player(
-            ["LeBron James"], "Nikola Jokic", player_alias_map
-        )
+        result = resolve_player(["LeBron James"], "Nikola Jokic", player_alias_map)
         assert result == "LeBron James"
 
     def test_single_player_normalizes_alias(self, player_alias_map):
@@ -152,10 +159,12 @@ class TestComputeMetrics:
 
     def test_basic_counts_and_rates(self):
         """Verify counts and rate calculations on synthetic data."""
-        df = pl.DataFrame({
-            "player": ["A", "A", "A", "A", "A", "B", "B", "B"],
-            "sentiment": ["neg", "neg", "pos", "neu", "neu", "neg", "pos", "pos"],
-        })
+        df = pl.DataFrame(
+            {
+                "player": ["A", "A", "A", "A", "A", "B", "B", "B"],
+                "sentiment": ["neg", "neg", "pos", "neu", "neu", "neg", "pos", "pos"],
+            }
+        )
 
         result = compute_metrics(df, ["player"])
 
@@ -179,10 +188,12 @@ class TestComputeMetrics:
 
     def test_rates_rounded_to_four_decimals(self):
         """Rate values are rounded to 4 decimal places."""
-        df = pl.DataFrame({
-            "player": ["A", "A", "A"],
-            "sentiment": ["neg", "pos", "pos"],
-        })
+        df = pl.DataFrame(
+            {
+                "player": ["A", "A", "A"],
+                "sentiment": ["neg", "pos", "pos"],
+            }
+        )
 
         result = compute_metrics(df, ["player"])
         a = result.row(0, named=True)
@@ -192,21 +203,25 @@ class TestComputeMetrics:
 
     def test_multi_group_columns(self):
         """Grouping by multiple columns works."""
-        df = pl.DataFrame({
-            "player": ["A", "A", "B"],
-            "team": ["LAL", "BOS", "LAL"],
-            "sentiment": ["neg", "pos", "neu"],
-        })
+        df = pl.DataFrame(
+            {
+                "player": ["A", "A", "B"],
+                "team": ["LAL", "BOS", "LAL"],
+                "sentiment": ["neg", "pos", "neu"],
+            }
+        )
 
         result = compute_metrics(df, ["player", "team"])
         assert result.height == 3
 
     def test_returns_frame_sorted_by_group_cols(self):
         """Output is a DataFrame deterministically sorted by the group columns."""
-        df = pl.DataFrame({
-            "player": ["C", "A", "B"],
-            "sentiment": ["neg", "pos", "neu"],
-        })
+        df = pl.DataFrame(
+            {
+                "player": ["C", "A", "B"],
+                "sentiment": ["neg", "pos", "neu"],
+            }
+        )
 
         result = compute_metrics(df, ["player"])
 
@@ -226,12 +241,12 @@ def _make_test_parquet(tmp_path, rows, metadata=None):
     return path
 
 
-class TestAggregatePlayerMetadata:
-    """Tests for player_metadata key in aggregate output."""
-
-    def test_player_metadata_key_exists(self, tmp_path):
-        """Output contains player_metadata top-level key."""
-        path = _make_test_parquet(tmp_path, {
+def _lebron_parquet(tmp_path):
+    """Two LeBron comments (Lakers + Celtics flair) — LeBron the only
+    attributed player. Shared by the Player-dimension tests."""
+    return _make_test_parquet(
+        tmp_path,
+        {
             "comment_id": ["c1", "c2"],
             "body": ["LeBron is great", "LeBron is washed"],
             "author": ["u1", "u2"],
@@ -246,67 +261,214 @@ class TestAggregatePlayerMetadata:
             "sentiment_player": ["LeBron James", "LeBron James"],
             "input_tokens": [100, 100],
             "output_tokens": [20, 20],
-        })
+        },
+    )
 
-        result = aggregate_sentiment(path)
 
-        assert "player_metadata" in result
-        assert isinstance(result["player_metadata"], dict)
+_LEBRON_ROSTER_ROW = {
+    "player_id": 2544,
+    "player_name": "LeBron James",
+    "team_name": "Los Angeles Lakers",
+    "team_abbr": "LAL",
+    "jersey_number": "23",
+    "position": "F",
+    "height": "6-9",
+    "weight": "250",
+    "age": 40,
+    "experience": "21",
+    "birth_date": date(1984, 12, 30),
+    "school": "St. Vincent-St. Mary HS (OH)",
+}
 
-    def test_metadata_contains_attributed_players(self, tmp_path):
-        """player_metadata includes metadata for attributed players."""
-        path = _make_test_parquet(tmp_path, {
-            "comment_id": ["c1", "c2"],
-            "body": ["LeBron is great", "LeBron is washed"],
-            "author": ["u1", "u2"],
-            "author_flair_text": [":lal-1: Lakers", ":bos-1: Celtics"],
-            "author_flair_css_class": ["lakers", "celtics"],
-            "created_utc": [1704067200, 1704153600],
-            "score": [10, 5],
-            "link_id": ["t3_post123", "t3_post456"],
-            "mentioned_players": [["LeBron James"], ["LeBron James"]],
-            "sentiment": ["pos", "neg"],
-            "confidence": [0.9, 0.8],
-            "sentiment_player": ["LeBron James", "LeBron James"],
-            "input_tokens": [100, 100],
-            "output_tokens": [20, 20],
-        })
 
-        result = aggregate_sentiment(path)
-        meta = result["player_metadata"]
+def _pin_snapshot(monkeypatch, tmp_path, rows=None, season=None, missing=False):
+    """Point pipeline.aggregation at a tmp reference dir with a roster snapshot.
 
-        assert "LeBron James" in meta
-        assert meta["LeBron James"]["team"] == "Los Angeles Lakers"
-        assert meta["LeBron James"]["conference"] == "West"
-        assert meta["LeBron James"]["player_id"] == 2544
-        assert "logo_url" in meta["LeBron James"]
-        assert "cdn.nba.com/logos" in meta["LeBron James"]["logo_url"]
+    rows=None writes the LeBron row; missing=True leaves the dir empty
+    (the no-snapshot degradation path). season stamps the file's metadata
+    (defaults to the active season so no drift warning fires).
+    """
+    ref_dir = tmp_path / "reference"
+    ref_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr("pipeline.aggregation.get_reference_dir", lambda: ref_dir)
+    if missing:
+        return ref_dir
+    df = pl.DataFrame(rows or [_LEBRON_ROSTER_ROW], schema=ROSTERS_SCHEMA)
+    df.write_parquet(
+        ref_dir / "rosters.parquet",
+        metadata={"season": season or get_active_season()},
+    )
+    return ref_dir
 
-    def test_metadata_excludes_non_attributed_players(self, tmp_path):
-        """player_metadata only includes players that appear in player_overall."""
-        path = _make_test_parquet(tmp_path, {
-            "comment_id": ["c1"],
-            "body": ["LeBron is great"],
-            "author": ["u1"],
-            "author_flair_text": [":lal-1: Lakers"],
-            "author_flair_css_class": ["lakers"],
-            "created_utc": [1704067200],
-            "score": [10],
-            "link_id": ["t3_post123"],
-            "mentioned_players": [["LeBron James"]],
-            "sentiment": ["pos"],
-            "confidence": [0.9],
-            "sentiment_player": ["LeBron James"],
-            "input_tokens": [100],
-            "output_tokens": [20],
-        })
 
-        result = aggregate_sentiment(path)
-        meta = result["player_metadata"]
+class TestAggregatePlayers:
+    """Tests for the players Player-dimension frame in aggregate output."""
 
-        # Only LeBron attributed — Giannis should not be in metadata
-        assert "LeBron James" in meta
-        assert "Giannis Antetokounmpo" not in meta
+    def test_players_is_frame_conforming_to_schema(self, tmp_path, monkeypatch):
+        """players is returned as a frame matching PLAYERS_SCHEMA; the legacy
+        player_metadata key no longer appears in the return dict."""
+        _pin_snapshot(monkeypatch, tmp_path)
+
+        result = aggregate_sentiment(_lebron_parquet(tmp_path))
+
+        assert isinstance(result["players"], pl.DataFrame)
+        assert result["players"].schema == PLAYERS_SCHEMA
+        assert "player_metadata" not in result
+
+    def test_config_side_populated(self, tmp_path, monkeypatch):
+        """Config columns carry the curated fields, roster team role-marked."""
+        _pin_snapshot(monkeypatch, tmp_path)
+
+        result = aggregate_sentiment(_lebron_parquet(tmp_path))
+
+        row = result["players"].row(
+            by_predicate=pl.col("attributed_player") == "LeBron James", named=True
+        )
+        assert row["roster_team"] == "Los Angeles Lakers"
+        assert row["conference"] == "West"
+        assert row["player_id"] == 2544
+        assert row["headshot_url"] is not None
+
+    def test_snapshot_side_joined(self, tmp_path, monkeypatch):
+        """Snapshot columns join in via player_id."""
+        _pin_snapshot(monkeypatch, tmp_path)
+
+        result = aggregate_sentiment(_lebron_parquet(tmp_path))
+
+        row = result["players"].row(
+            by_predicate=pl.col("attributed_player") == "LeBron James", named=True
+        )
+        assert row["position"] == "F"
+        assert row["jersey_number"] == "23"
+        assert row["height"] == "6-9"
+        assert row["birth_date"] == date(1984, 12, 30)
+
+    def test_excludes_non_attributed_players(self, tmp_path, monkeypatch):
+        """The frame only includes players that appear in player_overall."""
+        _pin_snapshot(monkeypatch, tmp_path)
+
+        result = aggregate_sentiment(_lebron_parquet(tmp_path))
+        players = result["players"]["attributed_player"].to_list()
+
+        assert players == ["LeBron James"]
+
+    def test_missing_snapshot_row_nulls_and_logs(self, tmp_path, monkeypatch, caplog):
+        """An attributed player absent from the snapshot gets null snapshot
+        columns and is logged (the baked-config fallback case)."""
+        _pin_snapshot(
+            monkeypatch,
+            tmp_path,
+            rows=[{**_LEBRON_ROSTER_ROW, "player_id": 999, "player_name": "Other"}],
+        )
+
+        with caplog.at_level(logging.INFO, logger="pipeline.aggregation"):
+            result = aggregate_sentiment(_lebron_parquet(tmp_path))
+
+        row = result["players"].row(
+            by_predicate=pl.col("attributed_player") == "LeBron James", named=True
+        )
+        assert row["roster_team"] == "Los Angeles Lakers"  # config side intact
+        assert row["position"] is None
+        assert row["birth_date"] is None
+        assert "missing from the roster snapshot" in caplog.text
+        assert "LeBron James" in caplog.text
+
+    def test_missing_snapshot_file_warns_and_degrades(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """No snapshot on disk: warn and ship the dimension with null
+        snapshot columns (aggregation stays runnable without reference assets)."""
+        _pin_snapshot(monkeypatch, tmp_path, missing=True)
+
+        with caplog.at_level(logging.WARNING, logger="pipeline.aggregation"):
+            result = aggregate_sentiment(_lebron_parquet(tmp_path))
+
+        assert result["players"].schema == PLAYERS_SCHEMA
+        row = result["players"].row(
+            by_predicate=pl.col("attributed_player") == "LeBron James", named=True
+        )
+        assert row["roster_team"] == "Los Angeles Lakers"
+        assert row["position"] is None
+        assert "snapshot columns will be null" in caplog.text
+
+    def test_snapshot_season_stamp_mismatch_warns(self, tmp_path, monkeypatch, caplog):
+        """A snapshot stamped for another season triggers the lineage warning."""
+        _pin_snapshot(monkeypatch, tmp_path, season="1999-00")
+
+        with caplog.at_level(logging.WARNING, logger="pipeline.aggregation"):
+            aggregate_sentiment(_lebron_parquet(tmp_path))
+
+        assert "season stamp" in caplog.text
+        assert "1999-00" in caplog.text
+
+
+class TestPlayersToMetadataDict:
+    """Tests for players_to_metadata_dict (frame -> legacy aggregates.json dict).
+
+    These guard the consumer contract: aggregates.json must keep serving
+    the nested {player: {...}} dict with the legacy value keys.
+    """
+
+    @pytest.fixture
+    def players_frame(self) -> pl.DataFrame:
+        """Two-row Player dimension frame conforming to PLAYERS_SCHEMA."""
+        rows = [
+            {
+                "attributed_player": "LeBron James",
+                "roster_team": "Los Angeles Lakers",
+                "conference": "West",
+                "player_id": 2544,
+                "headshot_url": "https://cdn.nba.com/headshots/nba/latest/1040x760/2544.png",
+                "position": "F",
+                "birth_date": date(1984, 12, 30),
+                "experience": "21",
+                "school": "St. Vincent-St. Mary HS (OH)",
+                "jersey_number": "23",
+                "height": "6-9",
+                "weight": "250",
+            },
+            {
+                "attributed_player": "Bam Adebayo",
+                "roster_team": "Miami Heat",
+                "conference": "East",
+                "player_id": 1628389,
+                "headshot_url": "https://cdn.nba.com/headshots/nba/latest/1040x760/1628389.png",
+                "position": "C",
+                "birth_date": date(1997, 7, 18),
+                "experience": "8",
+                "school": "Kentucky",
+                "jersey_number": "13",
+                "height": "6-9",
+                "weight": "255",
+            },
+        ]
+        return pl.DataFrame(rows, schema=PLAYERS_SCHEMA)
+
+    def test_reconstructs_nested_dict_keyed_by_player(self, players_frame):
+        """The dict keys by player name; roster_team serializes as legacy team."""
+        as_dict = players_to_metadata_dict(players_frame)
+
+        assert as_dict["LeBron James"]["team"] == "Los Angeles Lakers"
+        assert as_dict["LeBron James"]["conference"] == "West"
+        assert as_dict["Bam Adebayo"]["player_id"] == 1628389
+
+    def test_value_keys_match_json_contract(self, players_frame):
+        """Each entry carries exactly the legacy consumer keys, in order —
+        no snapshot columns, no logo_url."""
+        as_dict = players_to_metadata_dict(players_frame)
+
+        assert list(as_dict["LeBron James"].keys()) == [
+            "team",
+            "conference",
+            "player_id",
+            "headshot_url",
+        ]
+
+    def test_preserves_row_order(self, players_frame):
+        """Dict key order follows frame row order (players.yaml order)."""
+        as_dict = players_to_metadata_dict(players_frame)
+
+        assert list(as_dict.keys()) == players_frame["attributed_player"].to_list()
 
 
 class TestConfigVersionLineage:
@@ -396,22 +558,25 @@ class TestAggregateTeamConference:
 
     def test_team_overall_has_conference(self, tmp_path):
         """Each team_overall row has a conference field."""
-        path = _make_test_parquet(tmp_path, {
-            "comment_id": ["c1", "c2"],
-            "body": ["Go team", "Nice game"],
-            "author": ["u1", "u2"],
-            "author_flair_text": [":lal-1: Lakers", ":bos-1: Celtics"],
-            "author_flair_css_class": ["lakers", "celtics"],
-            "created_utc": [1704067200, 1704153600],
-            "score": [10, 5],
-            "link_id": ["t3_post123", "t3_post456"],
-            "mentioned_players": [[], []],
-            "sentiment": ["pos", "neu"],
-            "confidence": [0.9, 0.7],
-            "sentiment_player": [None, None],
-            "input_tokens": [100, 100],
-            "output_tokens": [20, 20],
-        })
+        path = _make_test_parquet(
+            tmp_path,
+            {
+                "comment_id": ["c1", "c2"],
+                "body": ["Go team", "Nice game"],
+                "author": ["u1", "u2"],
+                "author_flair_text": [":lal-1: Lakers", ":bos-1: Celtics"],
+                "author_flair_css_class": ["lakers", "celtics"],
+                "created_utc": [1704067200, 1704153600],
+                "score": [10, 5],
+                "link_id": ["t3_post123", "t3_post456"],
+                "mentioned_players": [[], []],
+                "sentiment": ["pos", "neu"],
+                "confidence": [0.9, 0.7],
+                "sentiment_player": [None, None],
+                "input_tokens": [100, 100],
+                "output_tokens": [20, 20],
+            },
+        )
 
         result = aggregate_sentiment(path)
 
@@ -420,22 +585,25 @@ class TestAggregateTeamConference:
 
     def test_conference_values_correct(self, tmp_path):
         """Conference values match expected East/West assignments."""
-        path = _make_test_parquet(tmp_path, {
-            "comment_id": ["c1", "c2"],
-            "body": ["Go team", "Nice game"],
-            "author": ["u1", "u2"],
-            "author_flair_text": [":lal-1: Lakers", ":bos-1: Celtics"],
-            "author_flair_css_class": ["lakers", "celtics"],
-            "created_utc": [1704067200, 1704153600],
-            "score": [10, 5],
-            "link_id": ["t3_post123", "t3_post456"],
-            "mentioned_players": [[], []],
-            "sentiment": ["pos", "neu"],
-            "confidence": [0.9, 0.7],
-            "sentiment_player": [None, None],
-            "input_tokens": [100, 100],
-            "output_tokens": [20, 20],
-        })
+        path = _make_test_parquet(
+            tmp_path,
+            {
+                "comment_id": ["c1", "c2"],
+                "body": ["Go team", "Nice game"],
+                "author": ["u1", "u2"],
+                "author_flair_text": [":lal-1: Lakers", ":bos-1: Celtics"],
+                "author_flair_css_class": ["lakers", "celtics"],
+                "created_utc": [1704067200, 1704153600],
+                "score": [10, 5],
+                "link_id": ["t3_post123", "t3_post456"],
+                "mentioned_players": [[], []],
+                "sentiment": ["pos", "neu"],
+                "confidence": [0.9, 0.7],
+                "sentiment_player": [None, None],
+                "input_tokens": [100, 100],
+                "output_tokens": [20, 20],
+            },
+        )
 
         result = aggregate_sentiment(path)
         team_by_name = {r["team"]: r for r in result["team_overall"].to_dicts()}
@@ -445,22 +613,25 @@ class TestAggregateTeamConference:
 
     def test_team_overall_has_abbreviation(self, tmp_path):
         """Each team_overall row has the correct abbreviation."""
-        path = _make_test_parquet(tmp_path, {
-            "comment_id": ["c1", "c2"],
-            "body": ["Go team", "Nice game"],
-            "author": ["u1", "u2"],
-            "author_flair_text": [":lal-1: Lakers", ":bos-1: Celtics"],
-            "author_flair_css_class": ["lakers", "celtics"],
-            "created_utc": [1704067200, 1704153600],
-            "score": [10, 5],
-            "link_id": ["t3_post123", "t3_post456"],
-            "mentioned_players": [[], []],
-            "sentiment": ["pos", "neu"],
-            "confidence": [0.9, 0.7],
-            "sentiment_player": [None, None],
-            "input_tokens": [100, 100],
-            "output_tokens": [20, 20],
-        })
+        path = _make_test_parquet(
+            tmp_path,
+            {
+                "comment_id": ["c1", "c2"],
+                "body": ["Go team", "Nice game"],
+                "author": ["u1", "u2"],
+                "author_flair_text": [":lal-1: Lakers", ":bos-1: Celtics"],
+                "author_flair_css_class": ["lakers", "celtics"],
+                "created_utc": [1704067200, 1704153600],
+                "score": [10, 5],
+                "link_id": ["t3_post123", "t3_post456"],
+                "mentioned_players": [[], []],
+                "sentiment": ["pos", "neu"],
+                "confidence": [0.9, 0.7],
+                "sentiment_player": [None, None],
+                "input_tokens": [100, 100],
+                "output_tokens": [20, 20],
+            },
+        )
 
         result = aggregate_sentiment(path)
         team_by_name = {r["team"]: r for r in result["team_overall"].to_dicts()}
@@ -470,22 +641,25 @@ class TestAggregateTeamConference:
 
     def test_team_overall_has_logo_url(self, tmp_path):
         """Each team_overall row has a logo_url field."""
-        path = _make_test_parquet(tmp_path, {
-            "comment_id": ["c1", "c2"],
-            "body": ["Go team", "Nice game"],
-            "author": ["u1", "u2"],
-            "author_flair_text": [":lal-1: Lakers", ":bos-1: Celtics"],
-            "author_flair_css_class": ["lakers", "celtics"],
-            "created_utc": [1704067200, 1704153600],
-            "score": [10, 5],
-            "link_id": ["t3_post123", "t3_post456"],
-            "mentioned_players": [[], []],
-            "sentiment": ["pos", "neu"],
-            "confidence": [0.9, 0.7],
-            "sentiment_player": [None, None],
-            "input_tokens": [100, 100],
-            "output_tokens": [20, 20],
-        })
+        path = _make_test_parquet(
+            tmp_path,
+            {
+                "comment_id": ["c1", "c2"],
+                "body": ["Go team", "Nice game"],
+                "author": ["u1", "u2"],
+                "author_flair_text": [":lal-1: Lakers", ":bos-1: Celtics"],
+                "author_flair_css_class": ["lakers", "celtics"],
+                "created_utc": [1704067200, 1704153600],
+                "score": [10, 5],
+                "link_id": ["t3_post123", "t3_post456"],
+                "mentioned_players": [[], []],
+                "sentiment": ["pos", "neu"],
+                "confidence": [0.9, 0.7],
+                "sentiment_player": [None, None],
+                "input_tokens": [100, 100],
+                "output_tokens": [20, 20],
+            },
+        )
 
         result = aggregate_sentiment(path)
 
@@ -506,58 +680,74 @@ class TestAggregateViews:
         (tie with Durant), Stephen Curry 0.0 — exercises the player_overall
         sort and its tiebreaker.
         """
-        return _make_test_parquet(tmp_path, {
-            "comment_id": ["c1", "c2", "c3", "c4", "c5", "c6"],
-            "body": [
-                "Giannis traveled again",
-                "KD is a snake",
-                "KD is unstoppable",
-                "LeBron is washed",
-                "LeBron is the GOAT",
-                "Curry never misses",
-            ],
-            "author": ["u1", "u2", "u3", "u4", "u5", "u6"],
-            "author_flair_text": [
-                ":lal-1: Lakers",
-                ":bos-1: Celtics",
-                ":lal-1: Lakers",
-                ":bos-1: Celtics",
-                ":lal-1: Lakers",
-                ":bos-1: Celtics",
-            ],
-            "author_flair_css_class": [
-                "lakers", "celtics", "lakers", "celtics", "lakers", "celtics",
-            ],
-            "created_utc": [
-                1704067200, 1704067200, 1704067200,  # week of 2024-01-01
-                1704672000, 1704672000, 1704672000,  # week of 2024-01-08
-            ],
-            "score": [10, 5, 8, 3, 12, 7],
-            "link_id": [
-                "t3_game1", "t3_game1", "t3_game1",
-                "t3_game2", "t3_game2", "t3_game2",
-            ],
-            "mentioned_players": [
-                ["Giannis Antetokounmpo"],
-                ["Kevin Durant"],
-                ["Kevin Durant"],
-                ["LeBron James"],
-                ["LeBron James"],
-                ["Stephen Curry"],
-            ],
-            "sentiment": ["neg", "neg", "pos", "neg", "pos", "pos"],
-            "confidence": [0.9, 0.8, 0.9, 0.85, 0.95, 0.9],
-            "sentiment_player": [
-                "Giannis Antetokounmpo",
-                "Kevin Durant",
-                "Kevin Durant",
-                "LeBron James",
-                "LeBron James",
-                "Stephen Curry",
-            ],
-            "input_tokens": [100, 100, 100, 100, 100, 100],
-            "output_tokens": [20, 20, 20, 20, 20, 20],
-        })
+        return _make_test_parquet(
+            tmp_path,
+            {
+                "comment_id": ["c1", "c2", "c3", "c4", "c5", "c6"],
+                "body": [
+                    "Giannis traveled again",
+                    "KD is a snake",
+                    "KD is unstoppable",
+                    "LeBron is washed",
+                    "LeBron is the GOAT",
+                    "Curry never misses",
+                ],
+                "author": ["u1", "u2", "u3", "u4", "u5", "u6"],
+                "author_flair_text": [
+                    ":lal-1: Lakers",
+                    ":bos-1: Celtics",
+                    ":lal-1: Lakers",
+                    ":bos-1: Celtics",
+                    ":lal-1: Lakers",
+                    ":bos-1: Celtics",
+                ],
+                "author_flair_css_class": [
+                    "lakers",
+                    "celtics",
+                    "lakers",
+                    "celtics",
+                    "lakers",
+                    "celtics",
+                ],
+                "created_utc": [
+                    1704067200,
+                    1704067200,
+                    1704067200,  # week of 2024-01-01
+                    1704672000,
+                    1704672000,
+                    1704672000,  # week of 2024-01-08
+                ],
+                "score": [10, 5, 8, 3, 12, 7],
+                "link_id": [
+                    "t3_game1",
+                    "t3_game1",
+                    "t3_game1",
+                    "t3_game2",
+                    "t3_game2",
+                    "t3_game2",
+                ],
+                "mentioned_players": [
+                    ["Giannis Antetokounmpo"],
+                    ["Kevin Durant"],
+                    ["Kevin Durant"],
+                    ["LeBron James"],
+                    ["LeBron James"],
+                    ["Stephen Curry"],
+                ],
+                "sentiment": ["neg", "neg", "pos", "neg", "pos", "pos"],
+                "confidence": [0.9, 0.8, 0.9, 0.85, 0.95, 0.9],
+                "sentiment_player": [
+                    "Giannis Antetokounmpo",
+                    "Kevin Durant",
+                    "Kevin Durant",
+                    "LeBron James",
+                    "LeBron James",
+                    "Stephen Curry",
+                ],
+                "input_tokens": [100, 100, 100, 100, 100, 100],
+                "output_tokens": [20, 20, 20, 20, 20, 20],
+            },
+        )
 
     @pytest.mark.parametrize(
         "view_name,schema",
@@ -613,18 +803,20 @@ def _make_temporal_records(
     records = []
     for player, weeks in players_weeks.items():
         for week_str, neg, total in weeks:
-            records.append({
-                "attributed_player": player,
-                "week": week_str,
-                "neg_count": neg,
-                "pos_count": total - neg,
-                "neu_count": 0,
-                "comment_count": total,
-                "neg_rate": round(neg / total, 4) if total else 0,
-                "pos_rate": round((total - neg) / total, 4) if total else 0,
-                "net_sentiment": 0.0,
-                "polarization": 0.0,
-            })
+            records.append(
+                {
+                    "attributed_player": player,
+                    "week": week_str,
+                    "neg_count": neg,
+                    "pos_count": total - neg,
+                    "neu_count": 0,
+                    "comment_count": total,
+                    "neg_rate": round(neg / total, 4) if total else 0,
+                    "pos_rate": round((total - neg) / total, 4) if total else 0,
+                    "net_sentiment": 0.0,
+                    "polarization": 0.0,
+                }
+            )
     return records
 
 
@@ -633,28 +825,33 @@ class TestComputeCumulativeMetrics:
 
     def test_excludes_stub_week(self):
         """The maximum week (stub) is excluded from the output."""
-        records = _make_temporal_records({
-            "Player A": [
-                ("2024-10-07 00:00:00", 5, 50),
-                ("2024-10-14 00:00:00", 10, 100),
-                ("2024-10-21 00:00:00", 2, 10),  # stub (max week)
-            ],
-        })
+        records = _make_temporal_records(
+            {
+                "Player A": [
+                    ("2024-10-07 00:00:00", 5, 50),
+                    ("2024-10-14 00:00:00", 10, 100),
+                    ("2024-10-21 00:00:00", 2, 10),  # stub (max week)
+                ],
+            }
+        )
         result = compute_cumulative_metrics(records)
         weeks = result["week"].to_list()
         from datetime import date
+
         assert date(2024, 10, 21) not in weeks
         assert len(weeks) == 2
 
     def test_cumulative_sums_correct(self):
         """Running neg and total counts accumulate across weeks."""
-        records = _make_temporal_records({
-            "Player A": [
-                ("2024-10-07 00:00:00", 5, 50),
-                ("2024-10-14 00:00:00", 10, 100),
-                ("2024-10-21 00:00:00", 1, 10),  # stub
-            ],
-        })
+        records = _make_temporal_records(
+            {
+                "Player A": [
+                    ("2024-10-07 00:00:00", 5, 50),
+                    ("2024-10-14 00:00:00", 10, 100),
+                    ("2024-10-21 00:00:00", 1, 10),  # stub
+                ],
+            }
+        )
         result = compute_cumulative_metrics(records)
         rows = result.sort("week").to_dicts()
 
@@ -665,24 +862,28 @@ class TestComputeCumulativeMetrics:
 
     def test_fills_missing_weeks(self):
         """A player missing from a week gets zero new counts, cumulative carries forward."""
-        records = _make_temporal_records({
-            "Player A": [
-                ("2024-10-07 00:00:00", 5, 50),
-                # gap at 2024-10-14
-                ("2024-10-21 00:00:00", 10, 100),
-                ("2024-10-28 00:00:00", 1, 10),  # stub
-            ],
-            "Player B": [
-                ("2024-10-07 00:00:00", 3, 30),
-                ("2024-10-14 00:00:00", 7, 70),
-                ("2024-10-21 00:00:00", 2, 20),
-                ("2024-10-28 00:00:00", 1, 10),  # stub
-            ],
-        })
+        records = _make_temporal_records(
+            {
+                "Player A": [
+                    ("2024-10-07 00:00:00", 5, 50),
+                    # gap at 2024-10-14
+                    ("2024-10-21 00:00:00", 10, 100),
+                    ("2024-10-28 00:00:00", 1, 10),  # stub
+                ],
+                "Player B": [
+                    ("2024-10-07 00:00:00", 3, 30),
+                    ("2024-10-14 00:00:00", 7, 70),
+                    ("2024-10-21 00:00:00", 2, 20),
+                    ("2024-10-28 00:00:00", 1, 10),  # stub
+                ],
+            }
+        )
         result = compute_cumulative_metrics(records)
-        a_rows = result.filter(
-            pl.col("attributed_player") == "Player A"
-        ).sort("week").to_dicts()
+        a_rows = (
+            result.filter(pl.col("attributed_player") == "Player A")
+            .sort("week")
+            .to_dicts()
+        )
 
         # Player A has 3 rows (all non-stub weeks)
         assert len(a_rows) == 3
@@ -695,24 +896,28 @@ class TestComputeCumulativeMetrics:
 
     def test_cum_neg_rate_rounded(self):
         """Cumulative neg_rate is rounded to 4 decimal places."""
-        records = _make_temporal_records({
-            "Player A": [
-                ("2024-10-07 00:00:00", 1, 3),
-                ("2024-10-14 00:00:00", 1, 1),  # stub
-            ],
-        })
+        records = _make_temporal_records(
+            {
+                "Player A": [
+                    ("2024-10-07 00:00:00", 1, 3),
+                    ("2024-10-14 00:00:00", 1, 1),  # stub
+                ],
+            }
+        )
         result = compute_cumulative_metrics(records)
         rate = result["cum_neg_rate"][0]
         assert rate == 0.3333
 
     def test_single_player_single_week(self):
         """Minimal input: one player, two weeks (one real + one stub)."""
-        records = _make_temporal_records({
-            "Solo": [
-                ("2024-10-07 00:00:00", 4, 10),
-                ("2024-10-14 00:00:00", 1, 5),  # stub
-            ],
-        })
+        records = _make_temporal_records(
+            {
+                "Solo": [
+                    ("2024-10-07 00:00:00", 4, 10),
+                    ("2024-10-14 00:00:00", 1, 5),  # stub
+                ],
+            }
+        )
         result = compute_cumulative_metrics(records)
         assert result.height == 1
         row = result.to_dicts()[0]
@@ -727,13 +932,15 @@ class TestMaskBelowThreshold:
 
     def test_below_threshold_is_null(self):
         """Rows with cum_total below threshold get null cum_neg_rate."""
-        records = _make_temporal_records({
-            "Player A": [
-                ("2024-10-07 00:00:00", 50, 500),
-                ("2024-10-14 00:00:00", 60, 600),
-                ("2024-10-21 00:00:00", 1, 10),  # stub
-            ],
-        })
+        records = _make_temporal_records(
+            {
+                "Player A": [
+                    ("2024-10-07 00:00:00", 50, 500),
+                    ("2024-10-14 00:00:00", 60, 600),
+                    ("2024-10-21 00:00:00", 1, 10),  # stub
+                ],
+            }
+        )
         cumulative = compute_cumulative_metrics(records)
         # cum_total after week 1: 500, week 2: 1100
         masked = mask_below_threshold(cumulative, min_comments=1000)
@@ -744,12 +951,14 @@ class TestMaskBelowThreshold:
 
     def test_above_threshold_preserved(self):
         """Rows at or above threshold retain their cum_neg_rate."""
-        records = _make_temporal_records({
-            "Player A": [
-                ("2024-10-07 00:00:00", 100, 1000),
-                ("2024-10-14 00:00:00", 1, 10),  # stub
-            ],
-        })
+        records = _make_temporal_records(
+            {
+                "Player A": [
+                    ("2024-10-07 00:00:00", 100, 1000),
+                    ("2024-10-14 00:00:00", 1, 10),  # stub
+                ],
+            }
+        )
         cumulative = compute_cumulative_metrics(records)
         masked = mask_below_threshold(cumulative, min_comments=1000)
         row = masked.to_dicts()[0]
@@ -757,13 +966,15 @@ class TestMaskBelowThreshold:
 
     def test_custom_threshold(self):
         """Custom min_comments threshold is respected."""
-        records = _make_temporal_records({
-            "Player A": [
-                ("2024-10-07 00:00:00", 25, 250),
-                ("2024-10-14 00:00:00", 30, 300),
-                ("2024-10-21 00:00:00", 1, 10),  # stub
-            ],
-        })
+        records = _make_temporal_records(
+            {
+                "Player A": [
+                    ("2024-10-07 00:00:00", 25, 250),
+                    ("2024-10-14 00:00:00", 30, 300),
+                    ("2024-10-21 00:00:00", 1, 10),  # stub
+                ],
+            }
+        )
         cumulative = compute_cumulative_metrics(records)
         # cum_total: 250, 550
         masked = mask_below_threshold(cumulative, min_comments=500)
@@ -778,23 +989,25 @@ class TestPivotBarRaceWide:
 
     def _build_test_data(self):
         """Build test temporal records and metadata for pivot tests."""
-        records = _make_temporal_records({
-            "Player A": [
-                ("2024-10-07 00:00:00", 100, 1000),
-                ("2024-10-14 00:00:00", 150, 1500),
-                ("2024-10-21 00:00:00", 1, 10),  # stub
-            ],
-            "Player B": [
-                ("2024-10-07 00:00:00", 200, 1000),
-                ("2024-10-14 00:00:00", 250, 1500),
-                ("2024-10-21 00:00:00", 1, 10),  # stub
-            ],
-            "Player C": [
-                ("2024-10-07 00:00:00", 50, 1000),
-                ("2024-10-14 00:00:00", 80, 1500),
-                ("2024-10-21 00:00:00", 1, 10),  # stub
-            ],
-        })
+        records = _make_temporal_records(
+            {
+                "Player A": [
+                    ("2024-10-07 00:00:00", 100, 1000),
+                    ("2024-10-14 00:00:00", 150, 1500),
+                    ("2024-10-21 00:00:00", 1, 10),  # stub
+                ],
+                "Player B": [
+                    ("2024-10-07 00:00:00", 200, 1000),
+                    ("2024-10-14 00:00:00", 250, 1500),
+                    ("2024-10-21 00:00:00", 1, 10),  # stub
+                ],
+                "Player C": [
+                    ("2024-10-07 00:00:00", 50, 1000),
+                    ("2024-10-14 00:00:00", 80, 1500),
+                    ("2024-10-21 00:00:00", 1, 10),  # stub
+                ],
+            }
+        )
         metadata = {
             "Player A": {
                 "team": "Team Alpha",
@@ -816,8 +1029,11 @@ class TestPivotBarRaceWide:
         records, metadata = self._build_test_data()
         cumulative = compute_cumulative_metrics(records)
         wide = pivot_bar_race_wide(
-            cumulative, metadata, top_n=3,
-            min_ranking_comments=0, min_entry_comments=0,
+            cumulative,
+            metadata,
+            top_n=3,
+            min_ranking_comments=0,
+            min_entry_comments=0,
         )
 
         cols = wide.columns
@@ -831,8 +1047,11 @@ class TestPivotBarRaceWide:
         records, metadata = self._build_test_data()
         cumulative = compute_cumulative_metrics(records)
         wide = pivot_bar_race_wide(
-            cumulative, metadata, top_n=2,
-            min_ranking_comments=0, min_entry_comments=0,
+            cumulative,
+            metadata,
+            top_n=2,
+            min_ranking_comments=0,
+            min_entry_comments=0,
         )
 
         assert wide.height == 2
@@ -849,8 +1068,11 @@ class TestPivotBarRaceWide:
         records, metadata = self._build_test_data()
         cumulative = compute_cumulative_metrics(records)
         wide = pivot_bar_race_wide(
-            cumulative, metadata, top_n=2,
-            min_ranking_comments=0, min_entry_comments=0,
+            cumulative,
+            metadata,
+            top_n=2,
+            min_ranking_comments=0,
+            min_entry_comments=0,
         )
 
         date_cols = [c for c in wide.columns if c not in {"Label", "Category", "Image"}]
@@ -864,8 +1086,11 @@ class TestPivotBarRaceWide:
         # Ranking threshold 0 lets all players qualify; entry threshold 1500
         # means week 1 (cum_total=1000) is below, week 2 (cum_total=2500) is above
         wide = pivot_bar_race_wide(
-            cumulative, metadata, top_n=2,
-            min_ranking_comments=0, min_entry_comments=1500,
+            cumulative,
+            metadata,
+            top_n=2,
+            min_ranking_comments=0,
+            min_entry_comments=1500,
         )
 
         # First week column should have null values
@@ -879,22 +1104,25 @@ class TestAggregateMetadata:
 
     def test_metadata_includes_schema_version(self, tmp_path):
         """metadata carries the SCHEMA_VERSION from pipeline/schemas.py."""
-        path = _make_test_parquet(tmp_path, {
-            "comment_id": ["c1", "c2"],
-            "body": ["LeBron is great", "LeBron is washed"],
-            "author": ["u1", "u2"],
-            "author_flair_text": [":lal-1: Lakers", ":bos-1: Celtics"],
-            "author_flair_css_class": ["lakers", "celtics"],
-            "created_utc": [1704067200, 1704153600],
-            "score": [10, 5],
-            "link_id": ["t3_post123", "t3_post456"],
-            "mentioned_players": [["LeBron James"], ["LeBron James"]],
-            "sentiment": ["pos", "neg"],
-            "confidence": [0.9, 0.8],
-            "sentiment_player": ["LeBron James", "LeBron James"],
-            "input_tokens": [100, 100],
-            "output_tokens": [20, 20],
-        })
+        path = _make_test_parquet(
+            tmp_path,
+            {
+                "comment_id": ["c1", "c2"],
+                "body": ["LeBron is great", "LeBron is washed"],
+                "author": ["u1", "u2"],
+                "author_flair_text": [":lal-1: Lakers", ":bos-1: Celtics"],
+                "author_flair_css_class": ["lakers", "celtics"],
+                "created_utc": [1704067200, 1704153600],
+                "score": [10, 5],
+                "link_id": ["t3_post123", "t3_post456"],
+                "mentioned_players": [["LeBron James"], ["LeBron James"]],
+                "sentiment": ["pos", "neg"],
+                "confidence": [0.9, 0.8],
+                "sentiment_player": ["LeBron James", "LeBron James"],
+                "input_tokens": [100, 100],
+                "output_tokens": [20, 20],
+            },
+        )
 
         result = aggregate_sentiment(path)
 
@@ -908,22 +1136,25 @@ class TestAggregateMetadata:
         read can't silently mislabel a backfill.
         """
         season_override("2024-25")
-        path = _make_test_parquet(tmp_path, {
-            "comment_id": ["c1", "c2"],
-            "body": ["LeBron is great", "LeBron is washed"],
-            "author": ["u1", "u2"],
-            "author_flair_text": [":lal-1: Lakers", ":bos-1: Celtics"],
-            "author_flair_css_class": ["lakers", "celtics"],
-            "created_utc": [1704067200, 1704153600],
-            "score": [10, 5],
-            "link_id": ["t3_post123", "t3_post456"],
-            "mentioned_players": [["LeBron James"], ["LeBron James"]],
-            "sentiment": ["pos", "neg"],
-            "confidence": [0.9, 0.8],
-            "sentiment_player": ["LeBron James", "LeBron James"],
-            "input_tokens": [100, 100],
-            "output_tokens": [20, 20],
-        })
+        path = _make_test_parquet(
+            tmp_path,
+            {
+                "comment_id": ["c1", "c2"],
+                "body": ["LeBron is great", "LeBron is washed"],
+                "author": ["u1", "u2"],
+                "author_flair_text": [":lal-1: Lakers", ":bos-1: Celtics"],
+                "author_flair_css_class": ["lakers", "celtics"],
+                "created_utc": [1704067200, 1704153600],
+                "score": [10, 5],
+                "link_id": ["t3_post123", "t3_post456"],
+                "mentioned_players": [["LeBron James"], ["LeBron James"]],
+                "sentiment": ["pos", "neg"],
+                "confidence": [0.9, 0.8],
+                "sentiment_player": ["LeBron James", "LeBron James"],
+                "input_tokens": [100, 100],
+                "output_tokens": [20, 20],
+            },
+        )
 
         result = aggregate_sentiment(path)
 

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -265,60 +265,45 @@ def _lebron_parquet(tmp_path):
     )
 
 
-_LEBRON_ROSTER_ROW = {
-    "player_id": 2544,
-    "player_name": "LeBron James",
-    "team_name": "Los Angeles Lakers",
-    "team_abbr": "LAL",
-    "jersey_number": "23",
-    "position": "F",
-    "height": "6-9",
-    "weight": "250",
-    "age": 40,
-    "experience": "21",
-    "birth_date": date(1984, 12, 30),
-    "school": "St. Vincent-St. Mary HS (OH)",
-}
+def _write_snapshot(ref_dir, rows, season=None):
+    """Overwrite the pinned snapshot with custom rows (season=None → active)."""
+    pl.DataFrame(rows, schema=ROSTERS_SCHEMA).write_parquet(
+        ref_dir / "rosters.parquet",
+        metadata={"season": season or get_active_season()},
+    )
 
 
-def _pin_snapshot(monkeypatch, tmp_path, rows=None, season=None, missing=False):
-    """Point pipeline.aggregation at a tmp reference dir with a roster snapshot.
+@pytest.fixture(autouse=True)
+def pinned_snapshot(monkeypatch, tmp_path, lebron_roster_row):
+    """Pin pipeline.aggregation's reference dir to a tmp roster snapshot.
 
-    rows=None writes the LeBron row; missing=True leaves the dir empty
-    (the no-snapshot degradation path). season stamps the file's metadata
-    (defaults to the active season so no drift warning fires).
+    Autouse so no test in this module reads the real data/ reference dir —
+    aggregate_sentiment() takes the same code path on every machine.
+    Defaults to a one-row LeBron snapshot stamped with the active season;
+    tests needing other snapshot states overwrite or delete
+    rosters.parquet in the returned dir.
     """
     ref_dir = tmp_path / "reference"
     ref_dir.mkdir(parents=True, exist_ok=True)
     monkeypatch.setattr("pipeline.aggregation.get_reference_dir", lambda: ref_dir)
-    if missing:
-        return ref_dir
-    df = pl.DataFrame(rows or [_LEBRON_ROSTER_ROW], schema=ROSTERS_SCHEMA)
-    df.write_parquet(
-        ref_dir / "rosters.parquet",
-        metadata={"season": season or get_active_season()},
-    )
+    _write_snapshot(ref_dir, [lebron_roster_row])
     return ref_dir
 
 
 class TestAggregatePlayers:
     """Tests for the players Player-dimension frame in aggregate output."""
 
-    def test_players_is_frame_conforming_to_schema(self, tmp_path, monkeypatch):
+    def test_players_is_frame_conforming_to_schema(self, tmp_path):
         """players is returned as a frame matching PLAYERS_SCHEMA; the legacy
         player_metadata key no longer appears in the return dict."""
-        _pin_snapshot(monkeypatch, tmp_path)
-
         result = aggregate_sentiment(_lebron_parquet(tmp_path))
 
         assert isinstance(result["players"], pl.DataFrame)
         assert result["players"].schema == PLAYERS_SCHEMA
         assert "player_metadata" not in result
 
-    def test_config_side_populated(self, tmp_path, monkeypatch):
+    def test_config_side_populated(self, tmp_path):
         """Config columns carry the curated fields, roster team role-marked."""
-        _pin_snapshot(monkeypatch, tmp_path)
-
         result = aggregate_sentiment(_lebron_parquet(tmp_path))
 
         row = result["players"].row(
@@ -329,10 +314,8 @@ class TestAggregatePlayers:
         assert row["player_id"] == 2544
         assert row["headshot_url"] is not None
 
-    def test_snapshot_side_joined(self, tmp_path, monkeypatch):
+    def test_snapshot_side_joined(self, tmp_path):
         """Snapshot columns join in via player_id."""
-        _pin_snapshot(monkeypatch, tmp_path)
-
         result = aggregate_sentiment(_lebron_parquet(tmp_path))
 
         row = result["players"].row(
@@ -343,22 +326,21 @@ class TestAggregatePlayers:
         assert row["height"] == "6-9"
         assert row["birth_date"] == date(1984, 12, 30)
 
-    def test_excludes_non_attributed_players(self, tmp_path, monkeypatch):
+    def test_excludes_non_attributed_players(self, tmp_path):
         """The frame only includes players that appear in player_overall."""
-        _pin_snapshot(monkeypatch, tmp_path)
-
         result = aggregate_sentiment(_lebron_parquet(tmp_path))
         players = result["players"]["attributed_player"].to_list()
 
         assert players == ["LeBron James"]
 
-    def test_missing_snapshot_row_nulls_and_logs(self, tmp_path, monkeypatch, caplog):
+    def test_missing_snapshot_row_nulls_and_logs(
+        self, tmp_path, pinned_snapshot, lebron_roster_row, caplog
+    ):
         """An attributed player absent from the snapshot gets null snapshot
         columns and is logged (the baked-config fallback case)."""
-        _pin_snapshot(
-            monkeypatch,
-            tmp_path,
-            rows=[{**_LEBRON_ROSTER_ROW, "player_id": 999, "player_name": "Other"}],
+        _write_snapshot(
+            pinned_snapshot,
+            [{**lebron_roster_row, "player_id": 999, "player_name": "Other"}],
         )
 
         with caplog.at_level(logging.INFO, logger="pipeline.aggregation"):
@@ -374,11 +356,11 @@ class TestAggregatePlayers:
         assert "LeBron James" in caplog.text
 
     def test_missing_snapshot_file_warns_and_degrades(
-        self, tmp_path, monkeypatch, caplog
+        self, tmp_path, pinned_snapshot, caplog
     ):
         """No snapshot on disk: warn and ship the dimension with null
         snapshot columns (aggregation stays runnable without reference assets)."""
-        _pin_snapshot(monkeypatch, tmp_path, missing=True)
+        (pinned_snapshot / "rosters.parquet").unlink()
 
         with caplog.at_level(logging.WARNING, logger="pipeline.aggregation"):
             result = aggregate_sentiment(_lebron_parquet(tmp_path))
@@ -391,9 +373,11 @@ class TestAggregatePlayers:
         assert row["position"] is None
         assert "snapshot columns will be null" in caplog.text
 
-    def test_snapshot_season_stamp_mismatch_warns(self, tmp_path, monkeypatch, caplog):
+    def test_snapshot_season_stamp_mismatch_warns(
+        self, tmp_path, pinned_snapshot, lebron_roster_row, caplog
+    ):
         """A snapshot stamped for another season triggers the lineage warning."""
-        _pin_snapshot(monkeypatch, tmp_path, season="1999-00")
+        _write_snapshot(pinned_snapshot, [lebron_roster_row], season="1999-00")
 
         with caplog.at_level(logging.WARNING, logger="pipeline.aggregation"):
             aggregate_sentiment(_lebron_parquet(tmp_path))

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -441,6 +441,24 @@ class TestAggregatePlayers:
         assert "season stamp" in caplog.text
         assert "1999-00" in caplog.text
 
+    def test_unstamped_snapshot_warns_distinctly(
+        self, tmp_path, pinned_snapshot, lebron_roster_row, caplog
+    ):
+        """A snapshot with no season stamp warns that lineage is unverifiable.
+
+        Absent is not drift: the message must say lineage cannot be
+        verified, not claim a season mismatch.
+        """
+        pl.DataFrame([lebron_roster_row], schema=ROSTERS_SCHEMA).write_parquet(
+            pinned_snapshot / "rosters.parquet"
+        )
+
+        with caplog.at_level(logging.WARNING, logger="pipeline.aggregation"):
+            aggregate_sentiment(_lebron_parquet(tmp_path))
+
+        assert "no season stamp" in caplog.text
+        assert "does not match" not in caplog.text
+
 
 class TestPlayersToMetadataDict:
     """Tests for players_to_metadata_dict (frame -> legacy aggregates.json dict).

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -28,7 +28,7 @@ from pipeline.schemas import (
     SCHEMA_VERSION,
     SENTIMENT_SCHEMA,
 )
-from utils.player_config import load_player_config_version
+from utils.player_config import load_player_config_version, load_player_metadata
 from utils.season_config import get_active_season
 
 
@@ -241,28 +241,33 @@ def _make_test_parquet(tmp_path, rows, metadata=None):
     return path
 
 
+def _lebron_rows() -> dict:
+    """Two LeBron comments (Lakers + Celtics flair) in SENTIMENT_SCHEMA shape.
+
+    Base rows for the Player-dimension tests; override columns to vary
+    the mentioned players.
+    """
+    return {
+        "comment_id": ["c1", "c2"],
+        "body": ["LeBron is great", "LeBron is washed"],
+        "author": ["u1", "u2"],
+        "author_flair_text": [":lal-1: Lakers", ":bos-1: Celtics"],
+        "author_flair_css_class": ["lakers", "celtics"],
+        "created_utc": [1704067200, 1704153600],
+        "score": [10, 5],
+        "link_id": ["t3_post123", "t3_post456"],
+        "mentioned_players": [["LeBron James"], ["LeBron James"]],
+        "sentiment": ["pos", "neg"],
+        "confidence": [0.9, 0.8],
+        "sentiment_player": ["LeBron James", "LeBron James"],
+        "input_tokens": [100, 100],
+        "output_tokens": [20, 20],
+    }
+
+
 def _lebron_parquet(tmp_path):
-    """Two LeBron comments (Lakers + Celtics flair) — LeBron the only
-    attributed player. Shared by the Player-dimension tests."""
-    return _make_test_parquet(
-        tmp_path,
-        {
-            "comment_id": ["c1", "c2"],
-            "body": ["LeBron is great", "LeBron is washed"],
-            "author": ["u1", "u2"],
-            "author_flair_text": [":lal-1: Lakers", ":bos-1: Celtics"],
-            "author_flair_css_class": ["lakers", "celtics"],
-            "created_utc": [1704067200, 1704153600],
-            "score": [10, 5],
-            "link_id": ["t3_post123", "t3_post456"],
-            "mentioned_players": [["LeBron James"], ["LeBron James"]],
-            "sentiment": ["pos", "neg"],
-            "confidence": [0.9, 0.8],
-            "sentiment_player": ["LeBron James", "LeBron James"],
-            "input_tokens": [100, 100],
-            "output_tokens": [20, 20],
-        },
-    )
+    """Parquet of _lebron_rows() — LeBron the only attributed player."""
+    return _make_test_parquet(tmp_path, _lebron_rows())
 
 
 def _write_snapshot(ref_dir, rows, season=None):
@@ -332,6 +337,57 @@ class TestAggregatePlayers:
         players = result["players"]["attributed_player"].to_list()
 
         assert players == ["LeBron James"]
+
+    def test_multi_player_join_follows_config_order(
+        self, tmp_path, pinned_snapshot, lebron_roster_row
+    ):
+        """Two attributed players: one row each, ordered by players.yaml."""
+        giannis_row = {
+            **lebron_roster_row,
+            "player_id": 203507,
+            "player_name": "Giannis Antetokounmpo",
+            "team_name": "Milwaukee Bucks",
+            "team_abbr": "MIL",
+            "jersey_number": "34",
+        }
+        _write_snapshot(pinned_snapshot, [lebron_roster_row, giannis_row])
+        path = _make_test_parquet(
+            tmp_path,
+            {
+                **_lebron_rows(),
+                "body": ["LeBron is great", "Giannis is a freak"],
+                "mentioned_players": [["LeBron James"], ["Giannis Antetokounmpo"]],
+                "sentiment_player": ["LeBron James", "Giannis Antetokounmpo"],
+            },
+        )
+
+        result = aggregate_sentiment(path)
+
+        expected_order = [
+            player
+            for player in load_player_metadata()
+            if player in {"LeBron James", "Giannis Antetokounmpo"}
+        ]
+        assert result["players"]["attributed_player"].to_list() == expected_order
+        row = result["players"].row(
+            by_predicate=pl.col("attributed_player") == "Giannis Antetokounmpo",
+            named=True,
+        )
+        assert row["jersey_number"] == "34"
+
+    def test_duplicate_snapshot_player_id_raises(
+        self, tmp_path, pinned_snapshot, lebron_roster_row
+    ):
+        """A duplicate player_id in the snapshot fails loudly, not by fanning
+        the dimension out to multiple rows per player."""
+        _write_snapshot(
+            pinned_snapshot,
+            [lebron_roster_row, {**lebron_roster_row, "team_abbr": "BOS"}],
+        )
+
+        with pytest.raises(ValueError, match="duplicate") as exc:
+            aggregate_sentiment(_lebron_parquet(tmp_path))
+        assert "2544" in str(exc.value)
 
     def test_missing_snapshot_row_nulls_and_logs(
         self, tmp_path, pinned_snapshot, lebron_roster_row, caplog

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -6,7 +6,11 @@ import polars as pl
 import pytest
 
 from pipeline.schemas import (
+    AGGREGATE_VIEW_SCHEMAS,
     COMMENT_INPUT_SCHEMA,
+    DASHBOARD_OUTPUT_SCHEMAS,
+    PLAYERS_SCHEMA,
+    PLAYERS_SNAPSHOT_COLUMNS,
     ROSTERS_SCHEMA,
     SENTIMENT_SCHEMA,
     validate_schema,
@@ -73,6 +77,33 @@ def roster_frame() -> pl.DataFrame:
         ],
         schema=ROSTERS_SCHEMA,
     )
+
+
+class TestPlayersContract:
+    """Contract guards for the Player dimension (players.parquet)."""
+
+    def test_roster_team_is_role_marked(self):
+        """Verify the roster column is role-marked from birth — never bare `team`."""
+        assert PLAYERS_SCHEMA["roster_team"] == pl.String
+        assert "team" not in PLAYERS_SCHEMA.names()
+
+    def test_excludes_rejected_columns(self):
+        """Verify decided-out columns stay out (logo_url, age, snapshot team fields)."""
+        for col in ("logo_url", "age", "player_name", "team_name", "team_abbr"):
+            assert col not in PLAYERS_SCHEMA.names()
+
+    def test_snapshot_side_dtypes_derive_from_rosters(self):
+        """Verify snapshot-side dtypes match ROSTERS_SCHEMA exactly (no drift)."""
+        for col in PLAYERS_SNAPSHOT_COLUMNS:
+            assert PLAYERS_SCHEMA[col] == ROSTERS_SCHEMA[col]
+
+    def test_dashboard_outputs_superset(self):
+        """Verify the output mapping is views + the dimension, and views stay fact-only."""
+        assert set(DASHBOARD_OUTPUT_SCHEMAS) == set(AGGREGATE_VIEW_SCHEMAS) | {
+            "players"
+        }
+        assert DASHBOARD_OUTPUT_SCHEMAS["players"] is PLAYERS_SCHEMA
+        assert "players" not in AGGREGATE_VIEW_SCHEMAS
 
 
 class TestRostersContract:

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -1,7 +1,5 @@
 """Tests for pipeline/schemas.py schema validation."""
 
-from datetime import date
-
 import polars as pl
 import pytest
 
@@ -56,27 +54,9 @@ class TestLinkIdContract:
 
 
 @pytest.fixture
-def roster_frame() -> pl.DataFrame:
+def roster_frame(lebron_roster_row) -> pl.DataFrame:
     """One-row DataFrame conforming exactly to ROSTERS_SCHEMA."""
-    return pl.DataFrame(
-        [
-            {
-                "player_id": 2544,
-                "player_name": "LeBron James",
-                "team_name": "Los Angeles Lakers",
-                "team_abbr": "LAL",
-                "jersey_number": "23",
-                "position": "F",
-                "height": "6-9",
-                "weight": "250",
-                "age": 40,
-                "experience": "21",
-                "birth_date": date(1984, 12, 30),
-                "school": "St. Vincent-St. Mary HS (OH)",
-            }
-        ],
-        schema=ROSTERS_SCHEMA,
-    )
+    return pl.DataFrame([lebron_roster_row], schema=ROSTERS_SCHEMA)
 
 
 class TestPlayersContract:


### PR DESCRIPTION
Closes #39. Part 2 of 2 (part 1: #76, roster acquisition).

## What

Materializes the Player dimension as `players.parquet` — the thin-config build: curated fields from `config/<season>/players.yaml` LEFT JOINed on `player_id` with the season roster snapshot from #76. Supersedes PR #44's approach (closed unmerged; salvaged its shim design, mapping split, and test structure per the ticket).

- **`PLAYERS_SCHEMA`** — config side (`attributed_player`, `roster_team` role-marked from birth, `conference`, `player_id`, `headshot_url`) + snapshot side (`position`, `birth_date`, `experience`, `school`, `jersey_number`, `height`, `weight`) with dtypes derived from `ROSTERS_SCHEMA` so dimension and snapshot can't drift. Rejected per ticket: `logo_url`, `age`, snapshot team fields, `player_name`.
- **`_build_players_dimension()`** — attributed players in `players.yaml` order; explicit degradation at both grains (missing snapshot row → logged fallback + nulls; missing snapshot file → warning + config-only dimension); snapshot season-stamp lineage check.
- **`players_to_metadata_dict()`** — consumer-safe `aggregates.json` shim; value keys derived from the schema's config side, `roster_team` serialized as legacy `team`, `logo_url` dropped (verified unread: all UI logos come from `team_overall`).
- **Unified validation**: one loop over the new `DASHBOARD_OUTPUT_SCHEMAS` mapping (views + dimension); `AGGREGATE_VIEW_SCHEMAS` stays fact-only (the JSON record-shaping predicate keys off it). `SCHEMA_VERSION` → 3.
- **Stamp**: `players.parquet` carries `players_config_version` + `schema_version` (script-site, same mechanism as `sentiment.parquet`'s).
- `docs/data-model.md`: Player entity gains the snapshot attributes; `players.parquet.roster_team` is the first role-marked physical column; `jersey_number` under the point-in-time ceiling.

## Both seasons produced & verified

| | rows | fallback (snapshot gaps) | stamps |
|---|---|---|---|
| **2025-26** | 223 | 7 — the teamless carry-overs (Lonzo, Beasley, Beverley, Ivey, CP3, Rozier, Simmons), null `roster_team` in config too; exactly the case the ticket anticipated | `4.2` / `3` |
| **2024-25** | (attributed set) | 1 — Patrick Beverley, matching PR #76's coverage baseline | `2.0` / `3` |

- **v1 `aggregates.json` restored from git after the run** (owner-decided 2026-07-30): the +514-attributed republish stays deferred to the v2 backfill; only `players.parquet` kept. Working tree verified clean.
- **Belt-reign-by-position** (the ticket's verification query) now works: C-F is the saltiest qualified position class (0.389 avg neg_rate); Draymond crown intact at the #47 bit-for-bit numbers (0.5105 / 53,454), now with `roster_team`/`position` attached via a plain `USING (attributed_player)` join.
- Shimmed `aggregates.json` verified: exact legacy key set and value shape (`team`/`conference`/`player_id`/`headshot_url`), `players.yaml` order preserved; `enrich_with_metadata` smoke-tested against it.

## Test plan

- `TestPlayersContract` (schema guards: role-marked `roster_team`, rejected columns out, snapshot dtypes derive from `ROSTERS_SCHEMA`, mapping superset)
- `TestAggregatePlayers` (schema conformance, config+snapshot sides, attributed-only population, missing-row fallback + log, missing-file degradation, season-stamp lineage warning)
- `TestPlayersToMetadataDict` (legacy key contract, `roster_team`→`team`, row order)
- Full suite 434 passed, ruff clean, pre-commit gate passed per commit