### PR TITLE
fix(config): drop kai + snake aliases per verdict pass (v4.4)

### DIFF
--- a/config/2025-26/players.yaml
+++ b/config/2025-26/players.yaml
@@ -1074,10 +1074,9 @@ players:
     headshot_url: https://cdn.nba.com/headshots/nba/latest/1040x760/201935.png
     aliases:
     - harden
-    - the beard
+    - the beard  # kept v4.4 (#81 amendment): 82% sentiment_player agreement among named; generic-beard chatter sits below the 2:1 action rule
     - james floppen
-    - james soften
-    - literally hitler
+    - james soften  # kept v4.4 (#81 amendment): 92% agreement. 'literally hitler' dropped same pass: 0% — meme applied to SGA/Dort/Brown, never Harden
 
   Dylan Harper:
     team: San Antonio Spurs

--- a/config/2025-26/players.yaml
+++ b/config/2025-26/players.yaml
@@ -3,7 +3,7 @@
 # Carry-overs verbatim (+ §1.4 gaps); 108 new players: full-name + diacritic
 # floor + collision-safe surname. Flagged surnames -> Step 3 nba-superfan round.
 
-version: '4.3'
+version: '4.4'
 season: 2025-26
 short_aliases:
 - ad
@@ -135,7 +135,6 @@ short_aliases:
 - hield
 - the don
 - loon
-- kai
 - lonzo
 - flagg
 - jimmy g
@@ -148,7 +147,6 @@ short_aliases:
 - debo
 - k love
 - beal
-- snake
 - simmons
 - sarr
 - towns
@@ -808,8 +806,7 @@ players:
     - durantula
     - slim reaper
     - easy money sniper
-    - cupcake
-    - snake
+    - cupcake  # 'snake' dropped v4.4 (#81): 12% sentiment_player agreement — generic insult aimed at owners/execs/anyone, 0.60 neg rate
 
   Jalen Duren:
     team: Detroit Pistons
@@ -1244,8 +1241,7 @@ players:
     headshot_url: https://cdn.nba.com/headshots/nba/latest/1040x760/202681.png
     aliases:
     - kyrie
-    - irving
-    - kai
+    - irving  # 'kai' dropped v4.4 (#81): 31% sentiment_player agreement — Kai Jones/Sotto/Cenat/Lowry
     - uncle drew
     - world b flat
     - flat earther
@@ -1359,7 +1355,7 @@ players:
     headshot_url: https://cdn.nba.com/headshots/nba/latest/1040x760/203999.png
     aliases:
     - jokic
-    - joker
+    - joker  # kept v4.4 (#81): 92% sentiment_player agreement on 4,097 at-risk rows; movie/Murray bleed negligible
     - chokic
     - big honey
     - sombor shuffle


### PR DESCRIPTION
Closes #81.

## What

Config v4.4 (MINOR) — the frozen version for the full owner-extended verdict pass:
- drops `kai` (Kyrie Irving), `snake` (Kevin Durant), `literally hitler` (James Harden)
- records keeps: `joker` (92%), `the beard` (82% named agreement, owner-confirmed), `james soften` (92%)

Evidence and method in #81 + its dated amendment.

## Why

Same at-risk-grain method as #79 on the complete 2025-26 corpus: `kai` 31% agreement (Kai Jones/Sotto/Cenat), `snake` 12% (generic insult aimed at Cuban, Jeanie Buss, Nico Harrison, Doc Rivers — 0.60 neg rate injected into KD's stats), `literally hitler` 0% (meme applied to SGA/Dort/Brown, never Harden).

A corpus-wide agreement screen cleared the remaining alias set (sole outlier Paul Reed is a classifier-naming artifact, aggregates unaffected). Harden's qualified-#1 neg rate is real.

## Data rebuild (v4.4 final, local)

Re-assembled (2,110,479 rows) + re-aggregated; verified:

| Player | Before | After |
|---|---|---|
| Kevin Durant | 40,854 @ 0.429 | 40,181 @ 0.426 |
| Kyrie Irving | 8,995 @ 0.422 | 8,664 @ 0.426 |
| James Harden | 40,871 @ 0.553 | 40,814 @ 0.553 (still qualified #1) |
| Nikola Jokic | 72,848 | 72,852 |

No ranking-membership changes (all far above the 5,000 bar). Full-name coverage survives all drops. The 2024-25 config inherits the drops at the v2 backfill event, same deferral as #79's `zach`.