### PR TITLE
fix(pipeline): comment_samples — pos/neg receipts require a named sentiment_player

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -139,7 +139,7 @@ The `Player → Team (roster)` edge carries a fidelity ceiling worth stating pla
 
 ## 4. View lineage — cheap, needs-a-join, expensive
 
-Three classes of produced table: the four views are **rollups** of `ClassifiedComment` (fact tables with measures at a coarser grain); `Player` and `Team` are the **dimensions** joined in; `comment_samples` is a **fact subset** — verbatim rows of `ClassifiedComment` at its own grain, selected (top-N per player × sentiment by score, under candidacy gates) rather than aggregated.
+Three classes of produced table: the four views are **rollups** of `ClassifiedComment` (fact tables with measures at a coarser grain); `Player` and `Team` are the **dimensions** joined in; `comment_samples` is a **fact subset** — verbatim rows of `ClassifiedComment` at its own grain, selected (top-N per player × sentiment by score, under candidacy gates; a pos/neg receipt additionally requires the classifier's stated target, `sentiment_player`) rather than aggregated. Attribution counts every resolved comment; a receipt held up as *what was said about this player* holds the stricter bar.
 
 | Table (parquet) | Grain | Derives from | Cheap question it already answers |
 |---|---|---|---|

--- a/pipeline/aggregation.py
+++ b/pipeline/aggregation.py
@@ -388,11 +388,11 @@ def build_comment_samples(
     Neutral rows are exempt from both polar gates - the classifier
     reports a conventional 0.5 for neu and routinely omits the target on
     neutral comments; a polar row with no stated target is the ambiguity
-    class a receipt can't carry. Within each
-    (attributed_player, sentiment) cell, duplicate bodies collapse
-    to the best-ranked copy, rows rank by score desc (ties: confidence
-    desc, comment_id asc, nulls last) and the top n are kept; thin cells
-    are never padded. Bodies are verbatim.
+    class a receipt can't carry. Within each (attributed_player,
+    sentiment) cell, duplicate bodies collapse to the best-ranked copy,
+    rows rank by score desc (ties: confidence desc, comment_id asc,
+    nulls last) and the top n are kept; thin cells are never padded.
+    Bodies are verbatim.
 
     Args:
         df: Attributed, flair-resolved frame with attributed_player,

--- a/pipeline/aggregation.py
+++ b/pipeline/aggregation.py
@@ -384,18 +384,20 @@ def build_comment_samples(
     Select the comment samples: top-N receipts per player x sentiment.
 
     Candidacy: body no longer than max_body_chars and, for pos/neg,
-    confidence at or above min_confidence. Neutral rows are exempt from
-    the floor - the classifier reports a conventional 0.5 for neu, so a
-    floor there would starve the cells rather than guard them. Within
-    each (attributed_player, sentiment) cell, duplicate bodies collapse
+    confidence at or above min_confidence and a named sentiment_player.
+    Neutral rows are exempt from both polar gates - the classifier
+    reports a conventional 0.5 for neu and routinely omits the target on
+    neutral comments; a polar row with no stated target is the ambiguity
+    class a receipt can't carry. Within each
+    (attributed_player, sentiment) cell, duplicate bodies collapse
     to the best-ranked copy, rows rank by score desc (ties: confidence
     desc, comment_id asc, nulls last) and the top n are kept; thin cells
     are never padded. Bodies are verbatim.
 
     Args:
         df: Attributed, flair-resolved frame with attributed_player,
-            sentiment, comment_id, link_id, body, score, confidence,
-            created_utc, team.
+            sentiment, sentiment_player, comment_id, link_id, body,
+            score, confidence, created_utc, team.
         n: Maximum rows per (attributed_player, sentiment) cell.
         min_confidence: Candidacy floor on confidence, pos/neg rows only.
         max_body_chars: Candidacy cap on body length, in characters.
@@ -409,15 +411,21 @@ def build_comment_samples(
     passes_floor = (pl.col("sentiment") == "neu") | (
         pl.col("confidence") >= min_confidence
     )
+    has_target = (pl.col("sentiment") == "neu") | pl.col(
+        "sentiment_player"
+    ).is_not_null()
     within_cap = pl.col("body").str.len_chars() <= max_body_chars
-    candidates = df.filter(passes_floor & within_cap)
+    candidates = df.filter(passes_floor & has_target & within_cap)
     if df.height:
         below_floor = df.filter(~passes_floor).height
-        over_cap = df.filter(passes_floor & ~within_cap).height
+        no_target = df.filter(passes_floor & ~has_target).height
+        over_cap = df.filter(passes_floor & has_target & ~within_cap).height
         logger.info(
             f"comment_samples candidacy: {df.height:,} attributed rows; "
             f"{below_floor:,} ({below_floor / df.height:.1%}) removed by the "
             f"pos/neg confidence floor {min_confidence}, "
+            f"{no_target:,} ({no_target / df.height:.1%}) removed by the "
+            f"pos/neg target gate, "
             f"{over_cap:,} ({over_cap / df.height:.1%}) removed by the "
             f"{max_body_chars}-char body cap; {candidates.height:,} candidates"
         )

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -548,6 +548,7 @@ _SAMPLES_INPUT_SCHEMA = pl.Schema(
     {
         "attributed_player": pl.String,
         "sentiment": pl.String,
+        "sentiment_player": pl.String,
         "comment_id": pl.String,
         "link_id": pl.String,
         "body": pl.String,
@@ -561,7 +562,9 @@ _SAMPLES_INPUT_SCHEMA = pl.Schema(
 
 def _samples_input(rows: list[dict]) -> pl.DataFrame:
     """Build a build_comment_samples input frame from row dicts, filling
-    the columns a test doesn't care about with stable defaults."""
+    the columns a test doesn't care about with stable defaults.
+    sentiment_player defaults to the row's attributed_player (a named
+    target), so only the target-gate tests set it explicitly."""
     defaults = {
         "link_id": "t3_post1",
         "confidence": 0.95,
@@ -569,7 +572,15 @@ def _samples_input(rows: list[dict]) -> pl.DataFrame:
         "team": None,
     }
     return pl.DataFrame(
-        [{**defaults, **row} for row in rows], schema=_SAMPLES_INPUT_SCHEMA
+        [
+            {
+                "sentiment_player": row["attributed_player"],
+                **defaults,
+                **row,
+            }
+            for row in rows
+        ],
+        schema=_SAMPLES_INPUT_SCHEMA,
     )
 
 
@@ -685,6 +696,75 @@ class TestBuildCommentSamples:
         frame = build_comment_samples(_samples_input(rows), min_confidence=0.9)
 
         assert frame["comment_id"].to_list() == ["neutral"]
+
+    def test_target_gate_excludes_polar_rows_without_target(self):
+        """A polar row where the classifier declined to name a target is
+        not a candidate, whatever its score; the next-best named-target
+        row takes its rank."""
+        rows = [
+            {
+                "attributed_player": "Rudy Gobert",
+                "sentiment": "neg",
+                "sentiment_player": None,
+                "comment_id": "bystander",
+                "body": "You were fouling Wemby all game",
+                "score": 5000,
+            },
+            {
+                "attributed_player": "Rudy Gobert",
+                "sentiment": "neg",
+                "comment_id": "named",
+                "body": "classic Gobert defense",
+                "score": 10,
+            },
+        ]
+        frame = build_comment_samples(_samples_input(rows))
+
+        assert frame["comment_id"].to_list() == ["named"]
+        assert frame["rank"].to_list() == [1]
+
+    def test_target_gate_exempts_neutral(self):
+        """The gate guards the polar labels only: the classifier routinely
+        omits the target on neutral comments, so a null-target neu row is
+        still a candidate."""
+        rows = [
+            {
+                "attributed_player": "LeBron James",
+                "sentiment": "neu",
+                "sentiment_player": None,
+                "comment_id": "neutral",
+                "body": "LeBron had 28 tonight",
+                "score": 40,
+            },
+        ]
+        frame = build_comment_samples(_samples_input(rows))
+
+        assert frame["comment_id"].to_list() == ["neutral"]
+
+    def test_candidacy_log_reports_target_gate(self, caplog):
+        """The candidacy line reports the target gate's removals alongside
+        the floor and cap."""
+        rows = [
+            {
+                "attributed_player": "Rudy Gobert",
+                "sentiment": "neg",
+                "sentiment_player": None,
+                "comment_id": "bystander",
+                "body": "You were fouling Wemby all game",
+                "score": 5000,
+            },
+            {
+                "attributed_player": "Rudy Gobert",
+                "sentiment": "neg",
+                "comment_id": "named",
+                "body": "classic Gobert defense",
+                "score": 10,
+            },
+        ]
+        with caplog.at_level(logging.INFO, logger="pipeline.aggregation"):
+            build_comment_samples(_samples_input(rows))
+
+        assert "1 (50.0%) removed by the pos/neg target gate" in caplog.text
 
     def test_body_length_cap_excludes_long_bodies(self):
         """A high-score essay over the cap is not a candidate at all."""

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -1313,12 +1313,14 @@ class TestAggregateViews:
 
         neg_rates by player: Giannis 1.0, Kevin Durant 0.5, LeBron James 0.5
         (tie with Durant), Stephen Curry 0.0 — exercises the player_overall
-        sort and its tiebreaker.
+        sort and its tiebreaker. c7 is a Giannis neg with no stated target
+        (sentiment_player null): attributed by the single-mention rule
+        (Giannis stays 1.0), gated out of the receipts despite the top score.
         """
         return _make_test_parquet(
             tmp_path,
             {
-                "comment_id": ["c1", "c2", "c3", "c4", "c5", "c6"],
+                "comment_id": ["c1", "c2", "c3", "c4", "c5", "c6", "c7"],
                 "body": [
                     "Giannis traveled again",
                     "KD is a snake",
@@ -1326,14 +1328,16 @@ class TestAggregateViews:
                     "LeBron is washed",
                     "LeBron is the GOAT",
                     "Curry never misses",
+                    "You were fouling Giannis all game",
                 ],
-                "author": ["u1", "u2", "u3", "u4", "u5", "u6"],
+                "author": ["u1", "u2", "u3", "u4", "u5", "u6", "u7"],
                 "author_flair_text": [
                     ":lal-1: Lakers",
                     ":bos-1: Celtics",
                     ":lal-1: Lakers",
                     ":bos-1: Celtics",
                     ":lal-1: Lakers",
+                    ":bos-1: Celtics",
                     ":bos-1: Celtics",
                 ],
                 "author_flair_css_class": [
@@ -1343,6 +1347,7 @@ class TestAggregateViews:
                     "celtics",
                     "lakers",
                     "celtics",
+                    "celtics",
                 ],
                 "created_utc": [
                     1704067200,
@@ -1351,8 +1356,9 @@ class TestAggregateViews:
                     1704672000,
                     1704672000,
                     1704672000,  # week of 2024-01-08
+                    1704067200,  # week of 2024-01-01
                 ],
-                "score": [10, 5, 8, 3, 12, 7],
+                "score": [10, 5, 8, 3, 12, 7, 100],
                 "link_id": [
                     "t3_game1",
                     "t3_game1",
@@ -1360,6 +1366,7 @@ class TestAggregateViews:
                     "t3_game2",
                     "t3_game2",
                     "t3_game2",
+                    "t3_game1",
                 ],
                 "mentioned_players": [
                     ["Giannis Antetokounmpo"],
@@ -1368,9 +1375,10 @@ class TestAggregateViews:
                     ["LeBron James"],
                     ["LeBron James"],
                     ["Stephen Curry"],
+                    ["Giannis Antetokounmpo"],
                 ],
-                "sentiment": ["neg", "neg", "pos", "neg", "pos", "pos"],
-                "confidence": [0.9, 0.8, 0.9, 0.85, 0.95, 0.9],
+                "sentiment": ["neg", "neg", "pos", "neg", "pos", "pos", "neg"],
+                "confidence": [0.9, 0.8, 0.9, 0.85, 0.95, 0.9, 0.95],
                 "sentiment_player": [
                     "Giannis Antetokounmpo",
                     "Kevin Durant",
@@ -1378,9 +1386,10 @@ class TestAggregateViews:
                     "LeBron James",
                     "LeBron James",
                     "Stephen Curry",
+                    None,
                 ],
-                "input_tokens": [100, 100, 100, 100, 100, 100],
-                "output_tokens": [20, 20, 20, 20, 20, 20],
+                "input_tokens": [100, 100, 100, 100, 100, 100, 100],
+                "output_tokens": [20, 20, 20, 20, 20, 20, 20],
             },
         )
 
@@ -1417,6 +1426,23 @@ class TestAggregateViews:
         assert lebron["body"][0] == "LeBron is the GOAT"
         assert lebron["fan_team"][0] == "Los Angeles Lakers"
         assert "c4" not in samples["comment_id"].to_list()
+
+    def test_target_gate_diverges_from_attribution(self, views_parquet):
+        """Both sides of the receipts/aggregate divergence: c7 (polar,
+        null sentiment_player) is counted in player_overall — attribution
+        is untouched by the gate — yet never appears in comment_samples,
+        where c1, the named-target Giannis neg it out-scores, keeps
+        rank 1."""
+        result = aggregate_sentiment(views_parquet)
+
+        giannis = result["player_overall"].filter(
+            pl.col("attributed_player") == "Giannis Antetokounmpo"
+        )
+        assert giannis["comment_count"][0] == 2
+        assert giannis["neg_count"][0] == 2
+        sampled_ids = result["comment_samples"]["comment_id"].to_list()
+        assert "c7" not in sampled_ids
+        assert "c1" in sampled_ids
 
     def test_player_overall_sorted_by_neg_rate_desc_then_player_asc(
         self, views_parquet


### PR DESCRIPTION
Closes #86.

## What

`build_comment_samples()` candidacy for pos/neg rows now additionally requires a named `sentiment_player` — the classifier's stated target. Neutral rows are exempt (the model routinely omits the target on neu; the ambiguity class is polar-with-no-target). Receipts only: `resolve_player` and every aggregate view are untouched.

- New `has_target` predicate joins the confidence floor and body cap; the candidacy log line reports its removal share alongside them.
- Input contract gains `sentiment_player` (already on `df_attributed` — no call-site change).
- Schema unchanged; no `SCHEMA_VERSION` bump (the gate is a selection input, like confidence).
- Tests: polar null-target row excluded regardless of score (next-best pulled up); null-target neu row still a candidate; log line pinned via caplog. `_samples_input` fixture defaults `sentiment_player` to the row's `attributed_player`.
- Docs: `data-model.md` fact-subset paragraph states the principle (receipts require the classifier's stated target; attribution counts every resolved comment).

## Verification — matches the ticket's simulation exactly

2025-26 regenerated from `sentiment.parquet` on this branch:

| Check | Ticket simulation | Regenerated |
|---|---|---|
| `comment_samples` rows | 6,176 → 6,100 | 6,176 → 6,100 ✅ |
| Rank-1 **neg** changed, qualified (≥5,000) | 16/67 | 16/67 ✅ |
| Rank-1 **pos** changed, qualified | 11/67 | 11/67 ✅ |
| All six other parquets | byte-identical | byte-identical (`cmp`) ✅ |
| `aggregates.json` | identical modulo `generated_at` | identical modulo `generated_at` ✅ |

Target-gate removal share: 11,112 polar rows (0.6% of 1,786,309 attributed). Spot-checked the ticket's named upgrades — all landed verbatim (Gordon "from scoring 50 points to taking 11 total shots", Reaves "$40 million a year", Bane "biggest shit heads", Anunoby "Screw OG", Booker ← Kerr quote, Zion "most exciting player to watch").

## Manifest hand-off

The `requires_target` rule is already recorded in `docs/internal/manifest-spec.md` §1 Block 2 (2026-08-23); this PR flips its status from pending to landed (local file — `docs/internal/` is gitignored).

## Out of scope (per ticket + amendment)

Class-2 misdirected sentiment (classifier named the target, wrong in the "toward" sense) is the separate second-pass ticket; attribution/aggregate changes are timed to the backfill; `scottie`/`george` stay on the watchlist; 2024-25 rides the backfill.

`uv run pytest` 505 passed; `uv run ruff check .` clean.