### PR TITLE
chore(api): classifier lineage — PROMPT_VERSION, retro-stamps, record-at-submission

### DIFF
--- a/pipeline/aggregation.py
+++ b/pipeline/aggregation.py
@@ -187,7 +187,8 @@ def aggregate_sentiment(input_path: Path) -> dict:
     # Config-lineage check (#54): mentioned_players in the parquet reflects
     # the players.yaml it was assembled under; stale attribution is
     # legitimate to read, just not silently.
-    stamped = pl.read_parquet_metadata(input_path).get("players_config_version")
+    parquet_metadata = pl.read_parquet_metadata(input_path)
+    stamped = parquet_metadata.get("players_config_version")
     active = load_player_config_version()
     if stamped is None:
         logger.warning(
@@ -199,6 +200,17 @@ def aggregate_sentiment(input_path: Path) -> dict:
             f"{input_path}: players_config_version drift - parquet assembled "
             f"with config {stamped!r} but active config is {active!r}; "
             f"mentioned_players may not reflect the current players.yaml"
+        )
+
+    # Classifier lineage (#90): a birth certificate, not a cache stamp -
+    # nothing live to drift against, so only absence is warnable.
+    if (
+        parquet_metadata.get("classifier_sentiment_model") is None
+        or parquet_metadata.get("classifier_sentiment_prompt_version") is None
+    ):
+        logger.warning(
+            f"{input_path} carries no classifier identity stamp - "
+            f"classifier lineage cannot be verified"
         )
 
     total_rows = len(df)

