### PR TITLE
feat(config): per-season season.yaml — pointer split + calendar/corpus season facts (#52)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -11,7 +11,7 @@
 scripts/          → CLI entry points (download, filter, batch, aggregate)
 pipeline/         → Data processing (ArcticShiftClient, batch, aggregation)
 utils/            → Stateless helpers (constants, formatting, paths, player_config, team_config)
-config/           → YAML configs (2024-25/players.yaml, teams.yaml; season.yaml planned)
+config/           → YAML configs (season.yaml pointers; <season>/players.yaml + season.yaml facts; teams.yaml)
 app/              → Streamlit dashboard
 tests/            → pytest (unit/, conftest.py)
 notebooks/        → EDA and exploration, season-scoped (2024-25/, 2025-26/)

--- a/config/2024-25/season.yaml
+++ b/config/2024-25/season.yaml
@@ -1,23 +1,16 @@
-# Season facts — 2024-25 (v1 season)
+# Season facts — 2024-25 (v1 season). Values fill when knowable (season
+# flip: dates; bracket resolution: finals_start/finals_end; gate PASS:
+# corpus) and are never revised once set — unknown means null, not a guess.
+# version: MAJOR = key-set change, MINOR = value fill.
 #
-# version: MAJOR = key-set change, MINOR = value fill. Values fill when they
-# become knowable (season flip: preseason-published dates; bracket
-# resolution: finals_start/finals_end; gate PASS: corpus) and are never
-# revised once set — an unknown value is null, not a guess.
+# start_date/end_date are the operational download window, not the league
+# season — league dates live in `calendar`.
 #
-# start_date/end_date are the OPERATIONAL DOWNLOAD WINDOW, not the league
-# season: the corpus brackets the season (preseason and post-Finals
-# discourse are in it), it isn't the season. League dates live in
-# `calendar`, so the two vocabularies can't be confused.
-#
-# calendar admission test — a key belongs here only if the event is
-#   recurring (exists every season), crisp (one league-published date,
-#   fillable with zero judgment), and consumable (a consumer can distinguish
-#   on it as a phase boundary or annotation). One-off storylines are
-#   editorial and stay out. `all_star` is the All-Star Game date (the
-#   Sunday), not the weekend's start.
-# corpus — gate-time facts no shipped table can derive (the aggregate stage
-#   never sees raw). Recorded once from the corpus-baseline notebook.
+# calendar admission test: recurring (exists every season), crisp (one
+# league-published date, zero judgment), consumable (a phase boundary or
+# annotation). One-off storylines stay out. `all_star` is the All-Star
+# Game date (the Sunday), not the weekend's start.
+# corpus: gate-time facts no shipped table can derive.
 
 version: "1.0"
 season: "2024-25"

--- a/config/2024-25/season.yaml
+++ b/config/2024-25/season.yaml
@@ -1,0 +1,42 @@
+# Season facts — 2024-25 (v1 season)
+#
+# version: MAJOR = key-set change, MINOR = value fill. Values fill when they
+# become knowable (season flip: preseason-published dates; bracket
+# resolution: finals_start/finals_end; gate PASS: corpus) and are never
+# revised once set — an unknown value is null, not a guess.
+#
+# start_date/end_date are the OPERATIONAL DOWNLOAD WINDOW, not the league
+# season: the corpus brackets the season (preseason and post-Finals
+# discourse are in it), it isn't the season. League dates live in
+# `calendar`, so the two vocabularies can't be confused.
+#
+# calendar admission test — a key belongs here only if the event is
+#   recurring (exists every season), crisp (one league-published date,
+#   fillable with zero judgment), and consumable (a consumer can distinguish
+#   on it as a phase boundary or annotation). One-off storylines are
+#   editorial and stay out. `all_star` is the All-Star Game date (the
+#   Sunday), not the weekend's start.
+# corpus — gate-time facts no shipped table can derive (the aggregate stage
+#   never sees raw). Recorded once from the corpus-baseline notebook.
+
+version: "1.0"
+season: "2024-25"
+
+start_date: "2024-10-01"
+end_date: "2025-06-30"
+subreddits:
+  - nba
+
+calendar:
+  opening_night: "2024-10-22"
+  nba_cup_final: "2024-12-17"
+  christmas: "2024-12-25"
+  trade_deadline: "2025-02-06"
+  all_star: "2025-02-16"
+  play_in_start: "2025-04-15"
+  playoffs_start: "2025-04-19"
+  finals_start: "2025-06-05"
+  finals_end: "2025-06-22"
+
+corpus:
+  raw_comments: 7041235

--- a/config/2025-26/season.yaml
+++ b/config/2025-26/season.yaml
@@ -1,0 +1,42 @@
+# Season facts — 2025-26 (v2 season)
+#
+# version: MAJOR = key-set change, MINOR = value fill. Values fill when they
+# become knowable (season flip: preseason-published dates; bracket
+# resolution: finals_start/finals_end; gate PASS: corpus) and are never
+# revised once set — an unknown value is null, not a guess.
+#
+# start_date/end_date are the OPERATIONAL DOWNLOAD WINDOW, not the league
+# season: the corpus brackets the season (preseason and post-Finals
+# discourse are in it), it isn't the season. League dates live in
+# `calendar`, so the two vocabularies can't be confused.
+#
+# calendar admission test — a key belongs here only if the event is
+#   recurring (exists every season), crisp (one league-published date,
+#   fillable with zero judgment), and consumable (a consumer can distinguish
+#   on it as a phase boundary or annotation). One-off storylines are
+#   editorial and stay out. `all_star` is the All-Star Game date (the
+#   Sunday), not the weekend's start.
+# corpus — gate-time facts no shipped table can derive (the aggregate stage
+#   never sees raw). Recorded once from the corpus-baseline notebook.
+
+version: "1.0"
+season: "2025-26"
+
+start_date: "2025-10-01"
+end_date: "2026-06-30"
+subreddits:
+  - nba
+
+calendar:
+  opening_night: "2025-10-21"
+  nba_cup_final: "2025-12-16"
+  christmas: "2025-12-25"
+  trade_deadline: "2026-02-05"
+  all_star: "2026-02-15"
+  play_in_start: "2026-04-14"
+  playoffs_start: "2026-04-18"
+  finals_start: "2026-06-03"
+  finals_end: "2026-06-13"
+
+corpus:
+  raw_comments: 7283478

--- a/config/2025-26/season.yaml
+++ b/config/2025-26/season.yaml
@@ -1,23 +1,16 @@
-# Season facts — 2025-26 (v2 season)
+# Season facts — 2025-26 (v2 season). Values fill when knowable (season
+# flip: dates; bracket resolution: finals_start/finals_end; gate PASS:
+# corpus) and are never revised once set — unknown means null, not a guess.
+# version: MAJOR = key-set change, MINOR = value fill.
 #
-# version: MAJOR = key-set change, MINOR = value fill. Values fill when they
-# become knowable (season flip: preseason-published dates; bracket
-# resolution: finals_start/finals_end; gate PASS: corpus) and are never
-# revised once set — an unknown value is null, not a guess.
+# start_date/end_date are the operational download window, not the league
+# season — league dates live in `calendar`.
 #
-# start_date/end_date are the OPERATIONAL DOWNLOAD WINDOW, not the league
-# season: the corpus brackets the season (preseason and post-Finals
-# discourse are in it), it isn't the season. League dates live in
-# `calendar`, so the two vocabularies can't be confused.
-#
-# calendar admission test — a key belongs here only if the event is
-#   recurring (exists every season), crisp (one league-published date,
-#   fillable with zero judgment), and consumable (a consumer can distinguish
-#   on it as a phase boundary or annotation). One-off storylines are
-#   editorial and stay out. `all_star` is the All-Star Game date (the
-#   Sunday), not the weekend's start.
-# corpus — gate-time facts no shipped table can derive (the aggregate stage
-#   never sees raw). Recorded once from the corpus-baseline notebook.
+# calendar admission test: recurring (exists every season), crisp (one
+# league-published date, zero judgment), consumable (a phase boundary or
+# annotation). One-off storylines stay out. `all_star` is the All-Star
+# Game date (the Sunday), not the weekend's start.
+# corpus: gate-time facts no shipped table can derive.
 
 version: "1.0"
 season: "2025-26"

--- a/config/season.yaml
+++ b/config/season.yaml
@@ -1,9 +1,13 @@
+# Season pointers — which season the code operates on. Nothing else lives
+# here: a season's facts (download window, subreddits, league calendar,
+# corpus figures) are in config/<season>/season.yaml, so moving a pointer
+# never overwrites another season's record.
+
+# The pipeline's operational pointer: data paths, players.yaml, and the
+# per-season facts file all resolve through it (or the --season override).
 season: "2025-26"
-# What the deployed dashboard serves — decoupled from `season` (the pipeline's
-# operational pointer) so a season flip for pipeline work cannot take the
-# public app down. Flipping this line IS the v2 dashboard launch.
+
+# What the deployed dashboard serves — decoupled from `season` so a season
+# flip for pipeline work cannot take the public app down. Flipping this
+# line IS the v2 dashboard launch.
 published_season: "2024-25"
-start_date: "2025-10-01"
-end_date: "2026-06-30"
-subreddits:
-  - nba

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -551,7 +551,7 @@ def season_override() -> Generator[Callable[[str], None], None, None]:
     Set a process-level season override with cold caches; restores after.
 
     Yields a callable — season_override("2024-25") — that clears the
-    season-derived player-config caches (the override's warm-cache guard
+    season-derived config caches (the override's warm-cache guard
     would otherwise trip on caches populated by earlier tests) and sets
     the override. Teardown clears both the override and the caches so
     later tests see the on-disk active season again.
@@ -563,10 +563,15 @@ def season_override() -> Generator[Callable[[str], None], None, None]:
         load_player_config_version,
         load_player_metadata,
     )
-    from utils.season_config import clear_season_override, set_season_override
+    from utils.season_config import (
+        clear_season_override,
+        load_season_config,
+        set_season_override,
+    )
 
     def _clear_caches() -> None:
         for fn in (
+            load_season_config,
             load_player_config,
             build_alias_to_player_map,
             load_player_metadata,

--- a/tests/unit/test_config_version.py
+++ b/tests/unit/test_config_version.py
@@ -1,0 +1,45 @@
+"""
+Tests for the shared quoted-version-string validator.
+
+require_version_string() backs every config loader that stamps lineage
+(players.yaml, teams.yaml, season.yaml); its contract is pinned once
+here so the per-loader tests only need to check wiring.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from utils.config_version import require_version_string
+
+
+class TestRequireVersionString:
+    """Tests for require_version_string function."""
+
+    def test_returns_quoted_string(self):
+        """A quoted version passes through unchanged."""
+        assert (
+            require_version_string({"version": "4.10"}, Path("x.yaml"), "x.yaml")
+            == "4.10"
+        )
+
+    def test_missing_version_raises_with_label_and_path(self):
+        """A config with no version key names the file and its path."""
+        with pytest.raises(
+            ValueError, match=r"players\.yaml.*'version' key.*cfg/players\.yaml"
+        ):
+            require_version_string({}, Path("cfg/players.yaml"), "players.yaml")
+
+    def test_unquoted_version_raises(self):
+        """A YAML float version (trailing zero lost) is rejected.
+
+        4.10 unquoted parses as the float 4.1 and would silently
+        mis-stamp lineage; the message names the offending type.
+        """
+        with pytest.raises(ValueError, match=r"quoted string.*4\.1.*float"):
+            require_version_string({"version": 4.1}, Path("teams.yaml"), "teams.yaml")
+
+    def test_none_config_raises(self):
+        """An empty YAML document (parsed as None) reads as no version key."""
+        with pytest.raises(ValueError, match="'version' key"):
+            require_version_string(None, Path("empty.yaml"), "empty.yaml")

--- a/tests/unit/test_season_config.py
+++ b/tests/unit/test_season_config.py
@@ -1,13 +1,16 @@
 """
 Tests for season configuration loading.
 
-Tests cover loading from YAML, required key validation, convenience
-accessors, and caching behavior.
+Tests cover the pointer file, the per-season facts file (window,
+subreddits, calendar and corpus blocks, version), the --season override
+reaching every season-derived layer, and caching behavior.
 """
 
 import re
+from types import MappingProxyType
 
 import pytest
+import yaml
 
 import pipeline.processors
 from utils.paths import get_data_dir
@@ -18,21 +21,38 @@ from utils.player_config import (
     load_player_metadata,
 )
 from utils.season_config import (
+    CALENDAR_KEYS,
+    CORPUS_KEYS,
     clear_season_override,
     get_active_season,
     load_season_config,
+    load_season_config_version,
+    load_season_pointer,
     set_season_override,
 )
 
 
-def _clear_player_caches() -> None:
-    """Clear the season-derived player-config caches.
+# A well-formed per-season facts document for the tmp-file tests.
+VALID_FACTS = {
+    "version": "1.0",
+    "season": "2024-25",
+    "start_date": "2024-10-01",
+    "end_date": "2025-06-30",
+    "subreddits": ["nba"],
+    "calendar": {key: None for key in CALENDAR_KEYS},
+    "corpus": {key: None for key in CORPUS_KEYS},
+}
+
+
+def _clear_season_caches() -> None:
+    """Clear the season-derived config caches.
 
     Also resets the compiled-pattern global in pipeline.processors:
     cache_clear() bypasses the override's warm-cache guard, which
     normally subsumes that global via load_player_config().
     """
     for fn in (
+        load_season_config,
         load_player_config,
         build_alias_to_player_map,
         load_player_metadata,
@@ -42,8 +62,84 @@ def _clear_player_caches() -> None:
     pipeline.processors._player_patterns = None
 
 
+@pytest.fixture
+def facts_file(tmp_path, monkeypatch):
+    """Point the facts loader at a tmp season dir; yields a writer.
+
+    The writer takes a dict (or raw YAML text), writes it as
+    config/<season>/season.yaml under tmp_path, and clears the facts
+    cache so the next load_season_config() reads it. The pointer file
+    is untouched, so the active season is the real one.
+    """
+    monkeypatch.setattr("utils.season_config.CONFIG_DIR", tmp_path)
+    load_season_config.cache_clear()
+
+    def _write(doc: dict | str, season: str | None = None) -> None:
+        season = season or get_active_season()
+        target = tmp_path / season / "season.yaml"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        text = doc if isinstance(doc, str) else yaml.safe_dump(doc)
+        target.write_text(text)
+        load_season_config.cache_clear()
+
+    yield _write
+    load_season_config.cache_clear()
+
+
+class TestLoadSeasonPointer:
+    """Tests for load_season_pointer function (config/season.yaml)."""
+
+    @pytest.fixture
+    def pointer_file(self, tmp_path, monkeypatch):
+        """Point the pointer loader at a tmp file; yields a writer."""
+        path = tmp_path / "season.yaml"
+        monkeypatch.setattr("utils.season_config.POINTER_PATH", path)
+        load_season_pointer.cache_clear()
+
+        def _write(text: str) -> None:
+            path.write_text(text)
+            load_season_pointer.cache_clear()
+
+        yield _write
+        load_season_pointer.cache_clear()
+
+    def test_has_both_pointers(self):
+        """The real pointer file carries the operational and published seasons."""
+        pointers = load_season_pointer()
+        assert set(pointers) == {"season", "published_season"}
+        assert re.fullmatch(r"\d{4}-\d{2}", pointers["season"])
+        assert re.fullmatch(r"\d{4}-\d{2}", pointers["published_season"])
+
+    def test_pointer_file_carries_no_facts(self):
+        """The pointer file is pointers only: no per-season facts leak back in."""
+        with open("config/season.yaml") as f:
+            raw = yaml.safe_load(f)
+        assert set(raw) == {"season", "published_season"}
+
+    def test_published_season_optional(self, pointer_file):
+        """A pointer file without published_season loads with None."""
+        pointer_file('season: "2025-26"\n')
+        assert load_season_pointer()["published_season"] is None
+
+    def test_missing_season_raises(self, pointer_file):
+        """A pointer file without `season` fails loud."""
+        pointer_file('published_season: "2024-25"\n')
+        with pytest.raises(ValueError, match="'season'"):
+            load_season_pointer()
+
+    def test_malformed_pointer_raises(self, pointer_file):
+        """A non-YYYY-YY pointer is rejected."""
+        pointer_file('season: "2025"\n')
+        with pytest.raises(ValueError, match="YYYY-YY"):
+            load_season_pointer()
+
+    def test_caching_returns_same_object(self):
+        """Multiple calls return the same cached object."""
+        assert load_season_pointer() is load_season_pointer()
+
+
 class TestLoadSeasonConfig:
-    """Tests for load_season_config function."""
+    """Tests for load_season_config function (config/<season>/season.yaml)."""
 
     def test_returns_dict(self):
         """Config loader returns a dict."""
@@ -51,12 +147,18 @@ class TestLoadSeasonConfig:
         assert isinstance(config, dict)
 
     def test_has_required_keys(self):
-        """Config contains all required keys."""
+        """Config contains the original contract keys plus the new blocks."""
         config = load_season_config()
-        assert "season" in config
-        assert "start_date" in config
-        assert "end_date" in config
-        assert "subreddits" in config
+        for key in (
+            "season",
+            "start_date",
+            "end_date",
+            "subreddits",
+            "version",
+            "calendar",
+            "corpus",
+        ):
+            assert key in config
 
     def test_season_is_string(self):
         """Season identifier is a string."""
@@ -95,11 +197,162 @@ class TestLoadSeasonConfig:
         assert config["end_date"].startswith(str(start_year + 1))
         assert "nba" in config["subreddits"]
 
+    def test_calendar_block_shape(self):
+        """calendar is a read-only mapping over exactly CALENDAR_KEYS.
+
+        Values are ISO date strings or None (unknown-until-knowable);
+        no other type reaches callers.
+        """
+        calendar = load_season_config()["calendar"]
+        assert isinstance(calendar, MappingProxyType)
+        assert tuple(calendar) == CALENDAR_KEYS
+        for value in calendar.values():
+            assert value is None or re.fullmatch(r"\d{4}-\d{2}-\d{2}", value)
+
+    def test_calendar_dates_fall_inside_window(self):
+        """Every filled calendar date sits inside the download window.
+
+        The window brackets the season; a calendar date outside it would
+        mean either a typo or a window that doesn't cover the season.
+        """
+        config = load_season_config()
+        for key, value in config["calendar"].items():
+            if value is not None:
+                assert config["start_date"] <= value <= config["end_date"], key
+
+    def test_calendar_phase_boundaries_ordered(self):
+        """The phase-boundary keys are chronological when all are filled."""
+        calendar = load_season_config()["calendar"]
+        boundaries = [
+            calendar[k]
+            for k in (
+                "opening_night",
+                "play_in_start",
+                "playoffs_start",
+                "finals_start",
+                "finals_end",
+            )
+        ]
+        if all(boundaries):
+            assert boundaries == sorted(boundaries)
+
+    def test_corpus_block_shape(self):
+        """corpus is a read-only mapping over exactly CORPUS_KEYS, ints or None."""
+        corpus = load_season_config()["corpus"]
+        assert isinstance(corpus, MappingProxyType)
+        assert tuple(corpus) == CORPUS_KEYS
+        for value in corpus.values():
+            assert value is None or isinstance(value, int)
+
+    def test_version_is_quoted_string(self):
+        """version is a MAJOR.MINOR string, exposed by both accessors."""
+        version = load_season_config()["version"]
+        assert re.fullmatch(r"\d+\.\d+", version)
+        assert load_season_config_version() == version
+
     def test_caching_returns_same_object(self):
         """Multiple calls return the same cached object."""
         result1 = load_season_config()
         result2 = load_season_config()
         assert result1 is result2
+
+
+class TestLoadSeasonConfigValidation:
+    """Loader rejects malformed per-season facts files."""
+
+    def test_missing_required_key_raises(self, facts_file):
+        """A facts file without the original contract keys fails loud."""
+        doc = {k: v for k, v in VALID_FACTS.items() if k != "start_date"}
+        doc["season"] = get_active_season()
+        facts_file(doc)
+        with pytest.raises(ValueError, match="start_date"):
+            load_season_config()
+
+    def test_season_mismatch_raises(self, facts_file):
+        """A facts file whose `season` disagrees with its directory fails.
+
+        Guards the copy-a-season-dir-and-forget-to-edit mistake: the
+        directory is the resolver's truth, the in-file key must agree.
+        """
+        facts_file({**VALID_FACTS, "season": "1999-00"})
+        with pytest.raises(ValueError, match="1999-00"):
+            load_season_config()
+
+    def test_missing_version_raises(self, facts_file):
+        """A facts file without a version key raises with context."""
+        doc = {k: v for k, v in VALID_FACTS.items() if k != "version"}
+        doc["season"] = get_active_season()
+        facts_file(doc)
+        with pytest.raises(ValueError, match="'version' key"):
+            load_season_config()
+
+    def test_unquoted_version_raises(self, facts_file):
+        """An unquoted YAML version (parsed as float) is rejected."""
+        facts_file(
+            f'version: 1.10\nseason: "{get_active_season()}"\n'
+            + yaml.safe_dump(
+                {k: v for k, v in VALID_FACTS.items() if k not in ("version", "season")}
+            )
+        )
+        with pytest.raises(ValueError, match="quoted string"):
+            load_season_config()
+
+    def test_missing_calendar_block_raises(self, facts_file):
+        """The calendar block is part of the schema, even when all-null."""
+        doc = {k: v for k, v in VALID_FACTS.items() if k != "calendar"}
+        doc["season"] = get_active_season()
+        facts_file(doc)
+        with pytest.raises(ValueError, match="'calendar' block"):
+            load_season_config()
+
+    def test_calendar_key_set_is_exact(self, facts_file):
+        """A calendar with an unknown or missing key fails.
+
+        Write-once applies to the schema: a new key is a code change
+        (CALENDAR_KEYS), not a per-file addition.
+        """
+        doc = {**VALID_FACTS, "season": get_active_season()}
+        doc["calendar"] = {**doc["calendar"], "preseason_start": None}
+        facts_file(doc)
+        with pytest.raises(ValueError, match="'calendar' keys must be exactly"):
+            load_season_config()
+
+    def test_calendar_nulls_allowed(self, facts_file):
+        """All-null calendar and corpus blocks load (values fill when knowable)."""
+        facts_file({**VALID_FACTS, "season": get_active_season()})
+        config = load_season_config()
+        assert all(v is None for v in config["calendar"].values())
+        assert all(v is None for v in config["corpus"].values())
+
+    def test_unquoted_calendar_date_raises(self, facts_file):
+        """An unquoted date (YAML datetime.date) is rejected.
+
+        Calendar values are ISO strings like start_date/end_date, so
+        callers see one type; YAML's native date would leak a second.
+        """
+        doc = {**VALID_FACTS, "season": get_active_season()}
+        text = yaml.safe_dump(doc).replace(
+            "opening_night: null", "opening_night: 2024-10-22"
+        )
+        facts_file(text)
+        with pytest.raises(ValueError, match="calendar.opening_night"):
+            load_season_config()
+
+    def test_malformed_calendar_date_raises(self, facts_file):
+        """A non-ISO calendar string is rejected."""
+        doc = {**VALID_FACTS, "season": get_active_season()}
+        doc["calendar"] = {**doc["calendar"], "christmas": "Dec 25"}
+        facts_file(doc)
+        with pytest.raises(ValueError, match="calendar.christmas"):
+            load_season_config()
+
+    def test_non_integer_corpus_count_raises(self, facts_file):
+        """A corpus count that isn't an int is rejected."""
+        doc = {**VALID_FACTS, "season": get_active_season()}
+        doc["corpus"] = {"raw_comments": "7.28M"}
+        facts_file(doc)
+        with pytest.raises(ValueError, match="corpus.raw_comments"):
+            load_season_config()
 
 
 class TestGetActiveSeason:
@@ -110,10 +363,13 @@ class TestGetActiveSeason:
         season = get_active_season()
         assert isinstance(season, str)
 
-    def test_matches_config(self):
-        """Active season matches what load_season_config returns."""
-        config = load_season_config()
-        assert get_active_season() == config["season"]
+    def test_matches_pointer(self):
+        """Without an override, the active season is the pointer file's."""
+        assert get_active_season() == load_season_pointer()["season"]
+
+    def test_matches_facts_file(self):
+        """The facts file loaded is the active season's."""
+        assert load_season_config()["season"] == get_active_season()
 
     def test_matches_season_format(self):
         """Active season is a YYYY-YY identifier."""
@@ -126,26 +382,26 @@ class TestSeasonOverride:
     @pytest.fixture(autouse=True)
     def clean_override_state(self):
         """Cold season-derived caches and no override, before and after."""
-        _clear_player_caches()
+        _clear_season_caches()
         clear_season_override()
         yield
         clear_season_override()
-        _clear_player_caches()
+        _clear_season_caches()
 
     def test_override_changes_active_season(self):
         """get_active_season returns the override when set."""
         set_season_override("2024-25")
         assert get_active_season() == "2024-25"
 
-    def test_no_override_uses_config_file(self):
-        """Without an override, the on-disk config value is returned."""
-        assert get_active_season() == load_season_config()["season"]
+    def test_no_override_uses_pointer_file(self):
+        """Without an override, the on-disk pointer value is returned."""
+        assert get_active_season() == load_season_pointer()["season"]
 
-    def test_clear_restores_config_value(self):
-        """Clearing the override restores the on-disk config value."""
+    def test_clear_restores_pointer_value(self):
+        """Clearing the override restores the on-disk pointer value."""
         set_season_override("2024-25")
         clear_season_override()
-        assert get_active_season() == load_season_config()["season"]
+        assert get_active_season() == load_season_pointer()["season"]
 
     def test_override_reaches_paths(self):
         """Path resolution honors the override with no parameter threading."""
@@ -162,6 +418,21 @@ class TestSeasonOverride:
         players, _ = load_player_config()
         assert len(players) == 111
 
+    def test_override_reaches_season_facts(self):
+        """The facts loader resolves the override season's file.
+
+        Pins 2024-25's window and a calendar date — frozen season, safe
+        to pin. This is #51's former "known seam", now dissolved: the
+        override reaches dates, not just paths.
+        """
+        set_season_override("2024-25")
+        config = load_season_config()
+        assert config["season"] == "2024-25"
+        assert config["start_date"] == "2024-10-01"
+        assert config["end_date"] == "2025-06-30"
+        assert config["calendar"]["opening_night"] == "2024-10-22"
+        assert config["corpus"]["raw_comments"] == 7_041_235
+
     def test_invalid_format_raises(self):
         """A malformed season identifier is rejected up front."""
         with pytest.raises(ValueError, match="YYYY-YY"):
@@ -169,8 +440,8 @@ class TestSeasonOverride:
 
     @pytest.mark.parametrize(
         "warming_call",
-        [load_player_config, load_player_config_version],
-        ids=["player_config", "config_version"],
+        [load_season_config, load_player_config, load_player_config_version],
+        ids=["season_config", "player_config", "config_version"],
     )
     def test_raises_if_caches_already_warm(self, warming_call):
         """Setting the override after config loading fails loud.

--- a/utils/config_version.py
+++ b/utils/config_version.py
@@ -1,0 +1,38 @@
+"""
+Shared validation for the lineage `version` key in YAML configs.
+
+players.yaml, teams.yaml, and season.yaml each carry a quoted
+MAJOR.MINOR `version` that gets stamped into produced files; every
+loader validates it through require_version_string() so the rule (must
+exist, must be a string) has one home.
+"""
+
+from pathlib import Path
+
+
+def require_version_string(config: dict | None, path: Path, label: str) -> str:
+    """
+    Return a config's `version` value, requiring a quoted string.
+
+    Args:
+        config: Parsed YAML document (None when the file is empty).
+        path: Path the config was read from, for the error message.
+        label: Human name of the config file, e.g. "players.yaml".
+
+    Returns:
+        The version string, e.g. "4.2".
+
+    Raises:
+        ValueError: If there is no 'version' key, or the value is not a
+            string (an unquoted version parses as a YAML float and would
+            silently mis-stamp lineage, e.g. 4.10 -> "4.1").
+    """
+    version = (config or {}).get("version")
+    if version is None:
+        raise ValueError(f"{label} has no 'version' key: {path}")
+    if not isinstance(version, str):
+        raise ValueError(
+            f"{label} version must be a quoted string, got "
+            f"{version!r} ({type(version).__name__}) in {path}"
+        )
+    return version

--- a/utils/config_version.py
+++ b/utils/config_version.py
@@ -17,7 +17,8 @@ def require_version_string(config: dict | None, path: Path, label: str) -> str:
     Args:
         config: Parsed YAML document (None when the file is empty).
         path: Path the config was read from, for the error message.
-        label: Human name of the config file, e.g. "players.yaml".
+        label: How to refer to the config in error messages, e.g.
+            "players.yaml for season '2025-26'".
 
     Returns:
         The version string, e.g. "4.2".

--- a/utils/player_config.py
+++ b/utils/player_config.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import yaml
 
+from utils.config_version import require_version_string
 from utils.season_config import get_active_season
 
 
@@ -95,9 +96,7 @@ def _normalize_player_name(name: str) -> str:
     return " ".join(name.lower().replace(".", "").split())
 
 
-def resolve_sentiment_player(
-    name: str | None, alias_map: dict[str, str]
-) -> str | None:
+def resolve_sentiment_player(name: str | None, alias_map: dict[str, str]) -> str | None:
     """
     Resolve a classifier sentiment_player value to a canonical player name.
 
@@ -143,18 +142,9 @@ def load_player_config_version() -> str:
     with open(path) as f:
         config = yaml.safe_load(f)
 
-    version = config.get("version")
-    if version is None:
-        raise ValueError(
-            f"players.yaml for season {get_active_season()!r} has no "
-            f"'version' key: {path}"
-        )
-    if not isinstance(version, str):
-        raise ValueError(
-            f"players.yaml version must be a quoted string, got "
-            f"{version!r} ({type(version).__name__}) in {path}"
-        )
-    return version
+    return require_version_string(
+        config, path, f"players.yaml for season {get_active_season()!r}"
+    )
 
 
 @lru_cache(maxsize=1)

--- a/utils/season_config.py
+++ b/utils/season_config.py
@@ -24,6 +24,7 @@ The override is process-local module state: spawn-based worker processes
 """
 
 import re
+from collections.abc import Callable
 from datetime import date
 from functools import lru_cache
 from pathlib import Path
@@ -82,7 +83,9 @@ def load_season_pointer() -> dict:
         config = yaml.safe_load(f) or {}
 
     if "season" not in config:
-        raise ValueError(f"season.yaml missing required key 'season': {POINTER_PATH}")
+        raise ValueError(
+            f"season pointer file missing required key 'season': {POINTER_PATH}"
+        )
 
     pointers = {
         "season": config["season"],
@@ -93,7 +96,7 @@ def load_season_pointer() -> dict:
             continue
         if not isinstance(value, str) or not SEASON_FORMAT.fullmatch(value):
             raise ValueError(
-                f"season.yaml {key!r} must be a quoted YYYY-YY string, got "
+                f"season pointer {key!r} must be a quoted YYYY-YY string, got "
                 f"{value!r} in {POINTER_PATH}"
             )
     return pointers
@@ -128,16 +131,16 @@ def load_season_config() -> dict:
 
     missing = REQUIRED_KEYS - set(config)
     if missing:
-        raise ValueError(f"season.yaml missing required keys: {missing} in {path}")
+        raise ValueError(f"season facts missing required keys: {missing} in {path}")
 
     if config["season"] != season:
         raise ValueError(
-            f"season.yaml 'season' is {config['season']!r} but the file is "
+            f"season facts 'season' is {config['season']!r} but the file is "
             f"config/{season}/season.yaml"
         )
 
     if not config["subreddits"]:
-        raise ValueError(f"season.yaml 'subreddits' must not be empty: {path}")
+        raise ValueError(f"season facts 'subreddits' must not be empty: {path}")
 
     config["version"] = require_version_string(
         config, path, f"season.yaml for season {season!r}"
@@ -158,7 +161,7 @@ def load_season_config() -> dict:
 def _validated_block(
     block: dict | None,
     keys: tuple[str, ...],
-    check,
+    check: Callable[[object], None],
     label: str,
     path: Path,
 ) -> MappingProxyType:
@@ -180,10 +183,10 @@ def _validated_block(
             `keys`, or a non-null value fails `check`.
     """
     if not isinstance(block, dict):
-        raise ValueError(f"season.yaml missing '{label}' block: {path}")
+        raise ValueError(f"season facts missing '{label}' block: {path}")
     if set(block) != set(keys):
         raise ValueError(
-            f"season.yaml '{label}' keys must be exactly {sorted(keys)}, "
+            f"season facts '{label}' keys must be exactly {sorted(keys)}, "
             f"got {sorted(block)} in {path}"
         )
     for key in keys:
@@ -194,7 +197,7 @@ def _validated_block(
             check(value)
         except (TypeError, ValueError) as e:
             raise ValueError(
-                f"season.yaml {label}.{key} is malformed ({value!r}) in {path}: {e}"
+                f"season facts {label}.{key} is malformed ({value!r}) in {path}: {e}"
             ) from e
     return MappingProxyType({key: block[key] for key in keys})
 

--- a/utils/season_config.py
+++ b/utils/season_config.py
@@ -1,59 +1,153 @@
 """
 Season configuration loading from YAML.
 
-This module provides cached access to the active season identifier,
-date boundaries, and target subreddits from config/season.yaml.
+Two files, two kinds of config:
+
+- config/season.yaml — the *pointers*: `season` (the pipeline's
+  operational season) and `published_season` (what the deployed
+  dashboard serves). Mutable; moving a pointer never touches a season's
+  facts.
+- config/<season>/season.yaml — that season's *facts*: the operational
+  download window (start_date/end_date), subreddits, the league
+  `calendar` block, the `corpus` block, and a lineage `version`.
+  Write-once per season.
 
 The active season can be overridden per process via set_season_override()
 (the scripts' --season flag), which must be called at script entry before
 any season-derived config is loaded — one season per process still holds.
-The override redirects only the season identifier (paths, players.yaml);
-load_season_config()'s other fields (start_date, end_date, subreddits)
-deliberately keep their on-disk values, so scripts that consume those
-(download_comments) must not use the override.
+Everything that resolves through get_active_season() follows the override,
+including load_season_config()'s facts, so `--season X` reads season X's
+window and calendar, not the pointer season's.
 
 The override is process-local module state: spawn-based worker processes
 (multiprocessing) would not inherit it and must set it themselves.
 """
 
 import re
+from datetime import date
 from functools import lru_cache
 from pathlib import Path
+from types import MappingProxyType
 
 import yaml
 
+from utils.config_version import require_version_string
 
-CONFIG_PATH = Path(__file__).parent.parent / "config" / "season.yaml"
+
+CONFIG_DIR = Path(__file__).parent.parent / "config"
+POINTER_PATH = CONFIG_DIR / "season.yaml"
 
 REQUIRED_KEYS = {"season", "start_date", "end_date", "subreddits"}
+
+# The league-calendar key set. Every key must be present in every season's
+# file (a value may be null until knowable); the set only grows.
+CALENDAR_KEYS = (
+    "opening_night",
+    "nba_cup_final",
+    "christmas",
+    "trade_deadline",
+    "all_star",
+    "play_in_start",
+    "playoffs_start",
+    "finals_start",
+    "finals_end",
+)
+CORPUS_KEYS = ("raw_comments",)
 
 SEASON_FORMAT = re.compile(r"\d{4}-\d{2}")
 
 _season_override: str | None = None
 
 
+def _season_facts_path(season: str) -> Path:
+    """Resolve the per-season facts file for a season."""
+    return CONFIG_DIR / season / "season.yaml"
+
+
+@lru_cache(maxsize=1)
+def load_season_pointer() -> dict:
+    """
+    Load the season pointers from config/season.yaml.
+
+    Returns:
+        Dict with keys: season (str), published_season (str | None).
+
+    Raises:
+        FileNotFoundError: If the pointer file doesn't exist.
+        yaml.YAMLError: If the file is invalid YAML.
+        ValueError: If `season` is missing, or either pointer is not a
+            YYYY-YY string.
+    """
+    with open(POINTER_PATH) as f:
+        config = yaml.safe_load(f) or {}
+
+    if "season" not in config:
+        raise ValueError(f"season.yaml missing required key 'season': {POINTER_PATH}")
+
+    pointers = {
+        "season": config["season"],
+        "published_season": config.get("published_season"),
+    }
+    for key, value in pointers.items():
+        if value is None and key == "published_season":
+            continue
+        if not isinstance(value, str) or not SEASON_FORMAT.fullmatch(value):
+            raise ValueError(
+                f"season.yaml {key!r} must be a quoted YYYY-YY string, got "
+                f"{value!r} in {POINTER_PATH}"
+            )
+    return pointers
+
+
 @lru_cache(maxsize=1)
 def load_season_config() -> dict:
     """
-    Load season configuration from config/season.yaml.
+    Load the active season's facts from config/<season>/season.yaml.
+
+    The season is resolved through get_active_season(), so the --season
+    override reaches the facts layer too. Season-derived cache: joins the
+    override's warm-cache guard.
 
     Returns:
-        Dict with keys: season, start_date, end_date, subreddits.
+        Dict with keys: season, version, start_date, end_date, subreddits
+        (tuple), calendar (read-only mapping of the CALENDAR_KEYS to ISO
+        date strings or None), corpus (read-only mapping of the
+        CORPUS_KEYS to ints or None).
 
     Raises:
-        FileNotFoundError: If config file doesn't exist.
-        yaml.YAMLError: If config file is invalid YAML.
-        ValueError: If required keys are missing.
+        FileNotFoundError: If the season's facts file doesn't exist.
+        yaml.YAMLError: If the file is invalid YAML.
+        ValueError: If required keys are missing, the file's `season`
+            doesn't match the directory it lives in, `version` isn't a
+            quoted string, or a calendar/corpus value is malformed.
     """
-    with open(CONFIG_PATH) as f:
-        config = yaml.safe_load(f)
+    season = get_active_season()
+    path = _season_facts_path(season)
+    with open(path) as f:
+        config = yaml.safe_load(f) or {}
 
     missing = REQUIRED_KEYS - set(config)
     if missing:
-        raise ValueError(f"season.yaml missing required keys: {missing}")
+        raise ValueError(f"season.yaml missing required keys: {missing} in {path}")
+
+    if config["season"] != season:
+        raise ValueError(
+            f"season.yaml 'season' is {config['season']!r} but the file is "
+            f"config/{season}/season.yaml"
+        )
 
     if not config["subreddits"]:
-        raise ValueError("season.yaml 'subreddits' must not be empty")
+        raise ValueError(f"season.yaml 'subreddits' must not be empty: {path}")
+
+    config["version"] = require_version_string(
+        config, path, f"season.yaml for season {season!r}"
+    )
+    config["calendar"] = _validated_block(
+        config.get("calendar"), CALENDAR_KEYS, _check_iso_date, "calendar", path
+    )
+    config["corpus"] = _validated_block(
+        config.get("corpus"), CORPUS_KEYS, _check_int, "corpus", path
+    )
 
     # Freeze mutable values so callers can't corrupt the cache
     config["subreddits"] = tuple(config["subreddits"])
@@ -61,19 +155,87 @@ def load_season_config() -> dict:
     return config
 
 
+def _validated_block(
+    block: dict | None,
+    keys: tuple[str, ...],
+    check,
+    label: str,
+    path: Path,
+) -> MappingProxyType:
+    """
+    Validate a write-once fact block: exact key set, typed-or-null values.
+
+    Args:
+        block: The parsed YAML mapping (None if absent).
+        keys: The required key set, in canonical order.
+        check: Validator applied to each non-null value; raises ValueError.
+        label: Block name for error messages.
+        path: File the block was read from.
+
+    Returns:
+        Read-only mapping over the keys in canonical order.
+
+    Raises:
+        ValueError: If the block is missing, its key set differs from
+            `keys`, or a non-null value fails `check`.
+    """
+    if not isinstance(block, dict):
+        raise ValueError(f"season.yaml missing '{label}' block: {path}")
+    if set(block) != set(keys):
+        raise ValueError(
+            f"season.yaml '{label}' keys must be exactly {sorted(keys)}, "
+            f"got {sorted(block)} in {path}"
+        )
+    for key in keys:
+        value = block[key]
+        if value is None:
+            continue
+        try:
+            check(value)
+        except (TypeError, ValueError) as e:
+            raise ValueError(
+                f"season.yaml {label}.{key} is malformed ({value!r}) in {path}: {e}"
+            ) from e
+    return MappingProxyType({key: block[key] for key in keys})
+
+
+def _check_iso_date(value: object) -> None:
+    """Require a quoted ISO date string (an unquoted date parses as datetime.date)."""
+    if not isinstance(value, str):
+        raise TypeError("expected a quoted YYYY-MM-DD string")
+    date.fromisoformat(value)
+
+
+def _check_int(value: object) -> None:
+    """Require a plain integer count."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError("expected an integer")
+
+
+def load_season_config_version() -> str:
+    """
+    Get the active season's season.yaml version (lineage metadata).
+
+    Returns:
+        Version string, e.g. "1.0".
+    """
+    return load_season_config()["version"]
+
+
 def get_active_season() -> str:
     """
     Get the active season identifier.
 
     Returns the process-level override when one is set (see
-    set_season_override), otherwise the value from config/season.yaml.
+    set_season_override), otherwise the `season` pointer from
+    config/season.yaml.
 
     Returns:
         Season string, e.g. "2024-25".
     """
     if _season_override is not None:
         return _season_override
-    return load_season_config()["season"]
+    return load_season_pointer()["season"]
 
 
 def set_season_override(season: str) -> None:
@@ -83,9 +245,8 @@ def set_season_override(season: str) -> None:
     Call once at script entry (the --season flag), before any
     season-derived config is loaded. Everything that resolves through
     get_active_season() — data paths, the players.yaml loaders, the
-    aggregates.json season stamp — follows the override; the remaining
-    load_season_config() fields (start_date, end_date, subreddits) keep
-    their on-disk values.
+    season facts (load_season_config), the aggregates.json season stamp —
+    follows the override.
 
     Args:
         season: Season identifier, e.g. "2024-25".
@@ -98,8 +259,7 @@ def set_season_override(season: str) -> None:
     """
     if not SEASON_FORMAT.fullmatch(season):
         raise ValueError(
-            f"Invalid season identifier: {season!r} (expected YYYY-YY, "
-            'e.g. "2024-25")'
+            f'Invalid season identifier: {season!r} (expected YYYY-YY, e.g. "2024-25")'
         )
     _ensure_season_caches_cold()
     global _season_override
@@ -116,9 +276,10 @@ def _ensure_season_caches_cold() -> None:
     """
     Fail fast if season-derived caches were populated before the override.
 
-    Checks the player-config loaders' lru_caches; these subsume the
-    compiled-pattern cache in pipeline/processors.py, which is only ever
-    populated through load_player_config().
+    Checks this module's facts loader and the player-config loaders'
+    lru_caches; the latter subsume the compiled-pattern cache in
+    pipeline/processors.py, which is only ever populated through
+    load_player_config().
 
     Raises:
         RuntimeError: Naming the warm caches, if any.
@@ -133,6 +294,7 @@ def _ensure_season_caches_cold() -> None:
     warm = [
         fn.__name__
         for fn in (
+            load_season_config,
             load_player_config,
             build_alias_to_player_map,
             load_player_metadata,

--- a/utils/team_config.py
+++ b/utils/team_config.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 import yaml
 
+from utils.config_version import require_version_string
+
 
 CONFIG_PATH = Path(__file__).parent.parent / "config" / "teams.yaml"
 
@@ -60,15 +62,7 @@ def load_team_config_version() -> str:
     with open(CONFIG_PATH) as f:
         config = yaml.safe_load(f)
 
-    version = config.get("version")
-    if version is None:
-        raise ValueError(f"teams.yaml has no 'version' key: {CONFIG_PATH}")
-    if not isinstance(version, str):
-        raise ValueError(
-            f"teams.yaml version must be a quoted string, got "
-            f"{version!r} ({type(version).__name__}) in {CONFIG_PATH}"
-        )
-    return version
+    return require_version_string(config, CONFIG_PATH, "teams.yaml")
 
 
 @lru_cache(maxsize=1)


### PR DESCRIPTION
Closes #52.

## What

`config/season.yaml` conflated the mutable season pointer with the season's immutable facts — #48's flip overwrote 2024-25's dates, and #51's `--season` override could reach paths but never dates (the "known seam"). This splits them following the `players.yaml` precedent, plus the 2026-08-16 amendment's facts layer:

- **`config/season.yaml`** → pointers only: `season`, `published_season`.
- **`config/<season>/season.yaml`** (both seasons) → `version`, `season`, the operational download window (`start_date`/`end_date` — the corpus brackets the season, it isn't the season), `subreddits`, and two write-once blocks:
  - `calendar:` — nine league-recurring dates, `opening_night` → `finals_end`; admission test (recurring / crisp / consumable) stated in the file header.
  - `corpus:` — `raw_comments`, pinned from the corpus-baseline notebook.
- **`load_season_config()`** now resolves through `get_active_season()`, so the override reaches the facts (seam dissolved); it joins the override's warm-cache guard. New `load_season_pointer()` feeds `get_active_season()`; `load_season_config_version()` for the manifest stamp. Returned dict is a **superset** of the old contract — every call site (`download_comments`, `download_posts`, `app/utils/data.py`) unchanged.
- **`utils/config_version.py`** — `require_version_string()` extracted; all three loaders (players / teams / season) on it (the #83 review trigger).

## Values

All values verified — no NULLs needed. Full provenance table (git history, notebook cells, league record) is on #52. One definitional call recorded there: **`all_star` = the All-Star Game date (Sunday)**, not weekend start — the 2024-25 §2.4 seed used the other definition; the game date is the one that fills mechanically across seasons.

## Validation the loader enforces

Exact `CALENDAR_KEYS`/`CORPUS_KEYS` sets (a new key is a code change — write-once applies to the schema); calendar values quoted ISO strings or `null` (unquoted YAML dates rejected so callers see one type); corpus values ints or `null`; in-file `season` must match its directory; quoted `version`.

## Verification

- `uv run pytest` — 502 passed; `uv run ruff check .` clean; every commit passes the gate alone.
- Branch review pass: 0 must-fix; type hint + error-prefix findings applied on-branch (3rd commit).
- Smoke: `load_season_config()` under both pointer and `--season 2024-25`; `download_comments --help` still wires.

## Not in scope (unchanged from ticket)

Wiring `--season` into `download_comments` (now *eligible*); `manifest.json` (consumes this file's key set — next).
