### PR TITLE
feat(pipeline): teams.parquet export — the Team dimension (config-pure build) (#78)

### DIFF
--- a/config/teams.yaml
+++ b/config/teams.yaml
@@ -13,7 +13,6 @@
 #   - Multi-team flairs (Mavs & Magic)
 
 version: "2.1"
-season: "2024-25"
 
 teams:
   Atlanta Hawks:

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -65,7 +65,7 @@ The four aggregate views (`player_overall`, `player_temporal`, `player_team`, `t
 - **Population + event/classification fields** — frozen at filter/classification time: `body`, `author`, `created_utc`, `score`, `link_id`, `sentiment`, `confidence`, `sentiment_player`. Re-running assembly never changes them; which comments exist in the fact (the population) is part of this frozen layer.
 - **Config-versioned derivations** — `mentioned_players`, and therefore `attributed_player`: caches of `f(body, players.yaml@version)`, re-derived at every assembly and stamped with the config `version` into the parquet's file metadata. The stamp is checked at aggregation read time (drift → WARNING) — the config `version` field (major = roster, minor = alias) is load-bearing lineage metadata, not documentation.
 
-The distinction matters because the two layers age differently: frozen fields stay correct forever, while a stored derivation is only as current as the config it was derived under — copying it forward through a rebuild silently reintroduces every alias fix made since. `fan_team` = `f(author_flair_text, teams.yaml)` is the **same attribute class** (a config-derived attribute, currently unversioned) — a future team-alias fix is this same problem and gets this same treatment, not a rediscovery.
+The distinction matters because the two layers age differently: frozen fields stay correct forever, while a stored derivation is only as current as the config it was derived under — copying it forward through a rebuild silently reintroduces every alias fix made since. `fan_team` = `f(author_flair_text, teams.yaml)` is the **same attribute class** — a config-derived attribute, and a future team-alias fix is this same problem. Its lineage anchor is the `teams.yaml` `version` stamped into `teams.parquet`; the dimension and the fan-team views are produced in one atomic aggregation run, so the stamp dates the config every `fan_team` derivation in the output set was built under.
 
 > `link_id` — decided V2 addition for the v3 bridge; pending, must land before the classify run (see Forward look).
 
@@ -83,7 +83,7 @@ The distinction matters because the two layers age differently: frozen fields st
 
 ### `Team` — dimension (role-playing)
 
-**Grain:** one franchise. Sourced from `config/teams.yaml`. Referenced in **two roles** today (see §2).
+**Grain:** one franchise. Materialized as `teams.parquet`: a pure export of `config/teams.yaml` — all 30 franchises in config order, no fact dependency. The file carries the `teams.yaml` `version` in its parquet metadata (the same lineage stamp mechanism as the Player dimension). Referenced in **two roles** today (see §2).
 
 | Field | Notes |
 |---|---|

--- a/pipeline/aggregation.py
+++ b/pipeline/aggregation.py
@@ -18,6 +18,7 @@ from pipeline.schemas import (
     PLAYERS_SNAPSHOT_COLUMNS,
     SCHEMA_VERSION,
     SENTIMENT_SCHEMA,
+    TEAM_OVERALL_SCHEMA,
     TEAMS_SCHEMA,
     validate_schema,
 )
@@ -276,11 +277,15 @@ def aggregate_sentiment(input_path: Path) -> dict:
     # logo_url) so the two can never drift.
     teams = build_teams_dimension(team_config)
 
-    # Left join appends the enrichment columns after the metrics, matching
-    # TEAM_OVERALL_SCHEMA order. Re-sort because joins don't preserve row order.
+    # Positive selection: the enrichment set is the intersection of the
+    # two contracts, so a column added to the dimension alone never
+    # propagates into the view. Left join appends the columns after the
+    # metrics, matching TEAM_OVERALL_SCHEMA order; re-sort because joins
+    # don't preserve row order.
+    enrichment_cols = [c for c in TEAM_OVERALL_SCHEMA.names() if c in TEAMS_SCHEMA]
     team_overall = (
         compute_metrics(df_team, ["team"])
-        .join(teams.drop("team_id"), on="team", how="left")
+        .join(teams.select(enrichment_cols), on="team", how="left")
         .sort("team")
     )
 

--- a/pipeline/aggregation.py
+++ b/pipeline/aggregation.py
@@ -18,6 +18,7 @@ from pipeline.schemas import (
     PLAYERS_SNAPSHOT_COLUMNS,
     SCHEMA_VERSION,
     SENTIMENT_SCHEMA,
+    TEAMS_SCHEMA,
     validate_schema,
 )
 from utils.paths import get_reference_dir
@@ -163,8 +164,8 @@ def aggregate_sentiment(input_path: Path) -> dict:
 
     Returns:
         Dict where player_overall, player_temporal, player_team,
-        team_overall, and players hold pl.DataFrames conforming to
-        DASHBOARD_OUTPUT_SCHEMAS; metadata is a dict. The legacy
+        team_overall, players, and teams hold pl.DataFrames conforming
+        to DASHBOARD_OUTPUT_SCHEMAS; metadata is a dict. The legacy
         player_metadata dict is reconstructed at serialization time via
         players_to_metadata_dict().
 
@@ -270,27 +271,16 @@ def aggregate_sentiment(input_path: Path) -> dict:
     logger.info("Computing team_overall...")
     df_team = df.filter(pl.col("team").is_not_null())
 
-    # Enrich with abbreviation, conference and logo_url from config/teams.yaml.
-    # Schema pin so an all-null column can't infer as Null dtype; left join
-    # appends the enrichment columns after the metrics, matching
+    # Team dimension: pure config export, also the single source for
+    # team_overall's baked enrichment columns (abbreviation, conference,
+    # logo_url) so the two can never drift.
+    teams = build_teams_dimension(team_config)
+
+    # Left join appends the enrichment columns after the metrics, matching
     # TEAM_OVERALL_SCHEMA order. Re-sort because joins don't preserve row order.
-    team_enrichment = pl.DataFrame(
-        {
-            "team": list(team_config),
-            "abbreviation": [info["abbreviation"] for info in team_config.values()],
-            "conference": [info["conference"] for info in team_config.values()],
-            "logo_url": [info["logo_url"] for info in team_config.values()],
-        },
-        schema={
-            "team": pl.String,
-            "abbreviation": pl.String,
-            "conference": pl.String,
-            "logo_url": pl.String,
-        },
-    )
     team_overall = (
         compute_metrics(df_team, ["team"])
-        .join(team_enrichment, on="team", how="left")
+        .join(teams.drop("team_id"), on="team", how="left")
         .sort("team")
     )
 
@@ -328,6 +318,7 @@ def aggregate_sentiment(input_path: Path) -> dict:
         "player_team": player_team,
         "team_overall": team_overall,
         "players": players,
+        "teams": teams,
     }
     for name, schema in DASHBOARD_OUTPUT_SCHEMAS.items():
         validate_schema(outputs[name], schema, name)
@@ -336,6 +327,33 @@ def aggregate_sentiment(input_path: Path) -> dict:
         **outputs,
         "metadata": metadata,
     }
+
+
+def build_teams_dimension(team_config: dict[str, dict]) -> pl.DataFrame:
+    """
+    Build the Team dimension: a pure export of config/teams.yaml.
+
+    One row per franchise, in teams.yaml order. No fact dependency —
+    every franchise ships regardless of which fan_teams the comments
+    resolved to. Aliases stay config-only: the dimension describes and
+    slices, it never selects.
+
+    Args:
+        team_config: Per-team config dict from load_team_config().
+
+    Returns:
+        Frame conforming to TEAMS_SCHEMA.
+    """
+    return pl.DataFrame(
+        {
+            "team": list(team_config),
+            "abbreviation": [info["abbreviation"] for info in team_config.values()],
+            "conference": [info["conference"] for info in team_config.values()],
+            "team_id": [info["team_id"] for info in team_config.values()],
+            "logo_url": [info["logo_url"] for info in team_config.values()],
+        },
+        schema=TEAMS_SCHEMA,
+    )
 
 
 def _build_players_dimension(

--- a/pipeline/schemas.py
+++ b/pipeline/schemas.py
@@ -209,13 +209,32 @@ PLAYERS_SCHEMA = pl.Schema(
     }
 )
 
+# --- Team dimension (enforced in pipeline/aggregation.py) -------------------
+# One row per franchise — the Team dimension the fan-role `team` FK in
+# player_team/team_overall references (and the roster_team FK in players).
+# Pure config export from config/teams.yaml; aliases stay config-only (the
+# dimension describes and slices, it never selects). PK is bare `team`:
+# role-marking (roster_team/fan_team) applies to FK columns on fact tables,
+# not the dimension's own key. See docs/data-model.md §2.
+
+TEAMS_SCHEMA = pl.Schema(
+    {
+        "team": pl.String,
+        "abbreviation": pl.String,
+        "conference": pl.String,
+        "team_id": pl.Int64,
+        "logo_url": pl.String,
+    }
+)
+
 # Every table the aggregation stage produces -> its schema: the four fact
-# views plus the Player dimension. Single source for aggregate_sentiment()'s
-# unified validation loop and the script's parquet write loop
-# (<name>.parquet).
+# views plus the Player and Team dimensions. Single source for
+# aggregate_sentiment()'s unified validation loop and the script's parquet
+# write loop (<name>.parquet).
 DASHBOARD_OUTPUT_SCHEMAS: dict[str, pl.Schema] = {
     **AGGREGATE_VIEW_SCHEMAS,
     "players": PLAYERS_SCHEMA,
+    "teams": TEAMS_SCHEMA,
 }
 
 

--- a/pipeline/schemas.py
+++ b/pipeline/schemas.py
@@ -157,12 +157,12 @@ TEAM_OVERALL_SCHEMA = pl.Schema(
     }
 )
 
-# View name -> schema for the four aggregate *views* (fact-table rollups).
+# View name -> schema for the aggregate *views* (fact-table rollups).
 # Keys match aggregate_sentiment() return-dict keys and parquet filenames.
-# Deliberately fact-only: the aggregation script keys its JSON
-# record-shaping predicate ("is this a list of records?") off this
-# mapping, so the Player dimension below must NOT live here — it
-# serializes to a nested dict.
+# Deliberately fact-only: dimensions live in DASHBOARD_OUTPUT_SCHEMAS
+# below. Membership here does NOT put a view into aggregates.json — the
+# script freezes that key set separately as a literal (LEGACY_JSON_VIEWS),
+# so future fact views join this mapping without touching the legacy file.
 AGGREGATE_VIEW_SCHEMAS: dict[str, pl.Schema] = {
     "player_overall": PLAYER_OVERALL_SCHEMA,
     "player_temporal": PLAYER_TEMPORAL_SCHEMA,

--- a/scripts/aggregate_sentiment.py
+++ b/scripts/aggregate_sentiment.py
@@ -104,6 +104,22 @@ def main() -> None:
     logger.info(f"Output: {output_path}")
     logger.info("=" * 60)
 
+    # Pre-flight the config-version stamps before anything runs or is
+    # written: a bad config version (e.g. an unquoted YAML float) must
+    # abort here, never between output writes — a torn output set
+    # (fresh aggregates.json beside stale parquets) is exactly the
+    # inconsistency the stamps exist to make detectable.
+    stamps = {
+        "players": {
+            "players_config_version": load_player_config_version(),
+            "schema_version": str(SCHEMA_VERSION),
+        },
+        "teams": {
+            "teams_config_version": load_team_config_version(),
+            "schema_version": str(SCHEMA_VERSION),
+        },
+    }
+
     # Run aggregation
     result = aggregate_sentiment(input_path)
 
@@ -131,19 +147,9 @@ def main() -> None:
     logger.info(f"Wrote aggregates to {output_path}")
 
     # Write one parquet per produced table (four views + the players and
-    # teams dimensions). Each dimension carries its config-version stamp
-    # so fact<->dimension drift is checkable (same mechanism as
-    # sentiment.parquet's stamp in collect_results).
-    stamps = {
-        "players": {
-            "players_config_version": load_player_config_version(),
-            "schema_version": str(SCHEMA_VERSION),
-        },
-        "teams": {
-            "teams_config_version": load_team_config_version(),
-            "schema_version": str(SCHEMA_VERSION),
-        },
-    }
+    # teams dimensions). Each dimension carries the config-version stamp
+    # pre-flighted above, so fact<->dimension drift is checkable (same
+    # mechanism as sentiment.parquet's stamp in collect_results).
     for name in DASHBOARD_OUTPUT_SCHEMAS:
         parquet_path = output_path.parent / f"{name}.parquet"
         result[name].write_parquet(parquet_path, metadata=stamps.get(name))

--- a/scripts/aggregate_sentiment.py
+++ b/scripts/aggregate_sentiment.py
@@ -4,8 +4,9 @@ Aggregate sentiment data into dashboard-ready outputs.
 Reads classified sentiment parquet, computes player rankings,
 flair segmentation, and temporal trends. Writes the nested
 aggregates.json for the Streamlit dashboard plus one parquet per
-produced table (the four fact views and the players dimension)
-alongside it for ad-hoc DuckDB queries and the v2 frontend.
+produced table (the four fact views and the players and teams
+dimensions) alongside it for ad-hoc DuckDB queries and the v2
+frontend.
 
 Usage:
     uv run python -m scripts.aggregate_sentiment
@@ -27,6 +28,7 @@ from pipeline.schemas import (
 from utils.paths import get_dashboard_dir, get_processed_dir
 from utils.player_config import load_player_config_version
 from utils.season_config import set_season_override
+from utils.team_config import load_team_config_version
 
 # -----------------------------------------------------------------------------
 # Logging setup
@@ -108,9 +110,12 @@ def main() -> None:
     # Ensure output directory exists
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Write JSON output: the four record-shaped views -> lists of dicts;
-    # the players dimension -> the legacy nested player_metadata dict
-    # (consumer-safe shim); the metadata scalar passes through.
+    # Write JSON output — the legacy aggregates.json key set, frozen by
+    # allowlist: the four record-shaped views -> lists of dicts; the
+    # players dimension -> the legacy nested player_metadata dict
+    # (consumer-safe shim); the metadata scalar passes through. Anything
+    # else (the teams dimension, any future output) is parquet-only —
+    # no legacy JSON counterpart, so the key set never grows.
     # default=str keeps week datetimes serialized exactly as before.
     serializable = {}
     for key, value in result.items():
@@ -118,27 +123,30 @@ def main() -> None:
             serializable[key] = value.to_dicts()
         elif key == "players":
             serializable["player_metadata"] = players_to_metadata_dict(value)
-        else:
+        elif key == "metadata":
             serializable[key] = value
     with open(output_path, "w") as f:
         json.dump(serializable, f, indent=2, default=str)
 
     logger.info(f"Wrote aggregates to {output_path}")
 
-    # Write one parquet per produced table (four views + the players
-    # dimension). players.parquet carries the config-version stamp so
-    # fact<->dimension drift is checkable (same mechanism as
+    # Write one parquet per produced table (four views + the players and
+    # teams dimensions). Each dimension carries its config-version stamp
+    # so fact<->dimension drift is checkable (same mechanism as
     # sentiment.parquet's stamp in collect_results).
-    players_stamp = {
-        "players_config_version": load_player_config_version(),
-        "schema_version": str(SCHEMA_VERSION),
+    stamps = {
+        "players": {
+            "players_config_version": load_player_config_version(),
+            "schema_version": str(SCHEMA_VERSION),
+        },
+        "teams": {
+            "teams_config_version": load_team_config_version(),
+            "schema_version": str(SCHEMA_VERSION),
+        },
     }
     for name in DASHBOARD_OUTPUT_SCHEMAS:
         parquet_path = output_path.parent / f"{name}.parquet"
-        result[name].write_parquet(
-            parquet_path,
-            metadata=players_stamp if name == "players" else None,
-        )
+        result[name].write_parquet(parquet_path, metadata=stamps.get(name))
         logger.info(f"Wrote {parquet_path}")
 
     # Log metadata summary

--- a/scripts/aggregate_sentiment.py
+++ b/scripts/aggregate_sentiment.py
@@ -20,11 +20,7 @@ import sys
 from pathlib import Path
 
 from pipeline.aggregation import aggregate_sentiment, players_to_metadata_dict
-from pipeline.schemas import (
-    AGGREGATE_VIEW_SCHEMAS,
-    DASHBOARD_OUTPUT_SCHEMAS,
-    SCHEMA_VERSION,
-)
+from pipeline.schemas import DASHBOARD_OUTPUT_SCHEMAS, SCHEMA_VERSION
 from utils.paths import get_dashboard_dir, get_processed_dir
 from utils.player_config import load_player_config_version
 from utils.season_config import set_season_override
@@ -48,6 +44,18 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_INPUT_FILENAME = "sentiment.parquet"
 DEFAULT_OUTPUT_FILENAME = "aggregates.json"
+
+# The legacy aggregates.json key set, frozen as a literal: exactly the
+# record-shaped views the file carried when it was demoted to legacy.
+# Deliberately NOT keyed off AGGREGATE_VIEW_SCHEMAS — that mapping grows
+# with new fact views, and this list never does. New outputs of any kind
+# are parquet-only; the file retires wholesale.
+LEGACY_JSON_VIEWS = (
+    "player_overall",
+    "player_temporal",
+    "player_team",
+    "team_overall",
+)
 
 
 # -----------------------------------------------------------------------------
@@ -126,16 +134,15 @@ def main() -> None:
     # Ensure output directory exists
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Write JSON output — the legacy aggregates.json key set, frozen by
-    # allowlist: the four record-shaped views -> lists of dicts; the
-    # players dimension -> the legacy nested player_metadata dict
-    # (consumer-safe shim); the metadata scalar passes through. Anything
-    # else (the teams dimension, any future output) is parquet-only —
-    # no legacy JSON counterpart, so the key set never grows.
+    # Write JSON output — the LEGACY_JSON_VIEWS literal freezes the key
+    # set: those views -> lists of dicts; the players dimension -> the
+    # legacy nested player_metadata dict (consumer-safe shim); the
+    # metadata scalar passes through. Anything else (the teams
+    # dimension, any future output) is parquet-only.
     # default=str keeps week datetimes serialized exactly as before.
     serializable = {}
     for key, value in result.items():
-        if key in AGGREGATE_VIEW_SCHEMAS:
+        if key in LEGACY_JSON_VIEWS:
             serializable[key] = value.to_dicts()
         elif key == "players":
             serializable["player_metadata"] = players_to_metadata_dict(value)

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -13,6 +13,7 @@ import pytest
 
 from pipeline.aggregation import (
     aggregate_sentiment,
+    build_teams_dimension,
     compute_cumulative_metrics,
     compute_metrics,
     extract_team_from_flair,
@@ -27,9 +28,11 @@ from pipeline.schemas import (
     ROSTERS_SCHEMA,
     SCHEMA_VERSION,
     SENTIMENT_SCHEMA,
+    TEAMS_SCHEMA,
 )
 from utils.player_config import load_player_config_version, load_player_metadata
 from utils.season_config import get_active_season
+from utils.team_config import load_team_config
 
 
 class TestResolvePlayer:
@@ -458,6 +461,77 @@ class TestAggregatePlayers:
 
         assert "no season stamp" in caplog.text
         assert "does not match" not in caplog.text
+
+
+class TestBuildTeamsDimension:
+    """Tests for build_teams_dimension (pure config export)."""
+
+    @pytest.fixture
+    def two_team_config(self) -> dict[str, dict]:
+        """Minimal two-team config in deliberate non-alphabetical order."""
+        return {
+            "Utah Jazz": {
+                "abbreviation": "UTA",
+                "conference": "West",
+                "team_id": 1610612762,
+                "logo_url": "https://cdn.nba.com/logos/nba/1610612762/primary/L/logo.svg",
+                "aliases": ["uta", "jazz"],
+            },
+            "Boston Celtics": {
+                "abbreviation": "BOS",
+                "conference": "East",
+                "team_id": 1610612738,
+                "logo_url": "https://cdn.nba.com/logos/nba/1610612738/primary/L/logo.svg",
+                "aliases": ["bos", "celtics"],
+            },
+        }
+
+    def test_conforms_to_schema(self, two_team_config):
+        """The frame matches TEAMS_SCHEMA exactly."""
+        frame = build_teams_dimension(two_team_config)
+
+        assert frame.schema == TEAMS_SCHEMA
+
+    def test_preserves_config_order(self, two_team_config):
+        """Rows follow teams.yaml insertion order, never sorted."""
+        frame = build_teams_dimension(two_team_config)
+
+        assert frame["team"].to_list() == ["Utah Jazz", "Boston Celtics"]
+
+    def test_row_values_from_config(self, two_team_config):
+        """Each descriptive column carries its config value."""
+        frame = build_teams_dimension(two_team_config)
+
+        row = frame.row(by_predicate=pl.col("team") == "Boston Celtics", named=True)
+        assert row["abbreviation"] == "BOS"
+        assert row["conference"] == "East"
+        assert row["team_id"] == 1610612738
+        assert row["logo_url"].endswith("1610612738/primary/L/logo.svg")
+
+    def test_aliases_stay_config_only(self, two_team_config):
+        """The dimension describes and slices; aliases never materialize."""
+        frame = build_teams_dimension(two_team_config)
+
+        assert "aliases" not in frame.columns
+
+
+class TestAggregateTeams:
+    """Tests for the teams Team-dimension frame in aggregate output."""
+
+    def test_teams_is_frame_conforming_to_schema(self, tmp_path):
+        """teams is returned as a frame matching TEAMS_SCHEMA."""
+        result = aggregate_sentiment(_lebron_parquet(tmp_path))
+
+        assert isinstance(result["teams"], pl.DataFrame)
+        assert result["teams"].schema == TEAMS_SCHEMA
+
+    def test_all_30_franchises_in_config_order(self, tmp_path):
+        """Every franchise ships, in teams.yaml order — the dimension is a
+        pure config export, independent of which fan_teams the facts hit."""
+        result = aggregate_sentiment(_lebron_parquet(tmp_path))
+
+        assert result["teams"]["team"].to_list() == list(load_team_config())
+        assert result["teams"].height == 30
 
 
 class TestPlayersToMetadataDict:

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -11,6 +11,7 @@ from pipeline.schemas import (
     PLAYERS_SNAPSHOT_COLUMNS,
     ROSTERS_SCHEMA,
     SENTIMENT_SCHEMA,
+    TEAMS_SCHEMA,
     validate_schema,
 )
 
@@ -78,12 +79,41 @@ class TestPlayersContract:
             assert PLAYERS_SCHEMA[col] == ROSTERS_SCHEMA[col]
 
     def test_dashboard_outputs_superset(self):
-        """Verify the output mapping is views + the dimension, and views stay fact-only."""
+        """Verify the output mapping is views + the dimensions, and views stay fact-only."""
         assert set(DASHBOARD_OUTPUT_SCHEMAS) == set(AGGREGATE_VIEW_SCHEMAS) | {
-            "players"
+            "players",
+            "teams",
         }
         assert DASHBOARD_OUTPUT_SCHEMAS["players"] is PLAYERS_SCHEMA
         assert "players" not in AGGREGATE_VIEW_SCHEMAS
+
+
+class TestTeamsContract:
+    """Contract guards for the Team dimension (teams.parquet)."""
+
+    def test_pins_column_set_and_dtypes(self):
+        """Verify the spec §3 column set with pinned dtypes."""
+        assert TEAMS_SCHEMA == pl.Schema(
+            {
+                "team": pl.String,
+                "abbreviation": pl.String,
+                "conference": pl.String,
+                "team_id": pl.Int64,
+                "logo_url": pl.String,
+            }
+        )
+
+    def test_pk_is_unmarked_team(self):
+        """Verify the dimension's own key is bare `team` — role-marking
+        (roster_team/fan_team) applies to FK columns on fact tables."""
+        assert TEAMS_SCHEMA.names()[0] == "team"
+        assert "fan_team" not in TEAMS_SCHEMA.names()
+
+    def test_joins_outputs_but_not_views(self):
+        """Verify teams ships via DASHBOARD_OUTPUT_SCHEMAS only — the script
+        keys its JSON record-shaping predicate off AGGREGATE_VIEW_SCHEMAS."""
+        assert DASHBOARD_OUTPUT_SCHEMAS["teams"] is TEAMS_SCHEMA
+        assert "teams" not in AGGREGATE_VIEW_SCHEMAS
 
 
 class TestRostersContract:

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -110,8 +110,8 @@ class TestTeamsContract:
         assert "fan_team" not in TEAMS_SCHEMA.names()
 
     def test_joins_outputs_but_not_views(self):
-        """Verify teams ships via DASHBOARD_OUTPUT_SCHEMAS only — the script
-        keys its JSON record-shaping predicate off AGGREGATE_VIEW_SCHEMAS."""
+        """Verify teams ships via DASHBOARD_OUTPUT_SCHEMAS only — a
+        dimension, not a fact rollup; the views mapping stays fact-only."""
         assert DASHBOARD_OUTPUT_SCHEMAS["teams"] is TEAMS_SCHEMA
         assert "teams" not in AGGREGATE_VIEW_SCHEMAS
 

--- a/tests/unit/test_team_config.py
+++ b/tests/unit/test_team_config.py
@@ -1,10 +1,19 @@
 """
 Tests for team configuration loading.
 
-Tests cover loading from YAML, alias map building, and caching behavior.
+Tests cover loading from YAML, alias map building, version loading,
+and caching behavior.
 """
 
-from utils.team_config import build_alias_to_team_map, load_team_config
+import re
+
+import pytest
+
+from utils.team_config import (
+    build_alias_to_team_map,
+    load_team_config,
+    load_team_config_version,
+)
 
 
 class TestLoadTeamConfig:
@@ -77,3 +86,53 @@ class TestBuildAliasToTeamMap:
         result1 = build_alias_to_team_map()
         result2 = build_alias_to_team_map()
         assert result1 is result2
+
+
+class TestLoadTeamConfigVersion:
+    """Tests for load_team_config_version function."""
+
+    @pytest.fixture
+    def cold_version_cache(self):
+        """Clear the version loader's cache before and after the test.
+
+        The invalid-config tests monkeypatch the config path; a warm
+        cache would return the real config's version and never consult
+        the patched path.
+        """
+        load_team_config_version.cache_clear()
+        yield
+        load_team_config_version.cache_clear()
+
+    def test_returns_version_string(self):
+        """Version is a MAJOR.MINOR string (format pinned, not the value —
+        the version bumps on team-config changes)."""
+        version = load_team_config_version()
+        assert re.fullmatch(r"\d+\.\d+", version)
+
+    def test_caching_returns_same_object(self):
+        """Multiple calls return the same cached object."""
+        result1 = load_team_config_version()
+        result2 = load_team_config_version()
+        assert result1 is result2
+
+    def test_missing_version_raises(self, tmp_path, monkeypatch, cold_version_cache):
+        """A teams.yaml without a version key raises ValueError with context."""
+        config_path = tmp_path / "teams.yaml"
+        config_path.write_text("teams: {}\n")
+        monkeypatch.setattr("utils.team_config.CONFIG_PATH", config_path)
+
+        with pytest.raises(ValueError, match="version"):
+            load_team_config_version()
+
+    def test_unquoted_version_raises(self, tmp_path, monkeypatch, cold_version_cache):
+        """An unquoted YAML version (parsed as float) raises ValueError.
+
+        Floats silently lose trailing zeros (2.10 -> "2.1"), which would
+        mis-stamp lineage; the loader demands a quoted string instead.
+        """
+        config_path = tmp_path / "teams.yaml"
+        config_path.write_text("version: 2.10\nteams: {}\n")
+        monkeypatch.setattr("utils.team_config.CONFIG_PATH", config_path)
+
+        with pytest.raises(ValueError, match="quoted string"):
+            load_team_config_version()

--- a/utils/team_config.py
+++ b/utils/team_config.py
@@ -33,6 +33,45 @@ def load_team_config() -> dict[str, dict]:
 
 
 @lru_cache(maxsize=1)
+def load_team_config_version() -> str:
+    """
+    Load the config version string from config/teams.yaml.
+
+    The version is lineage metadata: it is stamped into teams.parquet at
+    the aggregation write site, giving fan_team derivations the same
+    config-lineage treatment as players.yaml's version stamp on
+    sentiment.parquet.
+
+    Deliberately season-independent: teams.yaml is not season-scoped, so
+    this loader does not join the season-cache registry (no override
+    guard, no season_override fixture cache-clear) — by design, not
+    omission.
+
+    Returns:
+        Version string, e.g. "2.1".
+
+    Raises:
+        FileNotFoundError: If config file doesn't exist.
+        yaml.YAMLError: If config file is invalid YAML.
+        ValueError: If the config has no 'version' key, or the value is
+            not a quoted string (an unquoted version parses as a YAML
+            float and would silently mis-stamp, e.g. 2.10 -> "2.1").
+    """
+    with open(CONFIG_PATH) as f:
+        config = yaml.safe_load(f)
+
+    version = config.get("version")
+    if version is None:
+        raise ValueError(f"teams.yaml has no 'version' key: {CONFIG_PATH}")
+    if not isinstance(version, str):
+        raise ValueError(
+            f"teams.yaml version must be a quoted string, got "
+            f"{version!r} ({type(version).__name__}) in {CONFIG_PATH}"
+        )
+    return version
+
+
+@lru_cache(maxsize=1)
 def build_alias_to_team_map() -> dict[str, str]:
     """
     Invert team aliases to map each alias to its canonical team name.


### PR DESCRIPTION
Closes #78.

## What

Materializes the Team dimension as `teams.parquet` — a pure export of `config/teams.yaml` (30 franchises, config order, spec §3 column set), stamped with `teams_config_version` + `schema_version`. Completes the dimension side of the star schema and gives `logo_url` its decided home.

Commit-by-commit:

1. **`load_team_config_version()`** — mirrors the player loader incl. the quoted-string guard; deliberately outside the season-cache registry (`teams.yaml` is not season-scoped).
2. **`TEAMS_SCHEMA` + `build_teams_dimension()` + wiring** — joins `DASHBOARD_OUTPUT_SCHEMAS` under `"teams"` (not `AGGREGATE_VIEW_SCHEMAS`); the dimension also becomes the single source for `team_overall`'s baked enrichment columns (`teams.drop("team_id")` replaces the hand-built enrichment frame), so view and dimension can never drift.
3. **Script: stamp + allowlist inversion** — the JSON serialization loop flips from else-passthrough to an explicit allowlist, freezing `aggregates.json` at its legacy key set by construction (per the 2026-08-09 ticket amendment; a frame hitting the old passthrough would have been repr-stringified into the JSON).
4. **`docs/data-model.md`** — Team sourcing line states the materialization; the `fan_team` "currently unversioned" note replaced with the stamp that resolves it.

## Verification (per amended AC)

- `aggregates.json` key set byte-for-byte unchanged: `[metadata, player_metadata, player_overall, player_team, player_temporal, team_overall]`
- 2025-26 produced by the normal run; rebuild verified as a no-op on published numbers (Harden 0.5532 / 40,814 qualified #1, total 2,110,479)
- 2024-25 receives a **verified byte-identical copy** (`cmp` clean) instead of a `--season 2024-25` run — per the ticket amendment, keeping the v1 dashboard untouched ahead of the decided backfill/republish event
- FK completeness: `team_overall.team ANTI JOIN teams.parquet USING (team)` → 0 unmatched, both seasons
- Stamp verified on disk: `{teams_config_version: "2.1", schema_version: "3"}`
- `uv run pytest` (450 passed) and `uv run ruff check .` clean

## Out of scope (per ticket)

`TEAM_OVERALL_SCHEMA` slim-down, `manifest.json`, season-partitioned layout, fan-team column renames, per-season `teams.yaml`.