--- a/pipeline/batch.py
+++ b/pipeline/batch.py
@@ -553,6 +553,37 @@ def record_retry_attempt(
     batch["actual_cost_usd"] = 0.0
 
 
+def get_classifier_identity(state: dict) -> dict[str, str] | None:
+    """
+    Read the classifier identity recorded in state at submission.
+
+    The identity is a birth certificate for the frozen classification
+    layer: assembly stamps it into sentiment.parquet unchanged, never
+    re-deriving it from live code.
+
+    Args:
+        state: Current state dict.
+
+    Returns:
+        {"model": ..., "prompt_version": ...} when every batch entry
+        carries the same identity; None when no entry carries one
+        (state recorded before the fields existed).
+
+    Raises:
+        ValueError: If entries disagree, or only some carry an identity.
+    """
+    pairs = {
+        (b.get("model"), b.get("prompt_version")) for b in state.get("batches", [])
+    }
+    if not pairs or pairs == {(None, None)}:
+        return None
+    if len(pairs) > 1 or None in next(iter(pairs)):
+        raise ValueError(f"Inconsistent classifier identity in state: {pairs!r}")
+
+    model, prompt_version = next(iter(pairs))
+    return {"model": model, "prompt_version": prompt_version}
+
+
 def summarize_actual_usage(results: list[dict]) -> dict:
     """
     Sum actual token usage over a batch's downloaded results.

--- a/pipeline/batch.py
+++ b/pipeline/batch.py
@@ -36,13 +36,25 @@ BACKOFF_BASE_SECONDS = 2.0
 BACKOFF_CAP_SECONDS = 60.0
 
 
+# Frozen v2 prompt (notebooks/2025-26/06_prompt_experiments): the eval
+# floors and known_miss flags in tests/eval/cases.yaml are pinned to this
+# exact text. Any edit is a new classifier: bump PROMPT_VERSION, re-pin
+# the hash test, re-baseline the eval suite.
+PROMPT_VERSION = "v2-production+s-hint"
+PROMPT_TEMPLATE = """Classify sentiment toward NBA players.
+Slang: nasty/sick/filthy=positive, washed/brick/fraud/cooked=negative, GOAT=positive.
+A trailing "/s" tags the comment as sarcasm.
+
+Comment: {comment_body}
+
+Respond ONLY with JSON: {{"s":"pos|neg|neu","c":0.0-1.0,"p":"Player Name"|null}}"""
+
+
 def build_prompt(comment_body: str) -> str:
     """
     Build minimal prompt for sentiment classification.
 
-    Frozen v2 prompt (notebooks/2025-26/06_prompt_experiments): the eval
-    floors and known_miss flags in tests/eval/cases.yaml are pinned to this
-    exact text — any edit here requires a re-baselined eval suite.
+    Renders PROMPT_TEMPLATE, the frozen prompt labeled PROMPT_VERSION.
 
     Args:
         comment_body: The raw Reddit comment text.
@@ -50,13 +62,7 @@ def build_prompt(comment_body: str) -> str:
     Returns:
         The formatted prompt for the model.
     """
-    return f"""Classify sentiment toward NBA players.
-Slang: nasty/sick/filthy=positive, washed/brick/fraud/cooked=negative, GOAT=positive.
-A trailing "/s" tags the comment as sarcasm.
-
-Comment: {comment_body}
-
-Respond ONLY with JSON: {{"s":"pos|neg|neu","c":0.0-1.0,"p":"Player Name"|null}}"""
+    return PROMPT_TEMPLATE.format(comment_body=comment_body)
 
 
 def parse_response(text: str) -> dict:

--- a/pipeline/batch.py
+++ b/pipeline/batch.py
@@ -449,12 +449,16 @@ def new_batch_entry(
         estimated_cost_usd: Pre-submission cost estimate for this batch.
 
     Returns:
-        Batch entry dict with retry tracking and cost fields initialized.
+        Batch entry dict with retry tracking, cost fields, and classifier
+        identity (model + prompt_version, recorded at submission time)
+        initialized.
     """
     return {
         "batch_num": batch_num,
         "batch_id": submit_result["batch_id"],
         "request_file": request_file,
+        "model": MODEL,
+        "prompt_version": PROMPT_VERSION,
         "status": submit_result["processing_status"],
         "submitted_at": submitted_at,
         "ended_at": submit_result["ended_at"],
@@ -496,6 +500,8 @@ def new_failed_entry(
         "batch_num": batch_num,
         "batch_id": None,
         "request_file": request_file,
+        "model": MODEL,
+        "prompt_version": PROMPT_VERSION,
         "status": "failed",
         "submitted_at": attempted_at,
         "ended_at": None,
@@ -761,6 +767,7 @@ def download_results(batch_id: str) -> list[dict]:
         - content: str - Model response text (if succeeded)
         - input_tokens: int - Input token count (if succeeded)
         - output_tokens: int - Output token count (if succeeded)
+        - model: str - Model that served the request (if succeeded)
         - error: str - Error message (if errored)
 
     Raises:
@@ -782,6 +789,7 @@ def download_results(batch_id: str) -> list[dict]:
                     result["content"] = message.content[0].text
                     result["input_tokens"] = message.usage.input_tokens
                     result["output_tokens"] = message.usage.output_tokens
+                    result["model"] = message.model
             elif entry.result.type == "errored":
                 error_response = entry.result.error
                 result["error"] = f"{error_response.error.type}: {error_response.error.message}"

--- a/pipeline/results.py
+++ b/pipeline/results.py
@@ -23,6 +23,53 @@ from pipeline.schemas import (
 logger = logging.getLogger(__name__)
 
 
+def check_response_models(responses_dir: Path, expected_model: str) -> None:
+    """
+    Cross-check on-disk response model echoes against the recorded identity.
+
+    Reads each results file up to its first model-bearing line (a batch is
+    served by one model, so one echo per file suffices), capped at 1000
+    lines so files that never carry the field stay cheap to skip —
+    responses downloaded before the field was retained don't have it.
+    A file whose first 1000 lines all lack the field (all-errored head)
+    is skipped exactly like a field-free legacy file; the cap trades that
+    unlikely miss for not re-reading full files.
+
+    Args:
+        responses_dir: Directory containing batch_NNN_results.jsonl files.
+        expected_model: Model recorded in state at submission.
+
+    Raises:
+        RuntimeError: If any response's model differs from expected_model.
+        ValueError: If a scanned line is not valid JSON.
+    """
+    checked = 0
+    for results_file in sorted(responses_dir.glob("batch_*_results.jsonl")):
+        with open(results_file) as f:
+            for line_num, line in enumerate(f):
+                if line_num >= 1000:
+                    break
+                if not line.strip():
+                    continue
+                try:
+                    model = json.loads(line).get("model")
+                except json.JSONDecodeError as e:
+                    raise ValueError(
+                        f"Malformed JSON in {results_file.name}: {e}"
+                    ) from e
+                if model is None:
+                    continue
+                if model != expected_model:
+                    raise RuntimeError(
+                        f"{results_file.name}: response model {model!r} does not "
+                        f"match the identity recorded in state {expected_model!r}"
+                    )
+                checked += 1
+                break
+    if checked:
+        logger.info(f"Response model cross-check passed for {checked} file(s)")
+
+
 def build_sentiment_dataframe(
     responses_dir: Path, filtered_path: Path
 ) -> tuple[pl.DataFrame, list[dict]]:

--- a/scripts/collect_results.py
+++ b/scripts/collect_results.py
@@ -37,6 +37,7 @@ from pipeline.batch import (
     compute_run_totals,
     download_results,
     get_batch_status,
+    get_classifier_identity,
     get_downloadable_batches,
     get_missing_results,
     get_pending_batches,
@@ -46,7 +47,7 @@ from pipeline.batch import (
     save_state,
     summarize_actual_usage,
 )
-from pipeline.results import build_sentiment_dataframe
+from pipeline.results import build_sentiment_dataframe, check_response_models
 from pipeline.schemas import SCHEMA_VERSION
 from utils.paths import get_batches_dir, get_filtered_dir, get_processed_dir
 from utils.player_config import load_player_config_version
@@ -386,6 +387,26 @@ def main() -> None:
     logger.info("=" * 60)
 
     try:
+        # Classifier identity (#90): recorded in state at submission,
+        # carried through every re-assembly unchanged. Cross-check and
+        # metadata are settled before the expensive join to fail fast.
+        metadata = {
+            "players_config_version": load_player_config_version(),
+            "schema_version": str(SCHEMA_VERSION),
+        }
+        identity = get_classifier_identity(state)
+        if identity is None:
+            logger.warning(
+                "state.json carries no classifier identity - sentiment.parquet "
+                "will have no classifier lineage stamp"
+            )
+        else:
+            check_response_models(responses_dir, identity["model"])
+            metadata["classifier_sentiment_model"] = identity["model"]
+            metadata["classifier_sentiment_prompt_version"] = identity[
+                "prompt_version"
+            ]
+
         sentiment_df, failed_requests = build_sentiment_dataframe(
             responses_dir, filtered_path
         )
@@ -393,13 +414,7 @@ def main() -> None:
         # Save parquet with config-lineage stamp (#54): mentioned_players
         # was re-derived under this config version at assembly
         processed_dir.mkdir(parents=True, exist_ok=True)
-        sentiment_df.write_parquet(
-            output_path,
-            metadata={
-                "players_config_version": load_player_config_version(),
-                "schema_version": str(SCHEMA_VERSION),
-            },
-        )
+        sentiment_df.write_parquet(output_path, metadata=metadata)
         logger.info(f"Wrote {len(sentiment_df)} rows to {output_path}")
 
         # Save failed requests

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -1843,3 +1843,60 @@ class TestAggregateMetadata:
         result = aggregate_sentiment(path)
 
         assert result["metadata"]["season"] == "2024-25"
+
+
+class TestClassifierLineage:
+    """Tests for the classifier identity stamp readback (#90)."""
+
+    ROWS = TestConfigVersionLineage.ROWS
+
+    def _classifier_warnings(self, caplog) -> list[str]:
+        """Extract WARNING messages about the classifier identity stamp."""
+        return [
+            record.message
+            for record in caplog.records
+            if record.levelno == logging.WARNING
+            and "classifier identity" in record.message
+        ]
+
+    def test_stamped_parquet_emits_no_warning(self, tmp_path, caplog):
+        """A parquet carrying both classifier keys stays silent."""
+        # Arrange
+        path = _make_test_parquet(
+            tmp_path,
+            self.ROWS,
+            metadata={
+                "players_config_version": load_player_config_version(),
+                "classifier_sentiment_model": "claude-haiku-4-5-20251001",
+                "classifier_sentiment_prompt_version": "v2-production+s-hint",
+            },
+        )
+
+        # Act
+        with caplog.at_level(logging.WARNING, logger="pipeline.aggregation"):
+            aggregate_sentiment(path)
+
+        # Assert
+        assert self._classifier_warnings(caplog) == []
+
+    def test_absent_stamp_warns(self, tmp_path, caplog):
+        """A parquet with no classifier identity warns once.
+
+        A birth certificate has nothing live to drift against, so
+        absence is the only warnable condition — no drift variant.
+        """
+        # Arrange
+        path = _make_test_parquet(
+            tmp_path,
+            self.ROWS,
+            metadata={"players_config_version": load_player_config_version()},
+        )
+
+        # Act
+        with caplog.at_level(logging.WARNING, logger="pipeline.aggregation"):
+            aggregate_sentiment(path)
+
+        # Assert
+        warnings = self._classifier_warnings(caplog)
+        assert len(warnings) == 1
+        assert "no classifier identity" in warnings[0]

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -3,6 +3,7 @@
 import hashlib
 import json
 from pathlib import Path
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -17,6 +18,7 @@ from pipeline.batch import (
     build_prompt,
     calculate_cost,
     compute_run_totals,
+    download_results,
     format_batch_request,
     get_downloadable_batches,
     get_exhausted_batches,
@@ -833,6 +835,8 @@ class TestNewBatchEntry:
         assert entry["actual_input_tokens"] == 0
         assert entry["actual_output_tokens"] == 0
         assert entry["actual_cost_usd"] == 0.0
+        assert entry["model"] == MODEL
+        assert entry["prompt_version"] == PROMPT_VERSION
 
 
 class TestNewFailedEntry:
@@ -851,6 +855,8 @@ class TestNewFailedEntry:
         assert entry["status"] == "failed"
         assert entry["failed"] is True
         assert entry["retry_count"] == 3
+        assert entry["model"] == MODEL
+        assert entry["prompt_version"] == PROMPT_VERSION
 
     def test_terminal_entry_is_exhausted_not_pending(self):
         """Verify the entry trips fail-fast and never enters the poll loop."""
@@ -912,6 +918,32 @@ class TestRecordRetryAttempt:
         batch["request_counts"] = _ended_counts(succeeded=100)
         assert get_retryable_batches(state, max_retries=3) == []
         assert [b["batch_num"] for b in get_downloadable_batches(state)] == [1]
+
+    def test_preserves_classifier_identity(self):
+        """Verify a resubmission never re-stamps model/prompt_version.
+
+        A retry replays the same request file, so the classifier identity
+        recorded at first submission still describes what runs.
+        """
+        batch = new_batch_entry(
+            batch_num=1,
+            request_file="batch_001.jsonl",
+            submit_result=_submit_result("msgbatch_old"),
+            submitted_at="2026-07-08T00:00:00+00:00",
+            estimated_cost_usd=1.25,
+        )
+        batch["model"] = "some-earlier-model"
+        batch["prompt_version"] = "some-earlier-label"
+
+        record_retry_attempt(
+            batch,
+            submit_result=_submit_result("msgbatch_retry"),
+            submitted_at="2026-07-08T01:00:00+00:00",
+            estimated_cost_usd=1.25,
+        )
+
+        assert batch["model"] == "some-earlier-model"
+        assert batch["prompt_version"] == "some-earlier-label"
 
     def test_terminal_failure_after_max_retries(self):
         """Verify a batch failing every retry becomes exhausted, not retryable.
@@ -1234,3 +1266,70 @@ class TestSaveState:
             loaded = json.load(f)
 
         assert loaded["total_input_tokens"] == 9999
+
+
+class TestDownloadResults:
+    """Tests for download_results result projection."""
+
+    @staticmethod
+    def _succeeded_entry(custom_id: str = "abc123") -> Mock:
+        """Build a mocked succeeded batch-result entry."""
+        message = Mock()
+        message.content = [Mock(text='{"s":"neg","c":0.9,"p":"Draymond Green"}')]
+        message.usage = Mock(input_tokens=60, output_tokens=20)
+        message.model = "claude-haiku-4-5-20251001"
+
+        entry = Mock()
+        entry.custom_id = custom_id
+        entry.result = Mock(type="succeeded", message=message)
+        return entry
+
+    @staticmethod
+    def _errored_entry(custom_id: str = "def456") -> Mock:
+        """Build a mocked errored batch-result entry."""
+        entry = Mock()
+        entry.custom_id = custom_id
+        entry.result = Mock(
+            type="errored",
+            error=Mock(error=Mock(type="invalid_request", message="bad input")),
+        )
+        return entry
+
+    def test_succeeded_projection_retains_model(self):
+        """Verify the succeeded projection keeps message.model.
+
+        The response-side model echo is the on-disk cross-check for the
+        classifier identity recorded in state at submission (#90).
+        """
+        with patch("pipeline.batch.anthropic.Anthropic") as mock_client:
+            mock_client.return_value.messages.batches.results.return_value = iter(
+                [self._succeeded_entry()]
+            )
+            results = download_results("msgbatch_test")
+
+        assert results == [
+            {
+                "custom_id": "abc123",
+                "result_type": "succeeded",
+                "content": '{"s":"neg","c":0.9,"p":"Draymond Green"}',
+                "input_tokens": 60,
+                "output_tokens": 20,
+                "model": "claude-haiku-4-5-20251001",
+            }
+        ]
+
+    def test_errored_projection_carries_error_only(self):
+        """Verify errored rows keep the error string and no usage fields."""
+        with patch("pipeline.batch.anthropic.Anthropic") as mock_client:
+            mock_client.return_value.messages.batches.results.return_value = iter(
+                [self._errored_entry()]
+            )
+            results = download_results("msgbatch_test")
+
+        assert results == [
+            {
+                "custom_id": "def456",
+                "result_type": "errored",
+                "error": "invalid_request: bad input",
+            }
+        ]

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -20,6 +20,7 @@ from pipeline.batch import (
     compute_run_totals,
     download_results,
     format_batch_request,
+    get_classifier_identity,
     get_downloadable_batches,
     get_exhausted_batches,
     get_missing_results,
@@ -1333,3 +1334,63 @@ class TestDownloadResults:
                 "error": "invalid_request: bad input",
             }
         ]
+
+
+class TestGetClassifierIdentity:
+    """Tests for get_classifier_identity state reads."""
+
+    @staticmethod
+    def _entry(model: str | None, prompt_version: str | None) -> dict:
+        """Build a minimal state entry with optional identity fields."""
+        entry = {"batch_num": 1, "request_file": "batch_001.jsonl"}
+        if model is not None:
+            entry["model"] = model
+        if prompt_version is not None:
+            entry["prompt_version"] = prompt_version
+        return entry
+
+    def test_uniform_identity_returned(self):
+        """Verify a uniformly stamped state yields the identity pair."""
+        state = init_state()
+        state["batches"] = [
+            self._entry(MODEL, PROMPT_VERSION),
+            self._entry(MODEL, PROMPT_VERSION),
+        ]
+
+        assert get_classifier_identity(state) == {
+            "model": MODEL,
+            "prompt_version": PROMPT_VERSION,
+        }
+
+    def test_absent_everywhere_returns_none(self):
+        """Verify pre-#90 state (no identity fields at all) yields None."""
+        state = init_state()
+        state["batches"] = [self._entry(None, None), self._entry(None, None)]
+
+        assert get_classifier_identity(state) is None
+
+    def test_empty_state_returns_none(self):
+        """Verify a state with no batches yields None."""
+        assert get_classifier_identity(init_state()) is None
+
+    def test_mixed_models_raise(self):
+        """Verify two distinct recorded models are rejected loudly."""
+        state = init_state()
+        state["batches"] = [
+            self._entry("model-a", PROMPT_VERSION),
+            self._entry("model-b", PROMPT_VERSION),
+        ]
+
+        with pytest.raises(ValueError, match="[Ii]nconsistent"):
+            get_classifier_identity(state)
+
+    def test_partial_presence_raises(self):
+        """Verify some-stamped/some-not state is rejected, not guessed at."""
+        state = init_state()
+        state["batches"] = [
+            self._entry(MODEL, PROMPT_VERSION),
+            self._entry(None, None),
+        ]
+
+        with pytest.raises(ValueError, match="[Ii]nconsistent"):
+            get_classifier_identity(state)

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -1,5 +1,6 @@
 """Tests for pipeline.batch module."""
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -9,6 +10,8 @@ from pipeline.batch import (
     DEFAULT_MAX_RETRIES,
     MAX_TOKENS,
     MODEL,
+    PROMPT_TEMPLATE,
+    PROMPT_VERSION,
     TEMPERATURE,
     backoff_delay,
     build_prompt,
@@ -93,6 +96,43 @@ class TestBuildPrompt:
 
         assert "Classify sentiment" in result
         assert "Comment:" in result
+
+
+class TestPromptVersionPin:
+    """Tests pinning PROMPT_VERSION to the frozen template text."""
+
+    def test_template_hash_matches_labeled_version(self):
+        """Verify the template's sha256 matches the pin for PROMPT_VERSION.
+
+        Any template edit is a new classifier: it requires a new
+        PROMPT_VERSION label, a new pinned hash, and a re-baselined
+        eval suite (tests/eval/cases.yaml floors are pinned to this text).
+        """
+        assert PROMPT_VERSION == "v2-production+s-hint"
+        assert (
+            hashlib.sha256(PROMPT_TEMPLATE.encode()).hexdigest()
+            == "2ae50c6125a9eb177967edf5fbddd07bc0f3b6431972686756408d82d29fd0ed"
+        )
+
+    def test_build_prompt_renders_template_exactly(self):
+        """Verify build_prompt output is byte-identical to the frozen render.
+
+        Guards the template-extraction refactor: the rendered prompt must
+        match what the pre-extraction f-string produced, byte for byte.
+        """
+        expected = (
+            "Classify sentiment toward NBA players.\n"
+            "Slang: nasty/sick/filthy=positive, washed/brick/fraud/cooked=negative,"
+            " GOAT=positive.\n"
+            'A trailing "/s" tags the comment as sarcasm.\n'
+            "\n"
+            "Comment: test body\n"
+            "\n"
+            'Respond ONLY with JSON: {"s":"pos|neg|neu","c":0.0-1.0,'
+            '"p":"Player Name"|null}'
+        )
+
+        assert build_prompt("test body") == expected
 
 
 class TestParseResponse:

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -7,21 +7,31 @@ from pathlib import Path
 import polars as pl
 import pytest
 
-from pipeline.results import build_sentiment_dataframe
+from pipeline.results import build_sentiment_dataframe, check_response_models
 from pipeline.schemas import COMMENT_INPUT_SCHEMA, SENTIMENT_SCHEMA
 
 
 def _succeeded(
-    custom_id: str, content: str, input_tokens: int = 100, output_tokens: int = 20
+    custom_id: str,
+    content: str,
+    input_tokens: int = 100,
+    output_tokens: int = 20,
+    model: str | None = None,
 ) -> dict:
-    """Build a succeeded entry shaped like download_results output."""
-    return {
+    """Build a succeeded entry shaped like download_results output.
+
+    model is optional: responses downloaded before #90 never persisted it.
+    """
+    entry = {
         "custom_id": custom_id,
         "result_type": "succeeded",
         "content": content,
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
     }
+    if model is not None:
+        entry["model"] = model
+    return entry
 
 
 def _errored(custom_id: str) -> dict:
@@ -33,10 +43,12 @@ def _errored(custom_id: str) -> dict:
     }
 
 
-def _write_results_file(responses_dir: Path, entries: list[dict]) -> None:
+def _write_results_file(
+    responses_dir: Path, entries: list[dict], batch_num: int = 1
+) -> None:
     """Write entries as a batch results JSONL file."""
     responses_dir.mkdir(exist_ok=True)
-    path = responses_dir / "batch_001_results.jsonl"
+    path = responses_dir / f"batch_{batch_num:03d}_results.jsonl"
     path.write_text("\n".join(json.dumps(entry) for entry in entries) + "\n")
 
 
@@ -369,3 +381,82 @@ class TestBuildSentimentDataframe:
         with pytest.raises(ValueError, match="sentiment.parquet") as exc:
             build_sentiment_dataframe(responses_dir, filtered_comments_file)
         assert "score" in str(exc.value)
+
+
+class TestCheckResponseModels:
+    """Tests for the response-side classifier identity cross-check."""
+
+    def test_matching_model_passes(self, tmp_path):
+        """Verify a model-bearing results file matching state is accepted."""
+        directory = tmp_path / "responses"
+        _write_results_file(
+            directory,
+            [
+                _errored("aaa111"),
+                _succeeded("abc123", '{"s":"pos","c":0.9,"p":null}', model="model-x"),
+            ],
+        )
+
+        check_response_models(directory, "model-x")
+
+    def test_mismatched_model_raises_naming_both(self, tmp_path):
+        """Verify a response model differing from state fails loudly."""
+        directory = tmp_path / "responses"
+        _write_results_file(
+            directory,
+            [_succeeded("abc123", '{"s":"pos","c":0.9,"p":null}', model="model-y")],
+        )
+
+        with pytest.raises(RuntimeError, match="model-y.*model-x"):
+            check_response_models(directory, "model-x")
+
+    def test_model_free_file_is_skipped(self, tmp_path):
+        """Verify pre-#90 responses (no model field anywhere) pass untouched."""
+        directory = tmp_path / "responses"
+        _write_results_file(
+            directory,
+            [_succeeded("abc123", '{"s":"pos","c":0.9,"p":null}'), _errored("def456")],
+        )
+
+        check_response_models(directory, "model-x")
+
+    def test_mismatch_in_later_file_raises(self, tmp_path):
+        """Verify every file is checked, not just the first."""
+        directory = tmp_path / "responses"
+        _write_results_file(
+            directory,
+            [_succeeded("abc123", '{"s":"pos","c":0.9,"p":null}', model="model-x")],
+            batch_num=1,
+        )
+        _write_results_file(
+            directory,
+            [_succeeded("def456", '{"s":"neu","c":0.5,"p":null}', model="model-y")],
+            batch_num=2,
+        )
+
+        with pytest.raises(RuntimeError, match="batch_002.*model-y"):
+            check_response_models(directory, "model-x")
+
+    def test_mismatch_past_line_cap_is_skipped(self, tmp_path):
+        """Pin the 1000-line cap: a model echo past it is never scanned.
+
+        The cap keeps field-free legacy files cheap to skip; this test
+        locks the trade-off in so a refactor can't silently change it.
+        """
+        directory = tmp_path / "responses"
+        entries = [_errored(f"e{i}") for i in range(1000)]
+        entries.append(
+            _succeeded("abc123", '{"s":"pos","c":0.9,"p":null}', model="model-y")
+        )
+        _write_results_file(directory, entries)
+
+        check_response_models(directory, "model-x")
+
+    def test_malformed_line_raises_with_filename(self, tmp_path):
+        """Verify a malformed scanned line fails with file context."""
+        directory = tmp_path / "responses"
+        directory.mkdir()
+        (directory / "batch_001_results.jsonl").write_text("not json\n")
+
+        with pytest.raises(ValueError, match="Malformed JSON in batch_001"):
+            check_response_models(directory, "model-x")


### PR DESCRIPTION
Closes #90.

Classifier identity is a birth certificate, not a cache stamp: `{model, prompt_version}` describes the frozen, $-backed layer, minted at batch time and carried through re-assembly unchanged. Three commits, dependency-first:

1. **`PROMPT_TEMPLATE` + `PROMPT_VERSION`** (`"v2-production+s-hint"`, the eval suite's vocabulary per #62/PR #68) with a sha256 hash-pin test and an exact-render test proving the extraction is byte-identical.
2. **Record-at-submission**: `new_batch_entry`/`new_failed_entry` stamp the pair from module constants at the submission event; retries never re-stamp (same request file → same identity); `download_results` retains `message.model`, enabling the response-side cross-check from 2026-27 on.
3. **Collect-side stamping**: `get_classifier_identity(state)` (uniform pair, `None` for pre-#90 state, loud on inconsistency) → `classifier_sentiment_model` / `classifier_sentiment_prompt_version` parquet metadata beside the config stamps; `check_response_models` cross-checks on-disk echoes where present; aggregation warns on absence only — a birth certificate has nothing live to drift against. No `SCHEMA_VERSION` bump (metadata-only). Keys are per-stage from birth; #91 adds `classifier_target_*`, #89 consolidates the registry.

## v2 retro-stamp (executed, request-file evidence)

- **Evidence pass, full coverage**: all 22 request files, **2,110,485 lines** (the exact submitted population) — `params.model == claude-haiku-4-5-20251001` on every line (0 mismatches); every rendered prompt matches the frozen template's prefix/suffix split at `{comment_body}` (0 mismatches).
- **state.json backfilled** (22 entries, original backed up); readback verified through `get_classifier_identity`.
- **Re-assembly**: 2,110,479 rows; old-vs-new `df.equals()` **True** (data bit-for-bit identical); metadata diff shows exactly the two classifier keys added, nothing changed or removed.
- **Aggregation**: no lineage warnings; all 7 dashboard parquets byte-identical (`cmp`), `aggregates.json` identical modulo `generated_at`.

Review pass (code-reviewer): 0 must-fix; folded on-branch — malformed-JSON wrapping + script error-handling convention in the cross-check path, plus tests pinning the 1000-line cap, multi-file coverage, and malformed-line context.

Out of scope: v1 stamps (backfill event), any prompt change, #91's run.

524 tests green; every commit passes the gate alone.