### PR TITLE
fix(api): parse_response keeps the label on a non-numeric confidence

### DIFF
--- a/pipeline/batch.py
+++ b/pipeline/batch.py
@@ -79,6 +79,7 @@ def parse_response(text: str) -> dict:
 
     Returns:
         Success: {"s": "pos|neg|neu", "c": float, "p": str|None}
+        A non-numeric "c" reads 0.0; the label is never invalidated by it.
         A rare list-valued "p" (#71) is normalized — a single-string list
         unwraps, anything else becomes None — and the original list is
         preserved under "p_raw" so callers can log the occurrence.
@@ -118,11 +119,12 @@ def parse_response(text: str) -> dict:
         if sentiment not in ("pos", "neg", "neu"):
             return {"s": "error", "c": 0.0, "p": None, "raw": text}
 
-        parsed = {
-            "s": result["s"],
-            "c": float(result.get("c", 0.0)),
-            "p": result.get("p"),
-        }
+        # A non-numeric c must not cost the label: degrade to 0.0, keep s/p
+        try:
+            confidence = float(result.get("c", 0.0))
+        except (TypeError, ValueError):
+            confidence = 0.0
+        parsed = {"s": result["s"], "c": confidence, "p": result.get("p")}
 
         # Normalize rare list-valued player field (#71): unwrap a
         # single-string list, drop anything else; keep the original

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -223,6 +223,19 @@ class TestParseResponse:
 
         assert result == {"s": "pos", "c": 0.9, "p": "LeBron James"}
 
+    @pytest.mark.parametrize(
+        "raw_c",
+        ['"high"', '["0.9"]', '{"value": 0.9}', '"0.9.1"'],
+    )
+    def test_non_numeric_c_reads_zero(self, raw_c: str):
+        """Verify a non-numeric c degrades to 0.0 without invalidating the label (#94).
+
+        A bad confidence must not turn a usable label into an error row.
+        """
+        result = parse_response(f'{{"s": "neg", "c": {raw_c}, "p": "LeBron James"}}')
+
+        assert result == {"s": "neg", "c": 0.0, "p": "LeBron James"}
+
 
 class TestCalculateCost:
     """Tests for calculate_cost function."""


### PR DESCRIPTION
Closes #94.

A non-numeric `c` (`"high"`, a list, an object, a malformed numeric string) was caught by the parser's outer `except` and degraded the whole response to an error row, discarding a usable `s`/`p`. The coercion is now wrapped so `c` reads `0.0` and the label survives, matching `parse_target_response`.

**Ticket premise correction:** #94 says the parser raises and would abort collection. It doesn't; the outer `except` swallows it. The defect was a silently discarded label, not a crash. Same fix.

- Test: `TestParseResponse::test_non_numeric_c_reads_zero`, parametrized over the four shapes.
- No `PROMPT_VERSION` or schema change.
- Format drift in both files is pre-existing and left untouched.
