### PR TITLE
feat(pipeline): comment_samples.parquet — top-N receipts per player × sentiment (#84)

### DIFF
--- a/.claude/rules/python.md
+++ b/.claude/rules/python.md
@@ -53,6 +53,32 @@ def has_valid_body(comment: dict) -> dict | None:
 
 Skip docstrings only for obvious one-liners where the name says it all.
 
+## Comments
+
+Code explains itself; a comment carries the *why* the code can't. Keep them
+short — a contract or section comment is a few lines, not a paragraph.
+
+- **No links to doc sections.** `see docs/data-model.md §2` is a staleness
+  time-bomb: sections move, get renumbered, or stop being about the thing.
+  If the reasoning matters at the call site, state it in a sentence; if it's
+  conceptual, the doc is where a reader goes anyway.
+- **Ticket references only when the why is too long to summarize** — `(#84)`
+  next to a value whose derivation lives in a ticket is fine; a ticket number
+  as a substitute for saying what the code does is not.
+- **Decisions and rejected alternatives live in tickets, not comments.** The
+  comment says what the code does and the one non-obvious reason; the ticket
+  keeps the debate.
+
+```python
+# Good
+COMMENT_SAMPLES_MIN_CONFIDENCE = 0.9  # pos/neg only; neu is exempt
+
+# Avoid
+# The floor applies to pos/neg only. Neutral rows sit at a conventional
+# 0.5 (see docs/data-model.md §1 and ticket #84's amendment of 2026-08-15,
+# which considered and rejected a uniform 0.85 floor because ...)
+```
+
 ## Testing
 
 See `.claude/rules/testing.md` for testing conventions and TDD workflow.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -36,7 +36,7 @@ erDiagram
 
 The diagram carries **structure only** — entity boxes, the role-playing edges, and each box's grain/key. Full attribute lists live in the entity key below, so the diagram stays readable and so forward-look attributes never appear to already exist.
 
-The pipeline produces three classes of table from this model, none of which is drawn as a box: **rollups** of the `ClassifiedComment` fact (the four aggregate views — `player_overall`, `player_temporal`, `player_team`, `team_overall`: measures at a coarser grain), the **dimensions** (`players`, `teams`), and a **fact subset** (`comment_samples`: verbatim rows of the fact at its own grain, selected not aggregated). The subset is not a new entity — it *is* the `ClassifiedComment` box, sliced — and the rollups are derived from it; the lineage of all of them is the table in §4.
+The pipeline produces three classes of table from this model, none of which is drawn as a box: **rollups** of the `ClassifiedComment` fact (the four aggregate views — `player_overall`, `player_temporal`, `player_team`, `team_overall`: measures at a coarser grain), the **dimensions** (`players`, `teams`), and a **fact subset** (`comment_samples`: verbatim rows of the fact at its own grain, selected not aggregated). The subset is not a new entity — it *is* the `ClassifiedComment` box, sliced; the rollups are derived from the fact, not from the subset. The lineage of all of them is the table in §4.
 
 ---
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -36,7 +36,7 @@ erDiagram
 
 The diagram carries **structure only** — entity boxes, the role-playing edges, and each box's grain/key. Full attribute lists live in the entity key below, so the diagram stays readable and so forward-look attributes never appear to already exist.
 
-The four aggregate views (`player_overall`, `player_temporal`, `player_team`, `team_overall`) are **rollups of the `ClassifiedComment` fact** and are not drawn as boxes; their lineage is the table in §4.
+The pipeline produces three classes of table from this model, none of which is drawn as a box: **rollups** of the `ClassifiedComment` fact (the four aggregate views — `player_overall`, `player_temporal`, `player_team`, `team_overall`: measures at a coarser grain), the **dimensions** (`players`, `teams`), and a **fact subset** (`comment_samples`: verbatim rows of the fact at its own grain, selected not aggregated). The subset is not a new entity — it *is* the `ClassifiedComment` box, sliced — and the rollups are derived from it; the lineage of all of them is the table in §4.
 
 ---
 
@@ -123,8 +123,9 @@ The atomic fact stays at `created_utc` (seconds) and serves the replay directly;
 | `player_metadata.team` (legacy JSON only) | `roster_team` |
 | `player_team.team` | `fan_team` |
 | `team_overall.team` | `fan_team` |
+| `comment_samples.fan_team` | `fan_team` (role-marked physical name) |
 
-The fan-team columns still carry the unmarked physical name `team`; their rename is a **pending follow-up** (a separate ticket), not planned here. This doc records the concept and the mapping so the model and the code don't read as contradictory in the meantime.
+The fan-team columns in the two existing views still carry the unmarked physical name `team`; their rename is a **pending follow-up** (a separate ticket), not planned here. New produced files carry the role-marked name from birth. This doc records the concept and the mapping so the model and the code don't read as contradictory in the meantime.
 
 ---
 
@@ -138,20 +139,23 @@ The `Player → Team (roster)` edge carries a fidelity ceiling worth stating pla
 
 ## 4. View lineage — cheap, needs-a-join, expensive
 
-All four views are **fact tables** (rollups of `ClassifiedComment`); `Player` and `Team` are the **dimensions** joined in.
+Three classes of produced table: the four views are **rollups** of `ClassifiedComment` (fact tables with measures at a coarser grain); `Player` and `Team` are the **dimensions** joined in; `comment_samples` is a **fact subset** — verbatim rows of `ClassifiedComment` at its own grain, selected (top-N per player × sentiment by score, under candidacy gates) rather than aggregated.
 
-| View (parquet) | Grain | Derives from | Cheap question it already answers |
+| Table (parquet) | Grain | Derives from | Cheap question it already answers |
 |---|---|---|---|
 | `player_overall` | Player | fact → Player | "Draymond's overall hate" |
 | `player_temporal` | Player × Week | fact → Player, Date(`week`) | "Draymond week over week" |
 | `player_team` | Player × `fan_team` | fact → Player, Team(fan) | "Lakers fans about Draymond" |
 | `team_overall` | `fan_team` | fact → Team(fan) | "Which fanbase is saltiest" |
+| `comment_samples` | Player × sentiment × rank | fact → Player, Team(fan) | "The receipts: what a Lakers fan actually said about Draymond" |
+
+The fact subset makes *"show me the receipts"* **cheap** while leaving *"show me every comment"* deliberately **expensive** — the atomic fact is not a shipped table; a full drill is a separate engine (v3), not a view.
 
 **Needs a join** (no new pipeline output): any *roster-level* question — "OKC's roster sentiment over time," "own-fans vs. rivals" — joins a player-keyed view to `players.parquet` with `USING (attributed_player)` and groups by `roster_team` (or any other dimension attribute: position, experience, school).
 
 **Expensive** (a new aggregate view the pipeline must produce): "How Lakers fans' sentiment toward Draymond moved *week over week*" needs a `player_team_temporal` view (Player × `fan_team` × Week) that doesn't exist. A new grain ⇒ a new pipeline output.
 
-> **Non-additive measures guardrail:** the rate measures (`neg_rate`, `pos_rate`, `net_sentiment`, `polarization`) are **non-additive** — re-aggregate them from the counts (`neg_count` / `comment_count`), never by averaging rates across rows. (This is the salt-index lesson: a fanbase's true negativity is `sum(neg) / sum(total)`, not the mean of per-player rates.)
+> **Non-additive measures guardrail:** the rate measures (`neg_rate`, `pos_rate`, `net_sentiment`, `polarization`) are **non-additive** — re-aggregate them from the counts (`neg_count` / `comment_count`), never by averaging rates across rows. (This is the salt-index lesson: a fanbase's true negativity is `sum(neg) / sum(total)`, not the mean of per-player rates.) The guardrail has no purchase on the fact subset — it carries no measures, nothing to re-aggregate; its one rule is that `body` is never truncated (a receipt is verbatim or it isn't a receipt).
 
 > **Known seam:** the *qualified-player* threshold (min 5,000 comments) is a business rule applied at read time and currently restated across the dashboard, notebooks, and the launch post rather than defined once. It's a metric-definition concern, not strictly entity-relationship — but it's a real semantic-layer gap: the model has no single place that says "qualified."
 

--- a/pipeline/aggregation.py
+++ b/pipeline/aggregation.py
@@ -381,8 +381,11 @@ def build_comment_samples(
     Select the comment samples: top-N receipts per player x sentiment.
 
     A verbatim fact subset, selected not aggregated. Candidacy requires
-    the classifier's confidence at or above the floor and a body no
-    longer than the cap (a receipt is a quote, not an essay). Within each
+    a body no longer than the cap (a receipt is a quote, not an essay)
+    and, for the polar labels (pos/neg), the classifier's confidence at
+    or above the floor — a misclassification guard. Neutral rows are
+    exempt: the classifier reports a conventional 0.5 for neu, so a floor
+    there would starve the neutral cells, not guard them. Within each
     (attributed_player, sentiment) cell, exact-duplicate bodies collapse
     to their best-ranked copy (copypasta guard), rows rank by score
     descending — ties broken by confidence descending, then comment_id
@@ -397,7 +400,8 @@ def build_comment_samples(
             sentiment, comment_id, link_id, body, score, confidence,
             created_utc, team.
         n: Maximum rows per (attributed_player, sentiment) cell.
-        min_confidence: Candidacy floor on the classifier's confidence.
+        min_confidence: Candidacy floor on the classifier's confidence,
+            applied to pos/neg rows only.
         max_body_chars: Candidacy cap on body length, in characters.
 
     Returns:
@@ -406,12 +410,14 @@ def build_comment_samples(
     """
     cell = ["attributed_player", "sentiment"]
 
-    above_floor = df.filter(pl.col("confidence") >= min_confidence)
+    above_floor = df.filter(
+        (pl.col("sentiment") == "neu") | (pl.col("confidence") >= min_confidence)
+    )
     candidates = above_floor.filter(pl.col("body").str.len_chars() <= max_body_chars)
     if df.height:
         logger.info(
             f"comment_samples candidacy: {df.height:,} attributed rows -> "
-            f"{above_floor.height:,} at confidence >= {min_confidence} "
+            f"{above_floor.height:,} at pos/neg confidence >= {min_confidence} "
             f"({(df.height - above_floor.height) / df.height:.1%} removed) -> "
             f"{candidates.height:,} at body <= {max_body_chars} chars "
             f"({(above_floor.height - candidates.height) / df.height:.1%} removed)"

--- a/pipeline/aggregation.py
+++ b/pipeline/aggregation.py
@@ -318,8 +318,6 @@ def aggregate_sentiment(input_path: Path) -> dict:
     attributed_players = set(player_overall.get_column("attributed_player").to_list())
     players = _build_players_dimension(player_metadata, attributed_players)
 
-    # Comment samples: the receipts - a verbatim fact subset, top-N per
-    # player x sentiment by score under the candidacy gates
     logger.info("Selecting comment_samples...")
     comment_samples = build_comment_samples(df_attributed)
     _log_comment_samples_diagnostics(df_attributed, comment_samples)
@@ -385,30 +383,21 @@ def build_comment_samples(
     """
     Select the comment samples: top-N receipts per player x sentiment.
 
-    A verbatim fact subset, selected not aggregated. Candidacy requires
-    a body no longer than the cap (a receipt is a quote, not an essay)
-    and, for the polar labels (pos/neg), the classifier's confidence at
-    or above the floor — a misclassification guard. Neutral rows are
-    exempt: the prompt gives no confidence guidance and, empirically
-    (2025-26 run), the classifier reports a conventional 0.5 for neu, so
-    a floor there would starve the neutral cells rather than guard them.
-    Within each (attributed_player, sentiment) cell, exact-duplicate
-    bodies collapse to their best-ranked copy (copypasta guard), rows
-    rank by score descending — ties broken by confidence descending, then
-    comment_id ascending, nulls last, so output is deterministic — and
-    the top n are kept. A cell with fewer than n candidates yields fewer
-    rows, never padding.
-
-    The fact's fan-role ``team`` column ships as ``fan_team``. Bodies are
-    never truncated.
+    Candidacy: body no longer than max_body_chars and, for pos/neg,
+    confidence at or above min_confidence. Neutral rows are exempt from
+    the floor - the classifier reports a conventional 0.5 for neu, so a
+    floor there would starve the cells rather than guard them. Within
+    each (attributed_player, sentiment) cell, duplicate bodies collapse
+    to the best-ranked copy, rows rank by score desc (ties: confidence
+    desc, comment_id asc, nulls last) and the top n are kept; thin cells
+    are never padded. Bodies are verbatim.
 
     Args:
-        df: Attributed, flair-resolved frame: attributed_player,
+        df: Attributed, flair-resolved frame with attributed_player,
             sentiment, comment_id, link_id, body, score, confidence,
             created_utc, team.
         n: Maximum rows per (attributed_player, sentiment) cell.
-        min_confidence: Candidacy floor on the classifier's confidence,
-            applied to pos/neg rows only.
+        min_confidence: Candidacy floor on confidence, pos/neg rows only.
         max_body_chars: Candidacy cap on body length, in characters.
 
     Returns:
@@ -454,11 +443,8 @@ def _log_comment_samples_diagnostics(
     """
     Log the multi-mention share of the sampled rows.
 
-    A multi-mention comment is attributed via the classifier's explicit
-    sentiment_player, so its receipt always names a stated target — but
-    a two-name comment can still read ambiguously under one player's
-    card. Logged so the share is visible on every run; the reading
-    quality of those rows is a review-time judgment, not a code check.
+    A two-name receipt can read ambiguously under one player's card;
+    the share is logged every run so it stays visible.
 
     Args:
         df_attributed: The attributed frame (carries mentioned_players).
@@ -467,8 +453,7 @@ def _log_comment_samples_diagnostics(
     if not comment_samples.height:
         logger.info("comment_samples: no rows selected")
         return
-    # Semi-join: counts sampled rows whose id has a multi-mention fact
-    # row, and can't fan out if an id were ever duplicated in the fact
+    # Semi-join: can't fan out if a comment_id were ever duplicated
     multi = comment_samples.join(
         df_attributed.filter(pl.col("mentioned_players").list.len() > 1).select(
             "comment_id"

--- a/pipeline/aggregation.py
+++ b/pipeline/aggregation.py
@@ -23,6 +23,11 @@ from pipeline.schemas import (
     TEAMS_SCHEMA,
     validate_schema,
 )
+from utils.constants import (
+    COMMENT_SAMPLES_MAX_BODY_CHARS,
+    COMMENT_SAMPLES_MIN_CONFIDENCE,
+    COMMENT_SAMPLES_TOP_N,
+)
 from utils.paths import get_reference_dir
 from utils.player_config import (
     build_alias_to_player_map,
@@ -368,16 +373,6 @@ def build_teams_dimension(team_config: dict[str, dict]) -> pl.DataFrame:
         },
         schema=TEAMS_SCHEMA,
     )
-
-
-# comment_samples selection parameters - the defaults of
-# build_comment_samples(), named so the manifest can import rather than
-# retype them. Finalized on 2025-26 data: every qualified player's cells
-# fill at n=10; the cap removes ~2% of the candidate pool; the floor keeps
-# the classifier's top two confidence buckets on the polar labels.
-COMMENT_SAMPLES_TOP_N = 10
-COMMENT_SAMPLES_MIN_CONFIDENCE = 0.9  # pos/neg only; see build_comment_samples
-COMMENT_SAMPLES_MAX_BODY_CHARS = 500
 
 
 def build_comment_samples(

--- a/pipeline/aggregation.py
+++ b/pipeline/aggregation.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import polars as pl
 
 from pipeline.schemas import (
+    COMMENT_SAMPLES_SCHEMA,
     DASHBOARD_OUTPUT_SCHEMAS,
     PLAYERS_CONFIG_COLUMNS,
     PLAYERS_SCHEMA,
@@ -165,10 +166,10 @@ def aggregate_sentiment(input_path: Path) -> dict:
 
     Returns:
         Dict where player_overall, player_temporal, player_team,
-        team_overall, players, and teams hold pl.DataFrames conforming
-        to DASHBOARD_OUTPUT_SCHEMAS; metadata is a dict. The legacy
-        player_metadata dict is reconstructed at serialization time via
-        players_to_metadata_dict().
+        team_overall, players, teams, and comment_samples hold
+        pl.DataFrames conforming to DASHBOARD_OUTPUT_SCHEMAS; metadata is
+        a dict. The legacy player_metadata dict is reconstructed at
+        serialization time via players_to_metadata_dict().
 
     Raises:
         ValueError: If the input parquet does not match SENTIMENT_SCHEMA,
@@ -312,9 +313,16 @@ def aggregate_sentiment(input_path: Path) -> dict:
     attributed_players = set(player_overall.get_column("attributed_player").to_list())
     players = _build_players_dimension(player_metadata, attributed_players)
 
+    # Comment samples: the receipts - a verbatim fact subset, top-N per
+    # player x sentiment by score under the candidacy gates
+    logger.info("Selecting comment_samples...")
+    comment_samples = build_comment_samples(df_attributed)
+    _log_comment_samples_diagnostics(df_attributed, comment_samples)
+
     logger.info(
         f"Aggregation complete: {unique_players} players, "
-        f"{unique_teams} teams, {unique_weeks} weeks"
+        f"{unique_teams} teams, {unique_weeks} weeks, "
+        f"{comment_samples.height:,} comment samples"
     )
 
     outputs = {
@@ -324,6 +332,7 @@ def aggregate_sentiment(input_path: Path) -> dict:
         "team_overall": team_overall,
         "players": players,
         "teams": teams,
+        "comment_samples": comment_samples,
     }
     for name, schema in DASHBOARD_OUTPUT_SCHEMAS.items():
         validate_schema(outputs[name], schema, name)
@@ -358,6 +367,103 @@ def build_teams_dimension(team_config: dict[str, dict]) -> pl.DataFrame:
             "logo_url": [info["logo_url"] for info in team_config.values()],
         },
         schema=TEAMS_SCHEMA,
+    )
+
+
+def build_comment_samples(
+    df: pl.DataFrame,
+    *,
+    n: int = 10,
+    min_confidence: float = 0.9,
+    max_body_chars: int = 500,
+) -> pl.DataFrame:
+    """
+    Select the comment samples: top-N receipts per player x sentiment.
+
+    A verbatim fact subset, selected not aggregated. Candidacy requires
+    the classifier's confidence at or above the floor and a body no
+    longer than the cap (a receipt is a quote, not an essay). Within each
+    (attributed_player, sentiment) cell, exact-duplicate bodies collapse
+    to their best-ranked copy (copypasta guard), rows rank by score
+    descending — ties broken by confidence descending, then comment_id
+    ascending, so output is deterministic — and the top n are kept. A
+    cell with fewer than n candidates yields fewer rows, never padding.
+
+    The fact's fan-role ``team`` column ships as ``fan_team``. Bodies are
+    never truncated.
+
+    Args:
+        df: Attributed, flair-resolved frame: attributed_player,
+            sentiment, comment_id, link_id, body, score, confidence,
+            created_utc, team.
+        n: Maximum rows per (attributed_player, sentiment) cell.
+        min_confidence: Candidacy floor on the classifier's confidence.
+        max_body_chars: Candidacy cap on body length, in characters.
+
+    Returns:
+        Frame conforming to COMMENT_SAMPLES_SCHEMA, sorted by
+        (attributed_player, sentiment, rank).
+    """
+    cell = ["attributed_player", "sentiment"]
+
+    above_floor = df.filter(pl.col("confidence") >= min_confidence)
+    candidates = above_floor.filter(pl.col("body").str.len_chars() <= max_body_chars)
+    if df.height:
+        logger.info(
+            f"comment_samples candidacy: {df.height:,} attributed rows -> "
+            f"{above_floor.height:,} at confidence >= {min_confidence} "
+            f"({(df.height - above_floor.height) / df.height:.1%} removed) -> "
+            f"{candidates.height:,} at body <= {max_body_chars} chars "
+            f"({(above_floor.height - candidates.height) / df.height:.1%} removed)"
+        )
+
+    return (
+        candidates.sort(
+            ["score", "confidence", "comment_id"], descending=[True, True, False]
+        )
+        .unique(subset=[*cell, "body"], keep="first", maintain_order=True)
+        .with_columns(
+            (pl.int_range(pl.len()).over(cell) + 1).cast(pl.Int64).alias("rank")
+        )
+        .filter(pl.col("rank") <= n)
+        .rename({"team": "fan_team"})
+        .select(COMMENT_SAMPLES_SCHEMA.names())
+        .sort([*cell, "rank"])
+    )
+
+
+def _log_comment_samples_diagnostics(
+    df_attributed: pl.DataFrame, comment_samples: pl.DataFrame
+) -> None:
+    """
+    Log the multi-mention share of the sampled rows.
+
+    A multi-mention comment is attributed via the classifier's explicit
+    sentiment_player, so its receipt always names a stated target — but
+    a two-name comment can still read ambiguously under one player's
+    card. Logged so the share is visible on every run; the reading
+    quality of those rows is a review-time judgment, not a code check.
+
+    Args:
+        df_attributed: The attributed frame (carries mentioned_players).
+        comment_samples: The selected samples (COMMENT_SAMPLES_SCHEMA).
+    """
+    if not comment_samples.height:
+        logger.info("comment_samples: no rows selected")
+        return
+    multi = (
+        comment_samples.select("comment_id")
+        .join(
+            df_attributed.select("comment_id", "mentioned_players"),
+            on="comment_id",
+            how="left",
+        )
+        .filter(pl.col("mentioned_players").list.len() > 1)
+        .height
+    )
+    logger.info(
+        f"comment_samples: {comment_samples.height:,} rows selected; "
+        f"{multi:,} multi-mention ({multi / comment_samples.height:.1%})"
     )
 
 

--- a/pipeline/aggregation.py
+++ b/pipeline/aggregation.py
@@ -370,12 +370,22 @@ def build_teams_dimension(team_config: dict[str, dict]) -> pl.DataFrame:
     )
 
 
+# comment_samples selection parameters - the defaults of
+# build_comment_samples(), named so the manifest can import rather than
+# retype them. Finalized on 2025-26 data: every qualified player's cells
+# fill at n=10; the cap removes ~2% of the candidate pool; the floor keeps
+# the classifier's top two confidence buckets on the polar labels.
+COMMENT_SAMPLES_TOP_N = 10
+COMMENT_SAMPLES_MIN_CONFIDENCE = 0.9  # pos/neg only; see build_comment_samples
+COMMENT_SAMPLES_MAX_BODY_CHARS = 500
+
+
 def build_comment_samples(
     df: pl.DataFrame,
     *,
-    n: int = 10,
-    min_confidence: float = 0.9,
-    max_body_chars: int = 500,
+    n: int = COMMENT_SAMPLES_TOP_N,
+    min_confidence: float = COMMENT_SAMPLES_MIN_CONFIDENCE,
+    max_body_chars: int = COMMENT_SAMPLES_MAX_BODY_CHARS,
 ) -> pl.DataFrame:
     """
     Select the comment samples: top-N receipts per player x sentiment.
@@ -384,13 +394,15 @@ def build_comment_samples(
     a body no longer than the cap (a receipt is a quote, not an essay)
     and, for the polar labels (pos/neg), the classifier's confidence at
     or above the floor — a misclassification guard. Neutral rows are
-    exempt: the classifier reports a conventional 0.5 for neu, so a floor
-    there would starve the neutral cells, not guard them. Within each
-    (attributed_player, sentiment) cell, exact-duplicate bodies collapse
-    to their best-ranked copy (copypasta guard), rows rank by score
-    descending — ties broken by confidence descending, then comment_id
-    ascending, so output is deterministic — and the top n are kept. A
-    cell with fewer than n candidates yields fewer rows, never padding.
+    exempt: the prompt gives no confidence guidance and, empirically
+    (2025-26 run), the classifier reports a conventional 0.5 for neu, so
+    a floor there would starve the neutral cells rather than guard them.
+    Within each (attributed_player, sentiment) cell, exact-duplicate
+    bodies collapse to their best-ranked copy (copypasta guard), rows
+    rank by score descending — ties broken by confidence descending, then
+    comment_id ascending, nulls last, so output is deterministic — and
+    the top n are kept. A cell with fewer than n candidates yields fewer
+    rows, never padding.
 
     The fact's fan-role ``team`` column ships as ``fan_team``. Bodies are
     never truncated.
@@ -410,27 +422,30 @@ def build_comment_samples(
     """
     cell = ["attributed_player", "sentiment"]
 
-    above_floor = df.filter(
-        (pl.col("sentiment") == "neu") | (pl.col("confidence") >= min_confidence)
+    passes_floor = (pl.col("sentiment") == "neu") | (
+        pl.col("confidence") >= min_confidence
     )
-    candidates = above_floor.filter(pl.col("body").str.len_chars() <= max_body_chars)
+    within_cap = pl.col("body").str.len_chars() <= max_body_chars
+    candidates = df.filter(passes_floor & within_cap)
     if df.height:
+        below_floor = df.filter(~passes_floor).height
+        over_cap = df.filter(passes_floor & ~within_cap).height
         logger.info(
-            f"comment_samples candidacy: {df.height:,} attributed rows -> "
-            f"{above_floor.height:,} at pos/neg confidence >= {min_confidence} "
-            f"({(df.height - above_floor.height) / df.height:.1%} removed) -> "
-            f"{candidates.height:,} at body <= {max_body_chars} chars "
-            f"({(above_floor.height - candidates.height) / df.height:.1%} removed)"
+            f"comment_samples candidacy: {df.height:,} attributed rows; "
+            f"{below_floor:,} ({below_floor / df.height:.1%}) removed by the "
+            f"pos/neg confidence floor {min_confidence}, "
+            f"{over_cap:,} ({over_cap / df.height:.1%}) removed by the "
+            f"{max_body_chars}-char body cap; {candidates.height:,} candidates"
         )
 
     return (
         candidates.sort(
-            ["score", "confidence", "comment_id"], descending=[True, True, False]
+            ["score", "confidence", "comment_id"],
+            descending=[True, True, False],
+            nulls_last=True,
         )
         .unique(subset=[*cell, "body"], keep="first", maintain_order=True)
-        .with_columns(
-            (pl.int_range(pl.len()).over(cell) + 1).cast(pl.Int64).alias("rank")
-        )
+        .with_columns((pl.int_range(pl.len()).over(cell) + 1).alias("rank"))
         .filter(pl.col("rank") <= n)
         .rename({"team": "fan_team"})
         .select(COMMENT_SAMPLES_SCHEMA.names())
@@ -457,16 +472,15 @@ def _log_comment_samples_diagnostics(
     if not comment_samples.height:
         logger.info("comment_samples: no rows selected")
         return
-    multi = (
-        comment_samples.select("comment_id")
-        .join(
-            df_attributed.select("comment_id", "mentioned_players"),
-            on="comment_id",
-            how="left",
-        )
-        .filter(pl.col("mentioned_players").list.len() > 1)
-        .height
-    )
+    # Semi-join: counts sampled rows whose id has a multi-mention fact
+    # row, and can't fan out if an id were ever duplicated in the fact
+    multi = comment_samples.join(
+        df_attributed.filter(pl.col("mentioned_players").list.len() > 1).select(
+            "comment_id"
+        ),
+        on="comment_id",
+        how="semi",
+    ).height
     logger.info(
         f"comment_samples: {comment_samples.height:,} rows selected; "
         f"{multi:,} multi-mention ({multi / comment_samples.height:.1%})"

--- a/pipeline/schemas.py
+++ b/pipeline/schemas.py
@@ -16,6 +16,9 @@ pipeline produces. Data dictionary first, enforcement second:
 - PLAYERS_SCHEMA describes the Player dimension (players.parquet),
   config curation joined with snapshot facts; enforced in
   aggregate_sentiment() via the unified DASHBOARD_OUTPUT_SCHEMAS loop.
+- COMMENT_SAMPLES_SCHEMA describes the comment-samples fact subset
+  (comment_samples.parquet): verbatim rows of the fact, selected not
+  aggregated; enforced via the same unified loop.
 
 This module must not import from other pipeline modules (it is imported
 by them).
@@ -224,6 +227,32 @@ TEAMS_SCHEMA = pl.Schema(
         "conference": pl.String,
         "team_id": pl.Int64,
         "logo_url": pl.String,
+    }
+)
+
+# --- Comment samples: fact subset (enforced in pipeline/aggregation.py) ------
+# One row per sampled comment — verbatim rows of the ClassifiedComment fact
+# at its own grain, selected not aggregated: the top-N per player x sentiment
+# by score, under a confidence floor and a body-length cap. Logical PK is
+# (attributed_player, sentiment, rank), rank 1..N within each cell. Not a
+# rollup: there are no measures, so the non-additive guardrail doesn't
+# apply — the one rule is that body is never truncated (it is the receipt;
+# comment_id + link_id give the permalink). fan_team is the fan role of
+# Team, role-marked from birth (docs/data-model.md §2). Deliberately absent:
+# author (usernames don't serve the receipt) and confidence (a selection
+# input, near-constant once the floor is applied).
+
+COMMENT_SAMPLES_SCHEMA = pl.Schema(
+    {
+        "attributed_player": pl.String,  # FK -> players.parquet
+        "sentiment": pl.String,  # "pos" | "neg" | "neu", as the fact
+        "rank": pl.Int64,  # 1..N within (attributed_player, sentiment)
+        "comment_id": pl.String,  # provenance back to the fact
+        "link_id": pl.String,  # -> Reddit permalink, with comment_id
+        "body": pl.String,  # the receipt, verbatim
+        "score": pl.Int64,
+        "created_utc": pl.Int64,  # epoch seconds, as the fact
+        "fan_team": pl.String,  # nullable: flair may not resolve
     }
 )
 

--- a/pipeline/schemas.py
+++ b/pipeline/schemas.py
@@ -256,14 +256,16 @@ COMMENT_SAMPLES_SCHEMA = pl.Schema(
     }
 )
 
-# Every table the aggregation stage produces -> its schema: the four fact
-# views plus the Player and Team dimensions. Single source for
-# aggregate_sentiment()'s unified validation loop and the script's parquet
-# write loop (<name>.parquet).
+# Every table the aggregation stage produces -> its schema, across the three
+# classes of produced table: the four fact rollups (AGGREGATE_VIEW_SCHEMAS),
+# the Player and Team dimensions, and the comment-samples fact subset.
+# Single source for aggregate_sentiment()'s unified validation loop and the
+# script's parquet write loop (<name>.parquet).
 DASHBOARD_OUTPUT_SCHEMAS: dict[str, pl.Schema] = {
     **AGGREGATE_VIEW_SCHEMAS,
     "players": PLAYERS_SCHEMA,
     "teams": TEAMS_SCHEMA,
+    "comment_samples": COMMENT_SAMPLES_SCHEMA,
 }
 
 

--- a/pipeline/schemas.py
+++ b/pipeline/schemas.py
@@ -231,18 +231,9 @@ TEAMS_SCHEMA = pl.Schema(
 )
 
 # --- Comment samples: fact subset (enforced in pipeline/aggregation.py) ------
-# One row per sampled comment — verbatim rows of the ClassifiedComment fact
-# at its own grain, selected not aggregated: the top-N per player x sentiment
-# by score, under a confidence floor and a body-length cap. Logical PK is
-# (attributed_player, sentiment, rank), rank 1..N within each cell. Not a
-# rollup: there are no measures, so the non-additive guardrail doesn't
-# apply — the one rule is that body is never truncated (it is the receipt;
-# comment_id + link_id give the permalink). fan_team is the fan role of
-# Team, role-marked from birth (docs/data-model.md §2). Deliberately absent:
-# author (usernames don't serve the receipt) and confidence (a selection
-# input: pos/neg rows pass a confidence floor, neu rows are exempt from it
-# - the value is not a per-row quality signal to display).
-
+# One row per sampled comment: verbatim fact rows, top-N per player x
+# sentiment by score (see build_comment_samples). PK (attributed_player,
+# sentiment, rank). body is never truncated. No author, no confidence.
 COMMENT_SAMPLES_SCHEMA = pl.Schema(
     {
         "attributed_player": pl.String,  # FK -> players.parquet
@@ -253,7 +244,7 @@ COMMENT_SAMPLES_SCHEMA = pl.Schema(
         "body": pl.String,  # the receipt, verbatim
         "score": pl.Int64,
         "created_utc": pl.Int64,  # epoch seconds, as the fact
-        "fan_team": pl.String,  # nullable: flair may not resolve
+        "fan_team": pl.String,  # nullable; fan role of Team, role-marked
     }
 )
 

--- a/pipeline/schemas.py
+++ b/pipeline/schemas.py
@@ -240,7 +240,8 @@ TEAMS_SCHEMA = pl.Schema(
 # comment_id + link_id give the permalink). fan_team is the fan role of
 # Team, role-marked from birth (docs/data-model.md §2). Deliberately absent:
 # author (usernames don't serve the receipt) and confidence (a selection
-# input, near-constant once the floor is applied).
+# input: pos/neg rows pass a confidence floor, neu rows are exempt from it
+# - the value is not a per-row quality signal to display).
 
 COMMENT_SAMPLES_SCHEMA = pl.Schema(
     {

--- a/scripts/aggregate_sentiment.py
+++ b/scripts/aggregate_sentiment.py
@@ -4,9 +4,9 @@ Aggregate sentiment data into dashboard-ready outputs.
 Reads classified sentiment parquet, computes player rankings,
 flair segmentation, and temporal trends. Writes the nested
 aggregates.json for the Streamlit dashboard plus one parquet per
-produced table (the four fact views and the players and teams
-dimensions) alongside it for ad-hoc DuckDB queries and the v2
-frontend.
+produced table (the four fact views, the players and teams
+dimensions, and the comment_samples fact subset) alongside it for
+ad-hoc DuckDB queries and the v2 frontend.
 
 Usage:
     uv run python -m scripts.aggregate_sentiment
@@ -153,10 +153,11 @@ def main() -> None:
 
     logger.info(f"Wrote aggregates to {output_path}")
 
-    # Write one parquet per produced table (four views + the players and
-    # teams dimensions). Each dimension carries the config-version stamp
-    # pre-flighted above, so fact<->dimension drift is checkable (same
-    # mechanism as sentiment.parquet's stamp in collect_results).
+    # Write one parquet per produced table (four views, the players and
+    # teams dimensions, comment_samples). Each dimension carries the
+    # config-version stamp pre-flighted above, so fact<->dimension drift
+    # is checkable (same mechanism as sentiment.parquet's stamp in
+    # collect_results); the other outputs carry none.
     for name in DASHBOARD_OUTPUT_SCHEMAS:
         parquet_path = output_path.parent / f"{name}.parquet"
         result[name].write_parquet(parquet_path, metadata=stamps.get(name))

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -12,6 +12,9 @@ import polars as pl
 import pytest
 
 from pipeline.aggregation import (
+    COMMENT_SAMPLES_MAX_BODY_CHARS,
+    COMMENT_SAMPLES_MIN_CONFIDENCE,
+    COMMENT_SAMPLES_TOP_N,
     aggregate_sentiment,
     build_comment_samples,
     build_teams_dimension,
@@ -802,6 +805,48 @@ class TestBuildCommentSamples:
         frame = build_comment_samples(_samples_input(rows))
 
         assert frame["comment_id"].to_list() == ["zz", "aa", "bb"]
+
+    def test_null_score_ranks_last(self):
+        """A null score never wins a cell: nulls sort last, so the true
+        top-upvoted receipt keeps rank 1."""
+        rows = [
+            {
+                "attributed_player": "LeBron James",
+                "sentiment": "neg",
+                "comment_id": "nullscore",
+                "body": "washed",
+                "score": None,
+            },
+            {
+                "attributed_player": "LeBron James",
+                "sentiment": "neg",
+                "comment_id": "real",
+                "body": "cooked",
+                "score": 12,
+            },
+        ]
+        frame = build_comment_samples(_samples_input(rows))
+
+        assert frame["comment_id"].to_list() == ["real", "nullscore"]
+
+    def test_defaults_are_the_named_constants(self):
+        """The kwarg defaults are the importable module constants, so the
+        manifest can import them rather than retype the rule."""
+        rows = [
+            {
+                "attributed_player": "LeBron James",
+                "sentiment": "neg",
+                "comment_id": f"c{k:02d}",
+                "body": f"b{k}",
+                "score": k,
+            }
+            for k in range(COMMENT_SAMPLES_TOP_N + 5, 0, -1)
+        ]
+        frame = build_comment_samples(_samples_input(rows))
+
+        assert frame.height == COMMENT_SAMPLES_TOP_N
+        assert COMMENT_SAMPLES_MIN_CONFIDENCE == 0.9
+        assert COMMENT_SAMPLES_MAX_BODY_CHARS == 500
 
     def test_fan_team_role_marked_and_nullable(self):
         """The fact's team column ships as fan_team; unresolved flair stays null."""

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -13,6 +13,7 @@ import pytest
 
 from pipeline.aggregation import (
     aggregate_sentiment,
+    build_comment_samples,
     build_teams_dimension,
     compute_cumulative_metrics,
     compute_metrics,
@@ -24,6 +25,7 @@ from pipeline.aggregation import (
 )
 from pipeline.schemas import (
     AGGREGATE_VIEW_SCHEMAS,
+    COMMENT_SAMPLES_SCHEMA,
     PLAYERS_SCHEMA,
     ROSTERS_SCHEMA,
     SCHEMA_VERSION,
@@ -534,6 +536,355 @@ class TestAggregateTeams:
         assert result["teams"].height == 30
 
 
+# Input contract of build_comment_samples: the attributed, fan-team-resolved
+# frame aggregate_sentiment() holds. Pinned so an all-null team column
+# can't infer as Null dtype.
+_SAMPLES_INPUT_SCHEMA = pl.Schema(
+    {
+        "attributed_player": pl.String,
+        "sentiment": pl.String,
+        "comment_id": pl.String,
+        "link_id": pl.String,
+        "body": pl.String,
+        "score": pl.Int64,
+        "confidence": pl.Float64,
+        "created_utc": pl.Int64,
+        "team": pl.String,
+    }
+)
+
+
+def _samples_input(rows: list[dict]) -> pl.DataFrame:
+    """Build a build_comment_samples input frame from row dicts, filling
+    the columns a test doesn't care about with stable defaults."""
+    defaults = {
+        "link_id": "t3_post1",
+        "confidence": 0.95,
+        "created_utc": 1704067200,
+        "team": None,
+    }
+    return pl.DataFrame(
+        [{**defaults, **row} for row in rows], schema=_SAMPLES_INPUT_SCHEMA
+    )
+
+
+class TestBuildCommentSamples:
+    """Tests for build_comment_samples (the comment-samples fact subset)."""
+
+    @pytest.fixture
+    def cell_rows(self) -> list[dict]:
+        """Twelve distinct LeBron/neg candidates with scores 12..1, bodies b12..b1
+        (score k has body bk), all above the confidence floor and short."""
+        return [
+            {
+                "attributed_player": "LeBron James",
+                "sentiment": "neg",
+                "comment_id": f"c{k:02d}",
+                "body": f"b{k}",
+                "score": k,
+            }
+            for k in range(12, 0, -1)
+        ]
+
+    def test_conforms_to_schema(self, cell_rows):
+        """The frame matches COMMENT_SAMPLES_SCHEMA exactly."""
+        frame = build_comment_samples(_samples_input(cell_rows))
+
+        assert frame.schema == COMMENT_SAMPLES_SCHEMA
+
+    def test_caps_each_cell_at_n_by_score(self, cell_rows):
+        """A cell keeps its top-n by score; rank follows score order."""
+        frame = build_comment_samples(_samples_input(cell_rows), n=10)
+
+        assert frame.height == 10
+        assert frame["rank"].to_list() == list(range(1, 11))
+        assert frame["score"].to_list() == list(range(12, 2, -1))
+        assert frame["comment_id"][0] == "c12"
+
+    def test_custom_n_honored(self, cell_rows):
+        """n is a keyword parameter, not a baked constant."""
+        frame = build_comment_samples(_samples_input(cell_rows), n=3)
+
+        assert frame["rank"].to_list() == [1, 2, 3]
+
+    def test_thin_cell_not_padded(self):
+        """A cell with fewer than n candidates yields fewer rows, never padding."""
+        rows = [
+            {
+                "attributed_player": "Stephen Curry",
+                "sentiment": "pos",
+                "comment_id": "c1",
+                "body": "splash",
+                "score": 4,
+            },
+            {
+                "attributed_player": "Stephen Curry",
+                "sentiment": "pos",
+                "comment_id": "c2",
+                "body": "greatest shooter",
+                "score": 9,
+            },
+        ]
+        frame = build_comment_samples(_samples_input(rows), n=10)
+
+        assert frame.height == 2
+        assert frame["rank"].to_list() == [1, 2]
+        assert frame["comment_id"].to_list() == ["c2", "c1"]
+
+    def test_confidence_floor_excludes_low_confidence(self):
+        """A high-score row below the floor is not a candidate at all."""
+        rows = [
+            {
+                "attributed_player": "LeBron James",
+                "sentiment": "neg",
+                "comment_id": "viral",
+                "body": "washed",
+                "score": 5000,
+                "confidence": 0.6,
+            },
+            {
+                "attributed_player": "LeBron James",
+                "sentiment": "neg",
+                "comment_id": "solid",
+                "body": "cooked",
+                "score": 10,
+                "confidence": 0.9,
+            },
+        ]
+        frame = build_comment_samples(_samples_input(rows), min_confidence=0.9)
+
+        assert frame["comment_id"].to_list() == ["solid"]
+        assert frame["rank"].to_list() == [1]
+
+    def test_body_length_cap_excludes_long_bodies(self):
+        """A high-score essay over the cap is not a candidate at all."""
+        rows = [
+            {
+                "attributed_player": "LeBron James",
+                "sentiment": "neg",
+                "comment_id": "essay",
+                "body": "x" * 501,
+                "score": 5000,
+            },
+            {
+                "attributed_player": "LeBron James",
+                "sentiment": "neg",
+                "comment_id": "quip",
+                "body": "x" * 500,
+                "score": 10,
+            },
+        ]
+        frame = build_comment_samples(_samples_input(rows), max_body_chars=500)
+
+        assert frame["comment_id"].to_list() == ["quip"]
+
+    def test_bodies_are_verbatim(self):
+        """body is carried untouched — no truncation, no whitespace edits."""
+        body = "  LeBron is  washed\n\nand it's not close  "
+        rows = [
+            {
+                "attributed_player": "LeBron James",
+                "sentiment": "neg",
+                "comment_id": "c1",
+                "body": body,
+                "score": 3,
+            },
+        ]
+        frame = build_comment_samples(_samples_input(rows))
+
+        assert frame["body"][0] == body
+
+    def test_dedup_by_body_keeps_highest_scored(self):
+        """Identical bodies within a cell collapse to the best-ranked copy."""
+        rows = [
+            {
+                "attributed_player": "LeBron James",
+                "sentiment": "neg",
+                "comment_id": "low",
+                "body": "same copypasta",
+                "score": 2,
+            },
+            {
+                "attributed_player": "LeBron James",
+                "sentiment": "neg",
+                "comment_id": "high",
+                "body": "same copypasta",
+                "score": 20,
+            },
+            {
+                "attributed_player": "LeBron James",
+                "sentiment": "neg",
+                "comment_id": "other",
+                "body": "different",
+                "score": 5,
+            },
+        ]
+        frame = build_comment_samples(_samples_input(rows))
+
+        assert frame["comment_id"].to_list() == ["high", "other"]
+        assert frame["rank"].to_list() == [1, 2]
+
+    def test_dedup_is_per_cell(self):
+        """The same body under two players (or sentiments) is not a duplicate."""
+        rows = [
+            {
+                "attributed_player": "LeBron James",
+                "sentiment": "neg",
+                "comment_id": "c1",
+                "body": "overrated",
+                "score": 5,
+            },
+            {
+                "attributed_player": "Kevin Durant",
+                "sentiment": "neg",
+                "comment_id": "c2",
+                "body": "overrated",
+                "score": 5,
+            },
+        ]
+        frame = build_comment_samples(_samples_input(rows))
+
+        assert frame.height == 2
+
+    def test_tiebreak_score_then_confidence_then_comment_id(self):
+        """Equal scores break on confidence desc, then comment_id asc."""
+        rows = [
+            {
+                "attributed_player": "LeBron James",
+                "sentiment": "neg",
+                "comment_id": "zz",
+                "body": "a",
+                "score": 7,
+                "confidence": 0.99,
+            },
+            {
+                "attributed_player": "LeBron James",
+                "sentiment": "neg",
+                "comment_id": "bb",
+                "body": "b",
+                "score": 7,
+                "confidence": 0.95,
+            },
+            {
+                "attributed_player": "LeBron James",
+                "sentiment": "neg",
+                "comment_id": "aa",
+                "body": "c",
+                "score": 7,
+                "confidence": 0.95,
+            },
+        ]
+        frame = build_comment_samples(_samples_input(rows))
+
+        assert frame["comment_id"].to_list() == ["zz", "aa", "bb"]
+
+    def test_fan_team_role_marked_and_nullable(self):
+        """The fact's team column ships as fan_team; unresolved flair stays null."""
+        rows = [
+            {
+                "attributed_player": "LeBron James",
+                "sentiment": "pos",
+                "comment_id": "c1",
+                "body": "goat",
+                "score": 9,
+                "team": "Los Angeles Lakers",
+            },
+            {
+                "attributed_player": "LeBron James",
+                "sentiment": "pos",
+                "comment_id": "c2",
+                "body": "king",
+                "score": 4,
+                "team": None,
+            },
+        ]
+        frame = build_comment_samples(_samples_input(rows))
+
+        assert "team" not in frame.columns
+        assert frame["fan_team"].to_list() == ["Los Angeles Lakers", None]
+
+    def test_all_three_sentiments_sampled(self):
+        """pos, neg, and neu cells are all sampled — balanced by construction."""
+        rows = [
+            {
+                "attributed_player": "LeBron James",
+                "sentiment": s,
+                "comment_id": f"c_{s}",
+                "body": s,
+                "score": 1,
+            }
+            for s in ("pos", "neg", "neu")
+        ]
+        frame = build_comment_samples(_samples_input(rows))
+
+        assert sorted(frame["sentiment"].to_list()) == ["neg", "neu", "pos"]
+
+    def test_sorted_by_player_sentiment_rank(self):
+        """File order is (attributed_player, sentiment, rank), independent
+        of input order and of score across cells."""
+        rows = [
+            {
+                "attributed_player": "Stephen Curry",
+                "sentiment": "pos",
+                "comment_id": "c1",
+                "body": "a",
+                "score": 100,
+            },
+            {
+                "attributed_player": "LeBron James",
+                "sentiment": "pos",
+                "comment_id": "c2",
+                "body": "b",
+                "score": 1,
+            },
+            {
+                "attributed_player": "LeBron James",
+                "sentiment": "neg",
+                "comment_id": "c3",
+                "body": "c",
+                "score": 50,
+            },
+            {
+                "attributed_player": "LeBron James",
+                "sentiment": "neg",
+                "comment_id": "c4",
+                "body": "d",
+                "score": 60,
+            },
+        ]
+        frame = build_comment_samples(_samples_input(rows))
+
+        assert frame.select("attributed_player", "sentiment", "rank").rows() == [
+            ("LeBron James", "neg", 1),
+            ("LeBron James", "neg", 2),
+            ("LeBron James", "pos", 1),
+            ("Stephen Curry", "pos", 1),
+        ]
+        assert frame["comment_id"].to_list() == ["c4", "c3", "c2", "c1"]
+
+    def test_empty_input_returns_conforming_empty_frame(self):
+        """No candidates (empty input, or everything gated out) still yields
+        a schema-conforming frame — the unified validation loop runs on it."""
+        empty = build_comment_samples(_samples_input([]))
+        gated = build_comment_samples(
+            _samples_input(
+                [
+                    {
+                        "attributed_player": "LeBron James",
+                        "sentiment": "neg",
+                        "comment_id": "c1",
+                        "body": "x",
+                        "score": 1,
+                        "confidence": 0.1,
+                    },
+                ]
+            )
+        )
+
+        assert empty.height == 0 and empty.schema == COMMENT_SAMPLES_SCHEMA
+        assert gated.height == 0 and gated.schema == COMMENT_SAMPLES_SCHEMA
+
+
 class TestPlayersToMetadataDict:
     """Tests for players_to_metadata_dict (frame -> legacy aggregates.json dict).
 
@@ -891,6 +1242,29 @@ class TestAggregateViews:
         result = aggregate_sentiment(views_parquet)
 
         assert result[view_name].schema == schema
+
+    def test_comment_samples_conforms_to_schema(self, views_parquet):
+        """comment_samples is returned as a frame matching its contract —
+        a dedicated check, since the parametrized one above iterates the
+        rollup registry only."""
+        result = aggregate_sentiment(views_parquet)
+
+        assert isinstance(result["comment_samples"], pl.DataFrame)
+        assert result["comment_samples"].schema == COMMENT_SAMPLES_SCHEMA
+
+    def test_comment_samples_selects_from_attributed_frame(self, views_parquet):
+        """Samples come from the attributed, flair-resolved rows: LeBron's
+        pos rank-1 is c5 with its Lakers fan_team; c4 (0.85) is gated out."""
+        result = aggregate_sentiment(views_parquet)
+        samples = result["comment_samples"]
+
+        lebron = samples.filter(pl.col("attributed_player") == "LeBron James")
+        assert lebron.select("sentiment", "rank", "comment_id").rows() == [
+            ("pos", 1, "c5"),
+        ]
+        assert lebron["body"][0] == "LeBron is the GOAT"
+        assert lebron["fan_team"][0] == "Los Angeles Lakers"
+        assert "c4" not in samples["comment_id"].to_list()
 
     def test_player_overall_sorted_by_neg_rate_desc_then_player_asc(
         self, views_parquet

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -12,9 +12,6 @@ import polars as pl
 import pytest
 
 from pipeline.aggregation import (
-    COMMENT_SAMPLES_MAX_BODY_CHARS,
-    COMMENT_SAMPLES_MIN_CONFIDENCE,
-    COMMENT_SAMPLES_TOP_N,
     aggregate_sentiment,
     build_comment_samples,
     build_teams_dimension,
@@ -34,6 +31,11 @@ from pipeline.schemas import (
     SCHEMA_VERSION,
     SENTIMENT_SCHEMA,
     TEAMS_SCHEMA,
+)
+from utils.constants import (
+    COMMENT_SAMPLES_MAX_BODY_CHARS,
+    COMMENT_SAMPLES_MIN_CONFIDENCE,
+    COMMENT_SAMPLES_TOP_N,
 )
 from utils.player_config import load_player_config_version, load_player_metadata
 from utils.season_config import get_active_season

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -656,6 +656,31 @@ class TestBuildCommentSamples:
         assert frame["comment_id"].to_list() == ["solid"]
         assert frame["rank"].to_list() == [1]
 
+    def test_confidence_floor_exempts_neutral(self):
+        """The floor guards the polar labels only: a neu row at the
+        classifier's conventional 0.5 is still a candidate."""
+        rows = [
+            {
+                "attributed_player": "LeBron James",
+                "sentiment": "neu",
+                "comment_id": "neutral",
+                "body": "LeBron had 28 tonight",
+                "score": 40,
+                "confidence": 0.5,
+            },
+            {
+                "attributed_player": "LeBron James",
+                "sentiment": "pos",
+                "comment_id": "hedged",
+                "body": "decent game I guess",
+                "score": 40,
+                "confidence": 0.5,
+            },
+        ]
+        frame = build_comment_samples(_samples_input(rows), min_confidence=0.9)
+
+        assert frame["comment_id"].to_list() == ["neutral"]
+
     def test_body_length_cap_excludes_long_bodies(self):
         """A high-score essay over the cap is not a candidate at all."""
         rows = [

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -80,10 +80,12 @@ class TestPlayersContract:
             assert PLAYERS_SCHEMA[col] == ROSTERS_SCHEMA[col]
 
     def test_dashboard_outputs_superset(self):
-        """Verify the output mapping is views + the dimensions, and views stay fact-only."""
+        """Verify the output mapping is the rollups + the dimensions + the
+        comment-samples fact subset, and the rollup mapping stays rollup-only."""
         assert set(DASHBOARD_OUTPUT_SCHEMAS) == set(AGGREGATE_VIEW_SCHEMAS) | {
             "players",
             "teams",
+            "comment_samples",
         }
         assert DASHBOARD_OUTPUT_SCHEMAS["players"] is PLAYERS_SCHEMA
         assert "players" not in AGGREGATE_VIEW_SCHEMAS
@@ -146,6 +148,13 @@ class TestCommentSamplesContract:
         """Verify decided-out columns stay out (author, confidence)."""
         for col in ("author", "confidence"):
             assert col not in COMMENT_SAMPLES_SCHEMA.names()
+
+    def test_joins_outputs_but_not_views(self):
+        """Verify comment_samples ships via DASHBOARD_OUTPUT_SCHEMAS only — a
+        fact subset (no measures), not a rollup; the rollup mapping stays
+        rollup-only."""
+        assert DASHBOARD_OUTPUT_SCHEMAS["comment_samples"] is COMMENT_SAMPLES_SCHEMA
+        assert "comment_samples" not in AGGREGATE_VIEW_SCHEMAS
 
     def test_fact_side_dtypes_derive_from_sentiment(self):
         """Verify every column carried verbatim from the fact keeps the

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -6,6 +6,7 @@ import pytest
 from pipeline.schemas import (
     AGGREGATE_VIEW_SCHEMAS,
     COMMENT_INPUT_SCHEMA,
+    COMMENT_SAMPLES_SCHEMA,
     DASHBOARD_OUTPUT_SCHEMAS,
     PLAYERS_SCHEMA,
     PLAYERS_SNAPSHOT_COLUMNS,
@@ -114,6 +115,43 @@ class TestTeamsContract:
         dimension, not a fact rollup; the views mapping stays fact-only."""
         assert DASHBOARD_OUTPUT_SCHEMAS["teams"] is TEAMS_SCHEMA
         assert "teams" not in AGGREGATE_VIEW_SCHEMAS
+
+
+class TestCommentSamplesContract:
+    """Contract guards for the comment-samples fact subset (comment_samples.parquet)."""
+
+    def test_pins_column_set_and_dtypes(self):
+        """Verify the decided column set with pinned dtypes, in order."""
+        assert COMMENT_SAMPLES_SCHEMA == pl.Schema(
+            {
+                "attributed_player": pl.String,
+                "sentiment": pl.String,
+                "rank": pl.Int64,
+                "comment_id": pl.String,
+                "link_id": pl.String,
+                "body": pl.String,
+                "score": pl.Int64,
+                "created_utc": pl.Int64,
+                "fan_team": pl.String,
+            }
+        )
+
+    def test_fan_team_is_role_marked(self):
+        """Verify the fan-role Team FK is role-marked from birth — no
+        unmarked `team` column on a new produced file."""
+        assert "fan_team" in COMMENT_SAMPLES_SCHEMA.names()
+        assert "team" not in COMMENT_SAMPLES_SCHEMA.names()
+
+    def test_excludes_rejected_columns(self):
+        """Verify decided-out columns stay out (author, confidence)."""
+        for col in ("author", "confidence"):
+            assert col not in COMMENT_SAMPLES_SCHEMA.names()
+
+    def test_fact_side_dtypes_derive_from_sentiment(self):
+        """Verify every column carried verbatim from the fact keeps the
+        fact's dtype (no drift between the subset and its source)."""
+        for col in ("comment_id", "link_id", "body", "score", "created_utc"):
+            assert COMMENT_SAMPLES_SCHEMA[col] == SENTIMENT_SCHEMA[col]
 
 
 class TestRostersContract:

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -107,14 +107,11 @@ NBA_STATS_RETRY_BACKOFF = 2.0
 # =============================================================================
 # AGGREGATION - comment_samples selection (pipeline/aggregation.py)
 # =============================================================================
-# The keyword defaults of build_comment_samples(), named so the manifest can
-# import rather than retype the rule. Finalized on 2025-26 data: every
-# qualified player's cells fill at n=10; the cap removes ~2% of the candidate
-# pool; the floor keeps the classifier's top two confidence buckets on the
-# polar labels (pos/neg only - neu sits at a conventional 0.5 and is exempt).
+# Keyword defaults of build_comment_samples(); named so the manifest can
+# import them. Finalized on 2025-26 data (#84).
 
 COMMENT_SAMPLES_TOP_N = 10
-COMMENT_SAMPLES_MIN_CONFIDENCE = 0.9
+COMMENT_SAMPLES_MIN_CONFIDENCE = 0.9  # pos/neg only; neu is exempt
 COMMENT_SAMPLES_MAX_BODY_CHARS = 500
 
 # =============================================================================

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -105,6 +105,19 @@ NBA_STATS_RETRY_BACKOFF = 2.0
 
 
 # =============================================================================
+# AGGREGATION - comment_samples selection (pipeline/aggregation.py)
+# =============================================================================
+# The keyword defaults of build_comment_samples(), named so the manifest can
+# import rather than retype the rule. Finalized on 2025-26 data: every
+# qualified player's cells fill at n=10; the cap removes ~2% of the candidate
+# pool; the floor keeps the classifier's top two confidence buckets on the
+# polar labels (pos/neg only - neu sits at a conventional 0.5 and is exempt).
+
+COMMENT_SAMPLES_TOP_N = 10
+COMMENT_SAMPLES_MIN_CONFIDENCE = 0.9
+COMMENT_SAMPLES_MAX_BODY_CHARS = 500
+
+# =============================================================================
 # FILE PATHS (relative subdirectories - root comes from environment)
 # =============================================================================
 


### PR DESCRIPTION
Closes #84.

## What

`comment_samples.parquet` — the receipts. A **fact subset**: verbatim rows of `ClassifiedComment` at its own grain, selected not aggregated. For every attributed player × sentiment, the top-10 comments by score among candidates, dedup'd by body, with the commenter's `fan_team`.

- **`COMMENT_SAMPLES_SCHEMA`** (`pipeline/schemas.py`): `attributed_player, sentiment, rank, comment_id, link_id, body, score, created_utc, fan_team`. Logical PK `(attributed_player, sentiment, rank)`. No `author` (usernames don't serve the receipt; `comment_id` + `link_id` give the permalink), no `confidence` (a selection input, near-constant once the floor applies). `fan_team` is role-marked from birth.
- **Registered directly in `DASHBOARD_OUTPUT_SCHEMAS`**, not `AGGREGATE_VIEW_SCHEMAS` — that mapping is the rollup registry (group cols + metric columns) and a subset has no measures. The registry comment now names the three produced-table classes; the parametrized rollup-conformance test doesn't cover the subset, so it has a dedicated one.
- **`build_comment_samples(df, *, n=10, min_confidence=0.9, max_body_chars=500)`** (`pipeline/aggregation.py`): pure, deterministic; the defaults are the named constants `COMMENT_SAMPLES_TOP_N` / `_MIN_CONFIDENCE` / `_MAX_BODY_CHARS` in `utils/constants.py`. Candidacy = body ≤ 500 chars and, for pos/neg, confidence ≥ 0.9; exact-duplicate bodies collapse per cell to the best-ranked copy; rank by `score desc, confidence desc, comment_id asc` (nulls last); top-n per cell, thin cells never padded; file sorted `(attributed_player, sentiment, rank)`. Bodies verbatim, never truncated.
- **Script unchanged** — the `DASHBOARD_OUTPUT_SCHEMAS` write loop picks it up; the `LEGACY_JSON_VIEWS` allowlist keeps it out of `aggregates.json`. No config stamp (stamp policy for fact-derived outputs → manifest ticket's registry). No `SCHEMA_VERSION` bump (additive).
- **Diagnostics logged per run:** candidate-pool share removed by each gate, rows selected, multi-mention share.
- **`docs/data-model.md`:** the produced tables are now stated as three classes (rollups / dimensions / fact subset) at the at-a-glance line and the §4 opener; §4 lineage row (cheap "receipts" vs. still-expensive "every comment"); guardrail note; §2 column-map entry. The subset is not an entity — no diagram change.

## Parameters — finalized on real data (2025-26)

| Gate | Start | Final | Evidence |
|---|---|---|---|
| `n` | 10 | **10** | every qualified player (67) has full pos/neg/neu cells |
| `max_body_chars` | 500 | **500** | removes 1.7% of the candidate pool; corpus body p90 = 348 |
| `min_confidence` | 0.9, uniform | **0.9 on pos/neg only** | confidence is effectively discrete (0.5 / 0.7–0.8 / 0.85 / 0.9 / 0.95); `neu` sits at a conventional 0.5 (p25 = p50 = p75), so a uniform floor starved neutral (13/65 qualified cells) while doing exactly its job on the polar labels. Candidacy became `neu OR confidence >= 0.9` (commit `c2eea71`). |

**Multi-mention verdict: keep, no single-mention filter.** 773/6,176 sampled rows (12.5%) are multi-mention; the 25 rank-1 multi-mention receipts eyeballed all named the classifier's stated target. The `mentioned_players.list.len() == 1` predicate stays a documented fallback, not applied.

For the manifest ticket to record: `comment_samples: {n: 10, min_confidence: 0.9 (pos/neg), max_body_chars: 500}`.

## Verification (2025-26, `uv run python -m scripts.aggregate_sentiment`)

- 6,176 rows, **407 KB** (tier-1 budget ≪ 1 MB) — 223 players × 3 sentiments; 2,065 neg / 2,230 neu / 1,881 pos.
- FK completeness: 0 `attributed_player` misses vs `players.parquet`; 0 non-null `fan_team` misses vs `teams.parquet ON fan_team = team`.
- `max(rank) = 10`, every cell contiguous 1..k, `max(len(body)) = 500`, 0 duplicate bodies per cell.
- Sanity: Harden neg #1 (944 ↑, Warriors fan) — *"…one of the biggest playoff droppers I've ever seen."*
- **Every other output unchanged:** all six existing parquets byte-identical to the pre-run copies; `aggregates.json` identical modulo `generated_at`, key set `metadata, player_metadata, player_overall, player_team, player_temporal, team_overall`.
- 2024-25: not produced here — rides the backfill/republish event (needs the fact; no config-only shortcut).
- `uv run pytest tests/unit tests/integration` (474 passed), `uv run ruff check .` clean; every commit passed the pre-commit gate alone.

## Branch review

`/code-review high` on the branch: 10 findings, 9 applied in `fix(pipeline): harden comment_samples selection per branch review` (nulls-last sort + test, named parameter constants, semi-join diagnostics, per-gate log shares, empirical basis for the neu exemption, schema-note reword, data-model antecedent fix, dead cast dropped, commit subjects ≤ 72 chars) plus the dated amendment on #84. Partially applied: the suggestion to add per-label confidence logging / a `"neu"` constant — the sentiment literals are used as-is throughout the pipeline; the docstring now states the exemption's empirical basis.

## Noted for follow-up (out of scope, seeded in spec §7 item 3)

Score-ranking selects for viral *incident* comments (the player fouled / traded / compared), where sentiment-of-comment and sentiment-toward-player diverge more often than in the corpus at large — visible in some rank-1 receipts. The file faithfully reflects the classifier's labels; a receipts-quality gate (e.g. a second-pass check over the sampled rows only) is a separate feature before receipts go public. Two alias false positives surfaced for the watchlist (`rudy` ← "Rudy Giuliani"; a Paul George alias ← "George Floyd").
