### PR TITLE
feat(pipeline): target stage run — pool, prepare, sidecar assembly; 2025-26 verdicts produced (#91 step 3, PR A)

### DIFF
--- a/pipeline/aggregation.py
+++ b/pipeline/aggregation.py
@@ -159,26 +159,25 @@ def compute_metrics(df: pl.DataFrame, group_cols: list[str]) -> pl.DataFrame:
     return grouped.sort(group_cols)
 
 
-def aggregate_sentiment(input_path: Path) -> dict:
+def load_attributed_frame(input_path: Path) -> tuple[pl.DataFrame, int]:
     """
-    Aggregate classified sentiment data into dashboard-ready JSON.
+    Load the fact and derive its config-versioned attributes.
 
-    Reads the sentiment parquet, attributes comments to players,
-    extracts team flair, and computes all aggregation views.
+    Reads sentiment.parquet, validates it, warns on missing or drifted
+    lineage stamps, drops error rows, and adds attributed_player (via
+    resolve_player under the active alias map), team (fan role, from
+    flair), and week. This is the frame every consumer of the model
+    starts from: the aggregate views, the receipts pool, and analysis.
 
     Args:
-        input_path: Path to sentiment.parquet file.
+        input_path: Path to sentiment.parquet.
 
     Returns:
-        Dict where player_overall, player_temporal, player_team,
-        team_overall, players, teams, and comment_samples hold
-        pl.DataFrames conforming to DASHBOARD_OUTPUT_SCHEMAS; metadata is
-        a dict. The legacy player_metadata dict is reconstructed at
-        serialization time via players_to_metadata_dict().
+        Tuple of (frame with attributed_player, team, and week columns
+        added; count of error rows excluded).
 
     Raises:
-        ValueError: If the input parquet does not match SENTIMENT_SCHEMA,
-            or a computed output does not match its schema contract.
+        ValueError: If the input parquet does not match SENTIMENT_SCHEMA.
     """
     logger.info(f"Loading sentiment data from {input_path}")
     df = pl.read_parquet(input_path)
@@ -225,8 +224,6 @@ def aggregate_sentiment(input_path: Path) -> dict:
     # Build lookup maps
     alias_map = build_alias_to_player_map()
     team_map = build_alias_to_team_map()
-    player_metadata = load_player_metadata()
-    team_config = load_team_config()
 
     # Player attribution
     logger.info("Attributing comments to players...")
@@ -265,6 +262,37 @@ def aggregate_sentiment(input_path: Path) -> dict:
 
     # Temporal prep: convert created_utc to datetime, truncate to week (Monday)
     df = df.with_columns(pl.from_epoch("created_utc").dt.truncate("1w").alias("week"))
+
+    return df, excluded_rows
+
+
+def aggregate_sentiment(input_path: Path) -> dict:
+    """
+    Aggregate classified sentiment data into dashboard-ready JSON.
+
+    Reads the sentiment parquet, attributes comments to players,
+    extracts team flair, and computes all aggregation views.
+
+    Args:
+        input_path: Path to sentiment.parquet file.
+
+    Returns:
+        Dict where player_overall, player_temporal, player_team,
+        team_overall, players, teams, and comment_samples hold
+        pl.DataFrames conforming to DASHBOARD_OUTPUT_SCHEMAS; metadata is
+        a dict. The legacy player_metadata dict is reconstructed at
+        serialization time via players_to_metadata_dict().
+
+    Raises:
+        ValueError: If the input parquet does not match SENTIMENT_SCHEMA,
+            or a computed output does not match its schema contract.
+    """
+    df, excluded_rows = load_attributed_frame(input_path)
+    usable_rows = len(df)
+    total_rows = usable_rows + excluded_rows
+    attributed_count = df.filter(pl.col("attributed_player").is_not_null()).height
+    player_metadata = load_player_metadata()
+    team_config = load_team_config()
 
     # --- Aggregation views ---
 

--- a/pipeline/aggregation.py
+++ b/pipeline/aggregation.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import polars as pl
 
+from pipeline.receipts import select_receipt_candidates
 from pipeline.schemas import (
     COMMENT_SAMPLES_SCHEMA,
     DASHBOARD_OUTPUT_SCHEMAS,
@@ -423,15 +424,11 @@ def build_comment_samples(
     """
     Select the comment samples: top-N receipts per player x sentiment.
 
-    Candidacy: body no longer than max_body_chars and, for pos/neg,
-    confidence at or above min_confidence and a named sentiment_player.
-    Neutral rows are exempt from both polar gates - the classifier
-    reports a conventional 0.5 for neu and routinely omits the target on
-    neutral comments; a polar row with no stated target is the ambiguity
-    class a receipt can't carry. Within each (attributed_player,
-    sentiment) cell, duplicate bodies collapse to the best-ranked copy,
-    rows rank by score desc (ties: confidence desc, comment_id asc,
-    nulls last) and the top n are kept; thin cells are never padded.
+    Candidacy and ranking are select_receipt_candidates with the target
+    gate on: a polar row with no stated target is the ambiguity class a
+    receipt can't carry, while neutral rows are exempt from both polar
+    gates (the classifier reports a conventional 0.5 for neu and
+    routinely omits the target there). Thin cells are never padded.
     Bodies are verbatim.
 
     Args:
@@ -447,38 +444,10 @@ def build_comment_samples(
         (attributed_player, sentiment, rank).
     """
     cell = ["attributed_player", "sentiment"]
-
-    passes_floor = (pl.col("sentiment") == "neu") | (
-        pl.col("confidence") >= min_confidence
-    )
-    has_target = (pl.col("sentiment") == "neu") | pl.col(
-        "sentiment_player"
-    ).is_not_null()
-    within_cap = pl.col("body").str.len_chars() <= max_body_chars
-    candidates = df.filter(passes_floor & has_target & within_cap)
-    if df.height:
-        below_floor = df.filter(~passes_floor).height
-        no_target = df.filter(passes_floor & ~has_target).height
-        over_cap = df.filter(passes_floor & has_target & ~within_cap).height
-        logger.info(
-            f"comment_samples candidacy: {df.height:,} attributed rows; "
-            f"{below_floor:,} ({below_floor / df.height:.1%}) removed by the "
-            f"pos/neg confidence floor {min_confidence}, "
-            f"{no_target:,} ({no_target / df.height:.1%}) removed by the "
-            f"pos/neg target gate, "
-            f"{over_cap:,} ({over_cap / df.height:.1%}) removed by the "
-            f"{max_body_chars}-char body cap; {candidates.height:,} candidates"
-        )
-
     return (
-        candidates.sort(
-            ["score", "confidence", "comment_id"],
-            descending=[True, True, False],
-            nulls_last=True,
+        select_receipt_candidates(
+            df, n=n, min_confidence=min_confidence, max_body_chars=max_body_chars
         )
-        .unique(subset=[*cell, "body"], keep="first", maintain_order=True)
-        .with_columns((pl.int_range(pl.len()).over(cell) + 1).alias("rank"))
-        .filter(pl.col("rank") <= n)
         .rename({"team": "fan_team"})
         .select(COMMENT_SAMPLES_SCHEMA.names())
         .sort([*cell, "rank"])

--- a/pipeline/batch.py
+++ b/pipeline/batch.py
@@ -100,6 +100,26 @@ def format_batch_request(
     }
 
 
+def write_request_file(output_dir: Path, batch_num: int, requests: list[dict]) -> Path:
+    """
+    Write one batch of requests as batch_NNN.jsonl.
+
+    Args:
+        output_dir: Directory to write into (created if missing).
+        batch_num: 1-based batch number for the filename.
+        requests: Request dicts as returned by format_batch_request.
+
+    Returns:
+        Path of the file written.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / f"batch_{batch_num:03d}.jsonl"
+    with open(path, "w") as f:
+        for request in requests:
+            f.write(json.dumps(request) + "\n")
+    return path
+
+
 # -----------------------------------------------------------------------------
 # State management
 # -----------------------------------------------------------------------------

--- a/pipeline/receipts.py
+++ b/pipeline/receipts.py
@@ -67,8 +67,9 @@ def select_receipt_candidates(
         below_floor = df.filter(~passes_floor).height
         no_target = df.filter(passes_floor & ~has_target).height
         over_cap = df.filter(passes_floor & has_target & ~within_cap).height
+        gate = "on" if require_target else "lifted"
         logger.info(
-            f"comment_samples candidacy: {df.height:,} attributed rows; "
+            f"receipt candidacy (target gate {gate}): {df.height:,} attributed rows; "
             f"{below_floor:,} ({below_floor / df.height:.1%}) removed by the "
             f"pos/neg confidence floor {min_confidence}, "
             f"{no_target:,} ({no_target / df.height:.1%}) removed by the "

--- a/pipeline/receipts.py
+++ b/pipeline/receipts.py
@@ -1,0 +1,158 @@
+"""The receipts: which comments stand for a player's sentiment.
+
+Candidate selection shared by the shipped comment_samples file and the
+target-verifier pool, so the two are the same computation by
+construction: the samples apply the classifier's target gate; the pool
+lifts it so named and unnamed rows compete for verification in one
+ranking.
+"""
+
+import logging
+
+import polars as pl
+
+from pipeline.schemas import TARGET_POOL_SCHEMA
+from utils.constants import (
+    COMMENT_SAMPLES_MAX_BODY_CHARS,
+    COMMENT_SAMPLES_MIN_CONFIDENCE,
+    TARGET_POOL_SEED,
+    TARGET_POOL_STRATA,
+    TARGET_POOL_STRATUM_N,
+)
+
+logger = logging.getLogger(__name__)
+
+POLAR_SENTIMENTS = ("pos", "neg")
+CELL = ["attributed_player", "sentiment"]
+
+
+def select_receipt_candidates(
+    df: pl.DataFrame,
+    *,
+    n: int,
+    min_confidence: float = COMMENT_SAMPLES_MIN_CONFIDENCE,
+    max_body_chars: int = COMMENT_SAMPLES_MAX_BODY_CHARS,
+    require_target: bool = True,
+) -> pl.DataFrame:
+    """
+    Rank receipt candidates and keep the top n per player x sentiment.
+
+    Candidacy: body no longer than max_body_chars and, for pos/neg,
+    confidence at or above min_confidence and (when require_target) a
+    named sentiment_player. Neutral rows are exempt from the polar gates.
+    Within each cell, duplicate bodies collapse to the best-ranked copy,
+    rows rank by score desc (ties: confidence desc, comment_id asc, nulls
+    last) and the top n are kept; thin cells are never padded.
+
+    Args:
+        df: Attributed frame with attributed_player, sentiment,
+            sentiment_player, comment_id, body, score, confidence.
+        n: Maximum rows per (attributed_player, sentiment) cell.
+        min_confidence: Candidacy floor on confidence, pos/neg rows only.
+        max_body_chars: Candidacy cap on body length, in characters.
+        require_target: Apply the pos/neg named-sentiment_player gate.
+
+    Returns:
+        The candidate rows with a rank column (1..n within the cell), in
+        input column order plus rank, unsorted beyond the ranking.
+    """
+    is_neu = pl.col("sentiment") == "neu"
+    passes_floor = is_neu | (pl.col("confidence") >= min_confidence)
+    has_target = is_neu | pl.col("sentiment_player").is_not_null()
+    if not require_target:
+        has_target = pl.lit(True)
+    within_cap = pl.col("body").str.len_chars() <= max_body_chars
+    candidates = df.filter(passes_floor & has_target & within_cap)
+    if df.height:
+        below_floor = df.filter(~passes_floor).height
+        no_target = df.filter(passes_floor & ~has_target).height
+        over_cap = df.filter(passes_floor & has_target & ~within_cap).height
+        logger.info(
+            f"comment_samples candidacy: {df.height:,} attributed rows; "
+            f"{below_floor:,} ({below_floor / df.height:.1%}) removed by the "
+            f"pos/neg confidence floor {min_confidence}, "
+            f"{no_target:,} ({no_target / df.height:.1%}) removed by the "
+            f"pos/neg target gate, "
+            f"{over_cap:,} ({over_cap / df.height:.1%}) removed by the "
+            f"{max_body_chars}-char body cap; {candidates.height:,} candidates"
+        )
+
+    return (
+        candidates.sort(
+            ["score", "confidence", "comment_id"],
+            descending=[True, True, False],
+            nulls_last=True,
+        )
+        .unique(subset=[*CELL, "body"], keep="first", maintain_order=True)
+        .with_columns((pl.int_range(pl.len()).over(CELL) + 1).alias("rank"))
+        .filter(pl.col("rank") <= n)
+    )
+
+
+def build_target_pool(
+    df: pl.DataFrame,
+    *,
+    k: int,
+    stratum_n: int = TARGET_POOL_STRATUM_N,
+    seed: int = TARGET_POOL_SEED,
+) -> pl.DataFrame:
+    """
+    Select the comments the target verifier screens, plus evidence strata.
+
+    Candidates are the top-k polar receipts per player x sentiment with
+    the target gate lifted, so rows the classifier left unnamed can be
+    re-admitted by the verifier. Two seeded random strata of attributed
+    polar rows ride the same run as evidence only: named-sentiment_player
+    rows (class-2 prevalence at the aggregate level) and NULL rows (the
+    class-1 split the resolve_player decision needs). A comment appears
+    once; the candidate stratum wins a collision.
+
+    Args:
+        df: The attributed frame from load_attributed_frame (unattributed
+            rows are ignored).
+        k: Candidate-pool depth per cell.
+        stratum_n: Rows per random stratum (capped by availability).
+        seed: Sampling seed, so the pool is reproducible.
+
+    Returns:
+        Frame conforming to TARGET_POOL_SCHEMA, sorted by stratum, cell,
+        rank, comment_id.
+    """
+    polar = df.filter(
+        pl.col("attributed_player").is_not_null()
+        & pl.col("sentiment").is_in(POLAR_SENTIMENTS)
+    )
+
+    candidates = (
+        select_receipt_candidates(polar, n=k, require_target=False)
+        .with_columns(pl.lit(TARGET_POOL_STRATA[0]).alias("stratum"))
+        .select(TARGET_POOL_SCHEMA.names())
+    )
+
+    remaining = polar.join(candidates.select("comment_id"), on="comment_id", how="anti")
+    named = remaining.filter(pl.col("sentiment_player").is_not_null())
+    unnamed = remaining.filter(pl.col("sentiment_player").is_null())
+    strata = [
+        stratum_df.sample(n=min(stratum_n, stratum_df.height), seed=seed)
+        .with_columns(
+            pl.lit(label).alias("stratum"), pl.lit(None, dtype=pl.Int64).alias("rank")
+        )
+        .select(TARGET_POOL_SCHEMA.names())
+        for stratum_df, label in (
+            (named, TARGET_POOL_STRATA[1]),
+            (unnamed, TARGET_POOL_STRATA[2]),
+        )
+    ]
+
+    pool = pl.concat([candidates, *strata]).sort(
+        ["stratum", *CELL, "rank", "comment_id"], nulls_last=True
+    )
+    counts = pool.group_by("stratum").len().sort("stratum")
+    logger.info(
+        f"target pool: {pool.height:,} rows over "
+        f"{pool['attributed_player'].n_unique()} players; "
+        + ", ".join(
+            f"{r['stratum']} {r['len']:,}" for r in counts.iter_rows(named=True)
+        )
+    )
+    return pool

--- a/pipeline/results.py
+++ b/pipeline/results.py
@@ -282,6 +282,12 @@ def build_targets_dataframe(
         },
     )
 
+    duplicates = verdicts_df.height - verdicts_df["comment_id"].n_unique()
+    if duplicates:
+        raise ValueError(
+            f"{duplicates} duplicate verdict(s) across the results files; the "
+            f"sidecar's grain is one row per comment"
+        )
     unknown = verdicts_df.join(pool.select("comment_id"), on="comment_id", how="anti")
     if unknown.height:
         raise ValueError(

--- a/pipeline/results.py
+++ b/pipeline/results.py
@@ -1,8 +1,10 @@
 """
-Assemble batch classification results into the sentiment DataFrame.
+Assemble batch classification results into produced frames.
 
-Joins parsed Batch API results with filtered comment metadata and
-enforces SENTIMENT_SCHEMA at the sentiment.parquet write boundary.
+The sentiment stage joins parsed results with filtered comment metadata
+(sentiment.parquet, SENTIMENT_SCHEMA); the target stage joins parsed
+verdicts with the pool that was sent (sentiment_targets.parquet,
+SENTIMENT_TARGETS_SCHEMA). Both enforce their schema at the write boundary.
 """
 
 import json
@@ -11,14 +13,17 @@ from pathlib import Path
 
 import polars as pl
 
-from pipeline.sentiment import parse_response
 from pipeline.processors import find_player_mentions
 from pipeline.schemas import (
     COMMENT_INPUT_SCHEMA,
     RESULTS_SCHEMA,
     SENTIMENT_SCHEMA,
+    SENTIMENT_TARGETS_SCHEMA,
+    TARGET_POOL_SCHEMA,
     validate_schema,
 )
+from pipeline.sentiment import parse_response
+from pipeline.targets import parse_target_response
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +75,38 @@ def check_response_models(responses_dir: Path, expected_model: str) -> None:
         logger.info(f"Response model cross-check passed for {checked} file(s)")
 
 
+def _iter_results(responses_dir: Path):
+    """
+    Yield every downloaded result dict across a stage's results files.
+
+    Args:
+        responses_dir: Directory containing batch_NNN_results.jsonl files.
+
+    Yields:
+        Result dicts as written by download_results.
+
+    Raises:
+        FileNotFoundError: If no results files exist in responses_dir.
+        ValueError: If a results file contains malformed JSON.
+    """
+    results_files = sorted(responses_dir.glob("batch_*_results.jsonl"))
+    if not results_files:
+        raise FileNotFoundError(f"No results files found in {responses_dir}")
+
+    logger.info(f"Loading results from {len(results_files)} files...")
+    for results_file in results_files:
+        with open(results_file) as f:
+            for line in f:
+                if not line.strip():
+                    continue
+                try:
+                    yield json.loads(line)
+                except json.JSONDecodeError as e:
+                    raise ValueError(
+                        f"Malformed JSON in {results_file.name}: {e}"
+                    ) from e
+
+
 def build_sentiment_dataframe(
     responses_dir: Path, filtered_path: Path
 ) -> tuple[pl.DataFrame, list[dict]]:
@@ -100,49 +137,31 @@ def build_sentiment_dataframe(
         ValueError: If a results file contains malformed JSON, or the
             assembled frame does not match SENTIMENT_SCHEMA.
     """
-    # Load all results
-    results_files = sorted(responses_dir.glob("batch_*_results.jsonl"))
-    if not results_files:
-        raise FileNotFoundError(f"No results files found in {responses_dir}")
-
-    logger.info(f"Loading results from {len(results_files)} files...")
-
     all_results = []
     failed_requests = []
     normalized_count = 0
 
-    for results_file in results_files:
-        with open(results_file) as f:
-            for line in f:
-                if not line.strip():
-                    continue
-                try:
-                    result = json.loads(line)
-                except json.JSONDecodeError as e:
-                    raise ValueError(
-                        f"Malformed JSON in {results_file.name}: {e}"
-                    ) from e
-
-                if result["result_type"] == "succeeded":
-                    parsed = parse_response(result["content"])
-                    if "p_raw" in parsed:
-                        normalized_count += 1
-                        logger.warning(
-                            f"Normalized list-valued p {parsed['p_raw']!r} -> "
-                            f"{parsed['p']!r} for {result['custom_id']}"
-                        )
-                    all_results.append(
-                        {
-                            "id": result["custom_id"],
-                            "sentiment": parsed["s"],
-                            "confidence": parsed["c"],
-                            "sentiment_player": parsed.get("p"),
-                            "input_tokens": result["input_tokens"],
-                            "output_tokens": result["output_tokens"],
-                        }
-                    )
-                else:
-                    failed_requests.append(result)
+    for result in _iter_results(responses_dir):
+        if result["result_type"] != "succeeded":
+            failed_requests.append(result)
+            continue
+        parsed = parse_response(result["content"])
+        if "p_raw" in parsed:
+            normalized_count += 1
+            logger.warning(
+                f"Normalized list-valued p {parsed['p_raw']!r} -> "
+                f"{parsed['p']!r} for {result['custom_id']}"
+            )
+        all_results.append(
+            {
+                "id": result["custom_id"],
+                "sentiment": parsed["s"],
+                "confidence": parsed["c"],
+                "sentiment_player": parsed.get("p"),
+                "input_tokens": result["input_tokens"],
+                "output_tokens": result["output_tokens"],
+            }
+        )
 
     logger.info(f"Loaded {len(all_results)} successful results")
     if normalized_count:
@@ -186,3 +205,101 @@ def build_sentiment_dataframe(
     validate_schema(joined_df, SENTIMENT_SCHEMA, "sentiment.parquet")
 
     return joined_df, failed_requests
+
+
+def build_targets_dataframe(
+    responses_dir: Path, pool_path: Path
+) -> tuple[pl.DataFrame, list[dict]]:
+    """
+    Build the verdict sidecar by joining parsed verdicts to the pool.
+
+    The pool records what was sent and why; each succeeded response
+    contributes the model's raw target string, confidence, and parse
+    validity. A parse failure is kept as a row with valid=False, never
+    read as a null verdict. Pool rows whose request did not succeed are
+    absent from the sidecar (they are the failed requests).
+
+    Args:
+        responses_dir: Directory containing batch_NNN_results.jsonl files.
+        pool_path: Path to the pool parquet written at prepare time.
+
+    Returns:
+        Tuple of (frame conforming to SENTIMENT_TARGETS_SCHEMA, sorted as
+        the pool; list of failed request results).
+
+    Raises:
+        FileNotFoundError: If no results files exist in responses_dir.
+        ValueError: If a results file contains malformed JSON, the pool
+            does not match TARGET_POOL_SCHEMA, or the assembled frame does
+            not match SENTIMENT_TARGETS_SCHEMA.
+    """
+    pool = pl.read_parquet(pool_path)
+    validate_schema(pool, TARGET_POOL_SCHEMA, str(pool_path))
+
+    verdicts = []
+    failed_requests = []
+    invalid_count = 0
+    normalized_count = 0
+    for result in _iter_results(responses_dir):
+        if result["result_type"] != "succeeded":
+            failed_requests.append(result)
+            continue
+        parsed = parse_target_response(result["content"])
+        if not parsed["valid"]:
+            invalid_count += 1
+        if "t_raw" in parsed:
+            normalized_count += 1
+            logger.warning(
+                f"Normalized list-valued t {parsed['t_raw']!r} -> "
+                f"{parsed['t']!r} for {result['custom_id']}"
+            )
+        verdicts.append(
+            {
+                "comment_id": result["custom_id"],
+                "target_raw": parsed["t"],
+                "target_confidence": parsed["c"],
+                "valid": parsed["valid"],
+                "input_tokens": result["input_tokens"],
+                "output_tokens": result["output_tokens"],
+            }
+        )
+
+    logger.info(f"Loaded {len(verdicts)} verdicts")
+    if invalid_count:
+        logger.warning(f"{invalid_count} verdict(s) did not parse (valid=False)")
+    if normalized_count:
+        logger.warning(f"Normalized {normalized_count} list-valued t field(s)")
+    if failed_requests:
+        logger.warning(f"Found {len(failed_requests)} failed requests")
+
+    verdict_columns = [
+        c for c in SENTIMENT_TARGETS_SCHEMA.names() if c not in pool.columns
+    ]
+    verdicts_df = pl.DataFrame(
+        verdicts,
+        schema={
+            c: SENTIMENT_TARGETS_SCHEMA[c] for c in ["comment_id", *verdict_columns]
+        },
+    )
+
+    unknown = verdicts_df.join(pool.select("comment_id"), on="comment_id", how="anti")
+    if unknown.height:
+        raise ValueError(
+            f"{unknown.height} verdict(s) have no pool row (responses and pool "
+            f"disagree): {unknown['comment_id'].head(5).to_list()}"
+        )
+
+    targets = pool.join(
+        verdicts_df, on="comment_id", how="inner", maintain_order="left"
+    ).select(SENTIMENT_TARGETS_SCHEMA.names())
+    missing = pool.height - targets.height
+    if missing:
+        logger.warning(
+            f"{missing} pool row(s) have no verdict "
+            f"({missing / pool.height:.1%} of the pool)"
+        )
+    logger.info(f"Final sidecar: {targets.height} rows")
+
+    validate_schema(targets, SENTIMENT_TARGETS_SCHEMA, "sentiment_targets.parquet")
+
+    return targets, failed_requests

--- a/pipeline/schemas.py
+++ b/pipeline/schemas.py
@@ -16,6 +16,9 @@ pipeline produces. Data dictionary first, enforcement second:
 - PLAYERS_SCHEMA describes the Player dimension (players.parquet),
   config curation joined with snapshot facts; enforced in
   aggregate_sentiment() via the unified DASHBOARD_OUTPUT_SCHEMAS loop.
+- TARGET_POOL_SCHEMA / SENTIMENT_TARGETS_SCHEMA describe the target
+  verifier's pool and its verdict sidecar (pipeline/receipts.py,
+  pipeline/results.py).
 - COMMENT_SAMPLES_SCHEMA describes the comment-samples fact subset
   (comment_samples.parquet): verbatim rows of the fact, selected not
   aggregated; enforced via the same unified loop.
@@ -245,6 +248,34 @@ COMMENT_SAMPLES_SCHEMA = pl.Schema(
         "score": pl.Int64,
         "created_utc": pl.Int64,  # epoch seconds, as the fact
         "fan_team": pl.String,  # nullable; fan role of Team, role-marked
+    }
+)
+
+# The target-verifier pool (data/<season>/batches/<stage>/pool.parquet):
+# which comments were sent to the verifier and why. attributed_player and
+# rank are pool-time snapshots under the config the pool was built with.
+TARGET_POOL_SCHEMA = pl.Schema(
+    {
+        "comment_id": pl.String,  # FK -> sentiment.parquet; the request custom_id
+        "attributed_player": pl.String,  # at pool time
+        "sentiment": pl.String,  # "pos" | "neg", the prompt input
+        "stratum": pl.String,  # candidate | random_named | random_null
+        "rank": pl.Int64,  # candidate rank within the cell; null for strata rows
+    }
+)
+
+# The verifier's verdicts (data/<season>/processed/sentiment_targets.parquet):
+# the pool joined to the model's response, one row per verified comment.
+# target_raw is the model's string, frozen; resolution to a canonical
+# player is config-derived and happens at aggregation.
+SENTIMENT_TARGETS_SCHEMA = pl.Schema(
+    {
+        **TARGET_POOL_SCHEMA,
+        "target_raw": pl.String,  # nullable: null = no player target
+        "target_confidence": pl.Float64,
+        "valid": pl.Boolean,  # False = the response did not parse
+        "input_tokens": pl.Int64,
+        "output_tokens": pl.Int64,
     }
 )
 

--- a/pipeline/stage.py
+++ b/pipeline/stage.py
@@ -51,6 +51,14 @@ class ClassifierStage:
     output_cost_per_mtok: float
     avg_input_tokens: int
 
+    @property
+    def stamp_keys(self) -> tuple[str, str]:
+        """Parquet metadata keys for this stage's model and prompt_version."""
+        return (
+            f"classifier_{self.name}_model",
+            f"classifier_{self.name}_prompt_version",
+        )
+
     def __post_init__(self) -> None:
         """Reject sampling params that would clobber the request's own keys."""
         clash = _RESERVED_REQUEST_KEYS & set(self.sampling_params)

--- a/scripts/collect_results.py
+++ b/scripts/collect_results.py
@@ -20,8 +20,9 @@ Output:
     - data/processed/sentiment.parquet (final joined output)
     - data/<season>/batches/<stage>/failed_requests.jsonl (if any failures)
 
-Only the sentiment stage has an assembly step; other stages stop after
-downloading (their sidecar builders land with their tickets).
+Assembly per stage: sentiment joins results to the filtered comments
+(sentiment.parquet); target joins verdicts to the pool prepared by
+prepare_targets (sentiment_targets.parquet).
 """
 
 import argparse
@@ -31,6 +32,7 @@ import sys
 import time
 from pathlib import Path
 
+import polars as pl
 from dotenv import load_dotenv
 
 from pipeline.batch import (
@@ -50,7 +52,11 @@ from pipeline.batch import (
     save_state,
     summarize_actual_usage,
 )
-from pipeline.results import build_sentiment_dataframe, check_response_models
+from pipeline.results import (
+    build_sentiment_dataframe,
+    build_targets_dataframe,
+    check_response_models,
+)
 from pipeline.schemas import SCHEMA_VERSION
 from pipeline.stage import STAGE_NAMES, ClassifierStage, get_stage
 from utils.paths import get_batches_dir, get_filtered_dir, get_processed_dir
@@ -73,7 +79,11 @@ logger = logging.getLogger(__name__)
 # -----------------------------------------------------------------------------
 
 FILTERED_FILENAME = "r_nba_player_mentions.jsonl"
-OUTPUT_FILENAME = "sentiment.parquet"
+POOL_FILENAME = "pool.parquet"
+OUTPUT_FILENAMES = {
+    "sentiment": "sentiment.parquet",
+    "target": "sentiment_targets.parquet",
+}
 FAILED_FILENAME = "failed_requests.jsonl"
 
 # -----------------------------------------------------------------------------
@@ -296,8 +306,9 @@ def main() -> None:
     requests_dir = batches_dir / REQUESTS_SUBDIR
     responses_dir = batches_dir / RESPONSES_SUBDIR
     filtered_path = get_filtered_dir() / FILTERED_FILENAME
+    pool_path = batches_dir / POOL_FILENAME
     processed_dir = get_processed_dir()
-    output_path = processed_dir / OUTPUT_FILENAME
+    output_path = processed_dir / OUTPUT_FILENAMES[stage.name]
     failed_path = batches_dir / FAILED_FILENAME
 
     logger.info("=" * 60)
@@ -317,8 +328,9 @@ def main() -> None:
         logger.error("No batches found in state. Run submit_batches.py first.")
         sys.exit(1)
 
-    if not filtered_path.exists():
-        logger.error(f"Filtered comments file not found: {filtered_path}")
+    assembly_input = filtered_path if stage.name == "sentiment" else pool_path
+    if not assembly_input.exists():
+        logger.error(f"Assembly input not found: {assembly_input}")
         sys.exit(1)
 
     logger.info(f"Found {batch_count} batch(es) in state")
@@ -374,13 +386,6 @@ def main() -> None:
         )
         sys.exit(0)
 
-    if stage.name != "sentiment":
-        logger.info(
-            f"No assembly step for stage {stage.name!r} in this version; "
-            f"its sidecar builder lands with its ticket (#91)"
-        )
-        sys.exit(0)
-
     # Check if we can build the final output
     pending = get_pending_batches(state)
     not_downloaded = get_missing_results(state)
@@ -408,39 +413,45 @@ def main() -> None:
         logger.warning("=" * 60)
 
     logger.info("=" * 60)
-    logger.info("Building sentiment.parquet...")
+    logger.info(f"Building {output_path.name}...")
     logger.info("=" * 60)
 
     try:
         # Classifier identity (#90): recorded in state at submission,
         # carried through every re-assembly unchanged. Cross-check and
         # metadata are settled before the expensive join to fail fast.
-        metadata = {
-            "players_config_version": load_player_config_version(),
-            "schema_version": str(SCHEMA_VERSION),
-        }
+        metadata = {"schema_version": str(SCHEMA_VERSION)}
         identity = get_classifier_identity(state)
         if identity is None:
             logger.warning(
-                "state.json carries no classifier identity - sentiment.parquet "
+                f"state.json carries no classifier identity - {output_path.name} "
                 "will have no classifier lineage stamp"
             )
         else:
             check_response_models(responses_dir, identity["model"])
-            metadata["classifier_sentiment_model"] = identity["model"]
-            metadata["classifier_sentiment_prompt_version"] = identity[
-                "prompt_version"
-            ]
+            model_key, prompt_key = stage.stamp_keys
+            metadata[model_key] = identity["model"]
+            metadata[prompt_key] = identity["prompt_version"]
 
-        sentiment_df, failed_requests = build_sentiment_dataframe(
-            responses_dir, filtered_path
-        )
+        if stage.name == "sentiment":
+            # Config-lineage stamp (#54): mentioned_players is re-derived
+            # under the active config at every assembly
+            metadata["players_config_version"] = load_player_config_version()
+            output_df, failed_requests = build_sentiment_dataframe(
+                responses_dir, filtered_path
+            )
+        else:
+            # The pool was selected under a config; the sidecar carries the
+            # pool's stamp, not the live one, so the two stay coherent
+            pool_metadata = pl.read_parquet_metadata(pool_path)
+            metadata["players_config_version"] = pool_metadata["players_config_version"]
+            output_df, failed_requests = build_targets_dataframe(
+                responses_dir, pool_path
+            )
 
-        # Save parquet with config-lineage stamp (#54): mentioned_players
-        # was re-derived under this config version at assembly
         processed_dir.mkdir(parents=True, exist_ok=True)
-        sentiment_df.write_parquet(output_path, metadata=metadata)
-        logger.info(f"Wrote {len(sentiment_df)} rows to {output_path}")
+        output_df.write_parquet(output_path, metadata=metadata)
+        logger.info(f"Wrote {len(output_df)} rows to {output_path}")
 
         # Save failed requests
         if failed_requests:

--- a/scripts/prepare_batches.py
+++ b/scripts/prepare_batches.py
@@ -27,7 +27,7 @@ from pathlib import Path
 
 from tqdm import tqdm
 
-from pipeline.batch import format_batch_request, REQUESTS_PER_BATCH
+from pipeline.batch import REQUESTS_PER_BATCH, format_batch_request, write_request_file
 from pipeline.stage import STAGE_NAMES, ClassifierStage, get_stage
 from utils.formatting import format_duration
 from utils.paths import get_batches_dir, get_filtered_dir
@@ -74,21 +74,6 @@ def count_lines(filepath: Path) -> int:
         for _ in f:
             count += 1
     return count
-
-
-def write_batch(output_dir: Path, batch_num: int, requests: list[dict]) -> None:
-    """
-    Write a batch of requests to a JSONL file.
-
-    Args:
-        output_dir: Directory to write the batch file.
-        batch_num: Batch number for filename.
-        requests: List of batch request dicts to write.
-    """
-    batch_path = output_dir / f"batch_{batch_num:03d}.jsonl"
-    with open(batch_path, "w") as f:
-        for request in requests:
-            f.write(json.dumps(request) + "\n")
 
 
 def process_file(
@@ -162,14 +147,14 @@ def process_file(
             # Write batch when full
             if len(current_batch) >= REQUESTS_PER_BATCH:
                 batch_num += 1
-                write_batch(output_dir, batch_num, current_batch)
+                write_request_file(output_dir, batch_num, current_batch)
                 stats["batches"] += 1
                 current_batch = []
 
     # Write remaining requests
     if current_batch:
         batch_num += 1
-        write_batch(output_dir, batch_num, current_batch)
+        write_request_file(output_dir, batch_num, current_batch)
         stats["batches"] += 1
 
     elapsed = time.time() - start_time

--- a/scripts/prepare_targets.py
+++ b/scripts/prepare_targets.py
@@ -91,10 +91,12 @@ def main() -> None:
     if not input_path.exists():
         logger.error(f"Sentiment parquet not found: {input_path}")
         sys.exit(1)
-    if requests_dir.exists() and any(requests_dir.glob("batch_*.jsonl")):
+    if pool_path.exists() or (
+        requests_dir.exists() and any(requests_dir.glob("batch_*.jsonl"))
+    ):
         logger.error(
-            f"{requests_dir} already holds request files - a pool was prepared "
-            f"here; remove the stage directory to prepare a fresh one"
+            f"{batches_dir} already holds a pool or request files; remove the "
+            f"stage directory to prepare a fresh one"
         )
         sys.exit(1)
 
@@ -134,6 +136,8 @@ def main() -> None:
         how="left",
         maintain_order="left",
     )
+    if with_bodies["body"].null_count():
+        raise ValueError("pool rows without a body: the pool must come from this frame")
     requests = [
         format_batch_request(
             TARGET_STAGE,

--- a/scripts/prepare_targets.py
+++ b/scripts/prepare_targets.py
@@ -1,0 +1,158 @@
+"""
+Prepare the target-verifier pool and its batch request files.
+
+Reads the season's sentiment.parquet, selects the pool (top-k receipt
+candidates per player x polar sentiment with the target gate lifted,
+plus two random evidence strata), writes it as pool.parquet, and writes
+one request per pool row for the target stage. Submit, collect, and
+run_batches then take --stage target.
+
+Usage:
+    uv run python -m scripts.prepare_targets
+    uv run python -m scripts.prepare_targets --season 2024-25 --k 30
+
+Input: data/<season>/processed/sentiment.parquet
+Output:
+    - data/<season>/batches/target/pool.parquet
+    - data/<season>/batches/target/requests/batch_NNN.jsonl
+"""
+
+import argparse
+import logging
+import sys
+
+
+from pipeline.aggregation import load_attributed_frame
+from pipeline.batch import (
+    REQUESTS_PER_BATCH,
+    REQUESTS_SUBDIR,
+    format_batch_request,
+    write_request_file,
+)
+from pipeline.receipts import build_target_pool
+from pipeline.schemas import SCHEMA_VERSION
+from pipeline.targets import TARGET_STAGE
+from utils.constants import TARGET_POOL_K, TARGET_POOL_SEED, TARGET_POOL_STRATUM_N
+from utils.paths import get_batches_dir, get_processed_dir
+from utils.player_config import load_player_config_version
+from utils.season_config import set_season_override
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s | %(levelname)-8s | %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+POOL_FILENAME = "pool.parquet"
+SENTIMENT_FILENAME = "sentiment.parquet"
+
+
+def main() -> None:
+    """Main entry point with CLI argument handling."""
+    parser = argparse.ArgumentParser(
+        description="Prepare the target-verifier pool and batch request files"
+    )
+    parser.add_argument(
+        "--k",
+        type=int,
+        default=TARGET_POOL_K,
+        help=f"Candidate depth per player x sentiment cell (default: {TARGET_POOL_K})",
+    )
+    parser.add_argument(
+        "--stratum-n",
+        type=int,
+        default=TARGET_POOL_STRATUM_N,
+        help=f"Rows per random evidence stratum (default: {TARGET_POOL_STRATUM_N})",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=TARGET_POOL_SEED,
+        help=f"Sampling seed for the strata (default: {TARGET_POOL_SEED})",
+    )
+    parser.add_argument(
+        "--season",
+        default=None,
+        metavar="YYYY-YY",
+        help='Override the active season (e.g. "2024-25"); data paths and '
+        "player config resolve to it for this run",
+    )
+    args = parser.parse_args()
+
+    if args.season:
+        set_season_override(args.season)
+
+    input_path = get_processed_dir() / SENTIMENT_FILENAME
+    batches_dir = get_batches_dir(TARGET_STAGE.name)
+    requests_dir = batches_dir / REQUESTS_SUBDIR
+    pool_path = batches_dir / POOL_FILENAME
+
+    if not input_path.exists():
+        logger.error(f"Sentiment parquet not found: {input_path}")
+        sys.exit(1)
+    if requests_dir.exists() and any(requests_dir.glob("batch_*.jsonl")):
+        logger.error(
+            f"{requests_dir} already holds request files - a pool was prepared "
+            f"here; remove the stage directory to prepare a fresh one"
+        )
+        sys.exit(1)
+
+    logger.info("=" * 60)
+    logger.info("Prepare Target-Verifier Pool")
+    logger.info("=" * 60)
+    logger.info(
+        f"Stage:    {TARGET_STAGE.name} ({TARGET_STAGE.model}, {TARGET_STAGE.prompt_version})"
+    )
+    logger.info(f"Input:    {input_path}")
+    logger.info(f"Pool:     {pool_path}")
+    logger.info(f"Requests: {requests_dir}")
+    logger.info(f"k={args.k}, stratum_n={args.stratum_n}, seed={args.seed}")
+    logger.info("=" * 60)
+
+    df, _ = load_attributed_frame(input_path)
+    pool = build_target_pool(df, k=args.k, stratum_n=args.stratum_n, seed=args.seed)
+
+    # The pool's composition is a config-derived selection; stamp it like
+    # the fact so drift is detectable at aggregation.
+    batches_dir.mkdir(parents=True, exist_ok=True)
+    pool.write_parquet(
+        pool_path,
+        metadata={
+            "players_config_version": load_player_config_version(),
+            "schema_version": str(SCHEMA_VERSION),
+            "pool_k": str(args.k),
+            "pool_stratum_n": str(args.stratum_n),
+            "pool_seed": str(args.seed),
+        },
+    )
+    logger.info(f"Wrote {pool.height:,} pool rows to {pool_path}")
+
+    with_bodies = pool.join(
+        df.select("comment_id", "body"),
+        on="comment_id",
+        how="left",
+        maintain_order="left",
+    )
+    requests = [
+        format_batch_request(
+            TARGET_STAGE,
+            row["comment_id"],
+            comment_body=row["body"],
+            sentiment=row["sentiment"],
+        )
+        for row in with_bodies.iter_rows(named=True)
+    ]
+    batch_count = 0
+    for start in range(0, len(requests), REQUESTS_PER_BATCH):
+        batch_count += 1
+        write_request_file(
+            requests_dir, batch_count, requests[start : start + REQUESTS_PER_BATCH]
+        )
+    logger.info(
+        f"Wrote {len(requests):,} requests across {batch_count} file(s) to {requests_dir}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -12,6 +12,7 @@ import polars as pl
 import pytest
 
 from pipeline.aggregation import (
+    load_attributed_frame,
     aggregate_sentiment,
     build_comment_samples,
     build_teams_dimension,
@@ -303,6 +304,44 @@ def pinned_snapshot(monkeypatch, tmp_path, lebron_roster_row):
     monkeypatch.setattr("pipeline.aggregation.get_reference_dir", lambda: ref_dir)
     _write_snapshot(ref_dir, [lebron_roster_row])
     return ref_dir
+
+
+def _lebron_rows_with_error() -> dict:
+    """_lebron_rows plus one error-sentiment row aggregation must exclude."""
+    rows = _lebron_rows()
+    extra = {
+        **{k: v[0] for k, v in rows.items()},
+        "comment_id": "err01",
+        "sentiment": "error",
+    }
+    return {k: v + [extra[k]] for k, v in rows.items()}
+
+
+class TestLoadAttributedFrame:
+    """Tests for load_attributed_frame, the model's shared starting frame."""
+
+    def test_adds_derived_columns_and_drops_error_rows(self, tmp_path):
+        """Verify the frame gains attributed_player, team, and week; errors are excluded."""
+        path = _make_test_parquet(tmp_path, _lebron_rows_with_error())
+
+        df, excluded = load_attributed_frame(path)
+
+        assert excluded == 1
+        assert df.height == 2
+        assert {"attributed_player", "team", "week"} <= set(df.columns)
+        assert "error" not in df["sentiment"].to_list()
+        assert df["attributed_player"].to_list() == ["LeBron James"] * df.height
+
+    def test_aggregate_sentiment_counts_match_the_frame(self, tmp_path):
+        """Verify aggregate_sentiment's metadata counts derive from the same frame."""
+        path = _make_test_parquet(tmp_path, _lebron_rows_with_error())
+
+        df, excluded = load_attributed_frame(path)
+        meta = aggregate_sentiment(path)["metadata"]
+
+        assert meta["excluded_comments"] == excluded
+        assert meta["usable_comments"] == df.height
+        assert meta["total_comments"] == df.height + excluded
 
 
 class TestAggregatePlayers:

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -800,7 +800,7 @@ class TestBuildCommentSamples:
                 "score": 10,
             },
         ]
-        with caplog.at_level(logging.INFO, logger="pipeline.aggregation"):
+        with caplog.at_level(logging.INFO, logger="pipeline.receipts"):
             build_comment_samples(_samples_input(rows))
 
         assert "1 (50.0%) removed by the pos/neg target gate" in caplog.text

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -30,6 +30,7 @@ from pipeline.batch import (
     record_retry_attempt,
     save_state,
     summarize_actual_usage,
+    write_request_file,
 )
 from pipeline.sentiment import (
     MAX_TOKENS,
@@ -1311,3 +1312,21 @@ class TestGetClassifierIdentity:
 
         with pytest.raises(ValueError, match="[Ii]nconsistent"):
             get_classifier_identity(state)
+
+
+class TestWriteRequestFile:
+    """Tests for write_request_file."""
+
+    def test_writes_one_json_line_per_request_and_names_by_batch_num(self, tmp_path):
+        """Verify the file is batch_NNN.jsonl with one compact JSON object per line."""
+        requests = [
+            format_batch_request(SENTIMENT_STAGE, "a", comment_body="x"),
+            format_batch_request(TARGET_STAGE, "b", comment_body="y", sentiment="neg"),
+        ]
+
+        path = write_request_file(tmp_path / "requests", 7, requests)
+
+        assert path.name == "batch_007.jsonl"
+        lines = path.read_text().splitlines()
+        assert [json.loads(line) for line in lines] == requests
+        assert lines[0] == json.dumps(requests[0])

--- a/tests/unit/test_receipts.py
+++ b/tests/unit/test_receipts.py
@@ -1,0 +1,194 @@
+"""Tests for pipeline.receipts (candidate selection and the target pool)."""
+
+import polars as pl
+import pytest
+
+from pipeline.receipts import build_target_pool, select_receipt_candidates
+from pipeline.schemas import TARGET_POOL_SCHEMA
+from utils.constants import TARGET_POOL_STRATA
+
+_INPUT_SCHEMA = pl.Schema(
+    {
+        "attributed_player": pl.String,
+        "sentiment": pl.String,
+        "sentiment_player": pl.String,
+        "comment_id": pl.String,
+        "body": pl.String,
+        "score": pl.Int64,
+        "confidence": pl.Float64,
+    }
+)
+
+
+def _frame(rows: list[dict]) -> pl.DataFrame:
+    """Build an attributed frame from row dicts with stable defaults.
+
+    sentiment_player defaults to the attributed player (a named target);
+    pass None explicitly for an unnamed row.
+    """
+    defaults = {"confidence": 0.95, "score": 1}
+    return pl.DataFrame(
+        [
+            {"sentiment_player": row["attributed_player"], **defaults, **row}
+            for row in rows
+        ],
+        schema=_INPUT_SCHEMA,
+    )
+
+
+def _cell(player: str, sentiment: str, count: int, *, named: bool = True) -> list:
+    """count rows for one cell, scores descending so ranks are predictable."""
+    return [
+        {
+            "attributed_player": player,
+            "sentiment": sentiment,
+            "sentiment_player": player if named else None,
+            "comment_id": f"{player[:2]}{sentiment}{i:02d}",
+            "body": f"{player} {sentiment} comment {i}",
+            "score": 100 - i,
+        }
+        for i in range(count)
+    ]
+
+
+class TestSelectReceiptCandidates:
+    """Tests for select_receipt_candidates."""
+
+    def test_ranks_within_cell_and_caps_at_n(self):
+        """Verify rank is 1..n per cell by score and rows past n are dropped."""
+        df = _frame(_cell("Luka Doncic", "neg", 5) + _cell("Luka Doncic", "pos", 2))
+
+        out = select_receipt_candidates(df, n=3)
+
+        neg = out.filter(pl.col("sentiment") == "neg").sort("rank")
+        assert neg["rank"].to_list() == [1, 2, 3]
+        assert neg["comment_id"].to_list() == ["Luneg00", "Luneg01", "Luneg02"]
+        assert out.filter(pl.col("sentiment") == "pos")["rank"].to_list() == [1, 2]
+
+    def test_target_gate_on_drops_unnamed_polar_rows(self):
+        """Verify the default gate removes polar rows with no sentiment_player."""
+        df = _frame(
+            _cell("Luka Doncic", "neg", 2, named=False) + _cell("Luka Doncic", "neg", 1)
+        )
+
+        out = select_receipt_candidates(df, n=10)
+
+        assert out["comment_id"].to_list() == ["Luneg00"]
+
+    def test_target_gate_off_ranks_named_and_unnamed_together(self):
+        """Verify lifting the gate lets unnamed rows compete on score."""
+        unnamed = _cell("Luka Doncic", "neg", 2, named=False)
+        named = _cell("Luka Doncic", "neg", 1)
+        named[0].update(comment_id="named", score=50, body="a distinct named body")
+
+        out = select_receipt_candidates(
+            _frame(unnamed + named), n=10, require_target=False
+        )
+
+        assert out.sort("rank")["comment_id"].to_list() == [
+            "Luneg00",
+            "Luneg01",
+            "named",
+        ]
+
+    def test_keeps_input_columns_plus_rank(self):
+        """Verify the output is the input's columns with rank appended."""
+        df = _frame(_cell("Luka Doncic", "neg", 1))
+
+        out = select_receipt_candidates(df, n=1)
+
+        assert out.columns == [*df.columns, "rank"]
+
+
+class TestBuildTargetPool:
+    """Tests for build_target_pool."""
+
+    def _attributed(self) -> pl.DataFrame:
+        """Two players, candidates deeper than k, named and unnamed rows, one neutral."""
+        rows = (
+            _cell("Luka Doncic", "neg", 6)
+            + _cell("Luka Doncic", "neg", 4, named=False)
+            + _cell("Anthony Davis", "pos", 3)
+            + [
+                {
+                    "attributed_player": "Anthony Davis",
+                    "sentiment": "neu",
+                    "comment_id": "neutral",
+                    "body": "AD played",
+                }
+            ]
+        )
+        # Make the unnamed ids distinct from the named ones
+        for i, row in enumerate(rows[6:10]):
+            row["comment_id"] = f"Lunull{i:02d}"
+            row["score"] = 200 - i
+        return _frame(rows)
+
+    def test_conforms_to_schema(self):
+        """Verify the pool matches TARGET_POOL_SCHEMA exactly."""
+        pool = build_target_pool(self._attributed(), k=3, stratum_n=2)
+
+        assert pool.schema == TARGET_POOL_SCHEMA
+
+    def test_candidates_are_top_k_with_gate_lifted(self):
+        """Verify unnamed rows outrank named ones on score when the gate is off."""
+        pool = build_target_pool(self._attributed(), k=3, stratum_n=0)
+
+        luka_neg = pool.filter(
+            (pl.col("attributed_player") == "Luka Doncic")
+            & (pl.col("stratum") == "candidate")
+        ).sort("rank")
+        assert luka_neg["comment_id"].to_list() == ["Lunull00", "Lunull01", "Lunull02"]
+        assert luka_neg["rank"].to_list() == [1, 2, 3]
+
+    def test_neutral_rows_never_enter_the_pool(self):
+        """Verify only polar rows are verified."""
+        pool = build_target_pool(self._attributed(), k=10, stratum_n=10)
+
+        assert "neutral" not in pool["comment_id"].to_list()
+        assert set(pool["sentiment"].to_list()) <= {"pos", "neg"}
+
+    def test_strata_are_named_and_unnamed_non_candidates(self):
+        """Verify each random stratum draws from the right class and excludes candidates."""
+        df = self._attributed()
+        pool = build_target_pool(df, k=2, stratum_n=10)
+        candidates = set(pool.filter(pl.col("stratum") == "candidate")["comment_id"])
+        named_ids = set(
+            df.filter(pl.col("sentiment_player").is_not_null())["comment_id"]
+        )
+
+        random_named = pool.filter(pl.col("stratum") == "random_named")
+        random_null = pool.filter(pl.col("stratum") == "random_null")
+        assert set(random_named["comment_id"]) <= named_ids - candidates
+        assert set(random_null["comment_id"]).isdisjoint(named_ids | candidates)
+        assert random_named["rank"].null_count() == random_named.height
+        assert set(pool["stratum"]) <= set(TARGET_POOL_STRATA)
+
+    def test_one_row_per_comment(self):
+        """Verify a comment appears once even when strata could redraw it."""
+        pool = build_target_pool(self._attributed(), k=2, stratum_n=100)
+
+        assert pool["comment_id"].n_unique() == pool.height
+
+    def test_stratum_size_capped_by_availability(self):
+        """Verify a stratum larger than its class yields every eligible row, no error."""
+        df = self._attributed()
+        pool = build_target_pool(df, k=1, stratum_n=100)
+
+        unnamed_polar = df.filter(
+            pl.col("sentiment_player").is_null() & (pl.col("sentiment") != "neu")
+        )
+        drawn = pool.filter(pl.col("stratum") == "random_null").height
+        assert (
+            drawn == unnamed_polar.height - 1
+        )  # one unnamed row is the rank-1 candidate
+
+    @pytest.mark.parametrize("seed", [7, 8])
+    def test_deterministic_for_a_seed(self, seed: int):
+        """Verify the same seed reproduces the same pool."""
+        df = self._attributed()
+
+        first = build_target_pool(df, k=2, stratum_n=2, seed=seed)
+        second = build_target_pool(df, k=2, stratum_n=2, seed=seed)
+
+        assert first.equals(second)

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -1,4 +1,4 @@
-"""Tests for pipeline/results.py sentiment frame assembly."""
+"""Tests for pipeline/results.py: sentiment and target frame assembly."""
 
 import json
 import logging
@@ -7,8 +7,17 @@ from pathlib import Path
 import polars as pl
 import pytest
 
-from pipeline.results import build_sentiment_dataframe, check_response_models
-from pipeline.schemas import COMMENT_INPUT_SCHEMA, SENTIMENT_SCHEMA
+from pipeline.results import (
+    build_sentiment_dataframe,
+    build_targets_dataframe,
+    check_response_models,
+)
+from pipeline.schemas import (
+    COMMENT_INPUT_SCHEMA,
+    SENTIMENT_SCHEMA,
+    SENTIMENT_TARGETS_SCHEMA,
+    TARGET_POOL_SCHEMA,
+)
 
 
 def _succeeded(
@@ -460,3 +469,117 @@ class TestCheckResponseModels:
 
         with pytest.raises(ValueError, match="Malformed JSON in batch_001"):
             check_response_models(directory, "model-x")
+
+
+def _write_pool(tmp_path: Path, rows: list[dict]) -> Path:
+    """Write a TARGET_POOL_SCHEMA parquet from row dicts, defaults filled."""
+    defaults = {
+        "attributed_player": "Luka Doncic",
+        "sentiment": "neg",
+        "stratum": "candidate",
+        "rank": 1,
+    }
+    path = tmp_path / "pool.parquet"
+    pl.DataFrame(
+        [{**defaults, **row} for row in rows], schema=TARGET_POOL_SCHEMA
+    ).write_parquet(path)
+    return path
+
+
+class TestBuildTargetsDataframe:
+    """Tests for build_targets_dataframe, the verdict sidecar assembly."""
+
+    def test_joins_verdicts_to_pool_in_pool_order(self, tmp_path):
+        """Verify each pool row gains the parsed verdict and the frame conforms."""
+        pool = _write_pool(
+            tmp_path,
+            [
+                {"comment_id": "a", "rank": 1},
+                {"comment_id": "b", "rank": 2},
+                {"comment_id": "c", "stratum": "random_null", "rank": None},
+            ],
+        )
+        responses = tmp_path / "responses"
+        _write_results_file(
+            responses,
+            [
+                _succeeded("b", '{"t": null, "c": 0.8}'),
+                _succeeded(
+                    "a",
+                    '{"t": "Luka Doncic", "c": 0.95}',
+                    input_tokens=210,
+                    output_tokens=12,
+                ),
+                _succeeded("c", '{"t": "Nico Harrison", "c": 0.7}'),
+            ],
+        )
+
+        targets, failed = build_targets_dataframe(responses, pool)
+
+        assert targets.schema == SENTIMENT_TARGETS_SCHEMA
+        assert failed == []
+        assert targets["comment_id"].to_list() == ["a", "b", "c"]
+        assert targets["target_raw"].to_list() == ["Luka Doncic", None, "Nico Harrison"]
+        assert targets["valid"].to_list() == [True, True, True]
+        assert targets.row(0, named=True)["input_tokens"] == 210
+
+    def test_parse_failure_kept_as_invalid_row(self, tmp_path):
+        """Verify unparseable output is a valid=False row, not a null verdict."""
+        pool = _write_pool(tmp_path, [{"comment_id": "a"}])
+        responses = tmp_path / "responses"
+        _write_results_file(responses, [_succeeded("a", "no json here")])
+
+        targets, _ = build_targets_dataframe(responses, pool)
+
+        row = targets.row(0, named=True)
+        assert row["valid"] is False
+        assert row["target_raw"] is None
+        assert row["target_confidence"] == 0.0
+
+    def test_failed_request_absent_from_sidecar(self, tmp_path):
+        """Verify an errored request is returned as failed and missing from the frame."""
+        pool = _write_pool(
+            tmp_path, [{"comment_id": "a"}, {"comment_id": "b", "rank": 2}]
+        )
+        responses = tmp_path / "responses"
+        _write_results_file(
+            responses,
+            [
+                _succeeded("a", '{"t": null, "c": 0.9}'),
+                _errored("b"),
+            ],
+        )
+
+        targets, failed = build_targets_dataframe(responses, pool)
+
+        assert targets["comment_id"].to_list() == ["a"]
+        assert [f["custom_id"] for f in failed] == ["b"]
+
+    def test_verdict_without_pool_row_raises(self, tmp_path):
+        """Verify a response the pool never sent fails loudly."""
+        pool = _write_pool(tmp_path, [{"comment_id": "a"}])
+        responses = tmp_path / "responses"
+        _write_results_file(
+            responses,
+            [
+                _succeeded("a", '{"t": null, "c": 0.9}'),
+                _succeeded("ghost", '{"t": null, "c": 0.9}'),
+            ],
+        )
+
+        with pytest.raises(ValueError, match="ghost"):
+            build_targets_dataframe(responses, pool)
+
+    def test_list_valued_target_normalized_and_logged(self, tmp_path, caplog):
+        """Verify a single-string list t unwraps and the normalization is logged."""
+        pool = _write_pool(tmp_path, [{"comment_id": "a"}])
+        responses = tmp_path / "responses"
+        _write_results_file(
+            responses, [_succeeded("a", '{"t": ["Luka Doncic"], "c": 0.9}')]
+        )
+
+        with caplog.at_level(logging.WARNING, logger="pipeline.results"):
+            targets, _ = build_targets_dataframe(responses, pool)
+
+        assert targets["target_raw"].to_list() == ["Luka Doncic"]
+        assert "Normalized list-valued t" in caplog.text

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -555,6 +555,16 @@ class TestBuildTargetsDataframe:
         assert targets["comment_id"].to_list() == ["a"]
         assert [f["custom_id"] for f in failed] == ["b"]
 
+    def test_duplicate_verdict_raises(self, tmp_path):
+        """Verify a comment answered twice across results files fails loudly."""
+        pool = _write_pool(tmp_path, [{"comment_id": "a"}])
+        responses = tmp_path / "responses"
+        _write_results_file(responses, [_succeeded("a", '{"t": null, "c": 0.9}')], 1)
+        _write_results_file(responses, [_succeeded("a", '{"t": null, "c": 0.9}')], 2)
+
+        with pytest.raises(ValueError, match="duplicate"):
+            build_targets_dataframe(responses, pool)
+
     def test_verdict_without_pool_row_raises(self, tmp_path):
         """Verify a response the pool never sent fails loudly."""
         pool = _write_pool(tmp_path, [{"comment_id": "a"}])

--- a/tests/unit/test_stage.py
+++ b/tests/unit/test_stage.py
@@ -24,6 +24,17 @@ class TestGetStage:
         with pytest.raises(ValueError, match="sentiment"):
             get_stage("nope")
 
+    def test_stamp_keys_are_the_lineage_metadata_keys(self):
+        """Verify stamp_keys spell the parquet metadata keys assembly writes."""
+        assert SENTIMENT_STAGE.stamp_keys == (
+            "classifier_sentiment_model",
+            "classifier_sentiment_prompt_version",
+        )
+        assert TARGET_STAGE.stamp_keys == (
+            "classifier_target_model",
+            "classifier_target_prompt_version",
+        )
+
     def test_stages_are_distinct_identities(self):
         """Verify the two stages differ in name, model, and sampling contract."""
         assert SENTIMENT_STAGE.name != TARGET_STAGE.name

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -114,6 +114,12 @@ COMMENT_SAMPLES_TOP_N = 10
 COMMENT_SAMPLES_MIN_CONFIDENCE = 0.9  # pos/neg only; neu is exempt
 COMMENT_SAMPLES_MAX_BODY_CHARS = 500
 
+# The target-verifier pool (pipeline/receipts.py): the candidates the
+# verifier screens, plus two random strata carried as evidence only.
+TARGET_POOL_STRATA = ("candidate", "random_named", "random_null")
+TARGET_POOL_STRATUM_N = 500  # rows per random stratum
+TARGET_POOL_SEED = 7
+
 # =============================================================================
 # FILE PATHS (relative subdirectories - root comes from environment)
 # =============================================================================

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -116,6 +116,7 @@ COMMENT_SAMPLES_MAX_BODY_CHARS = 500
 
 # The target-verifier pool (pipeline/receipts.py): the candidates the
 # verifier screens, plus two random strata carried as evidence only.
+TARGET_POOL_K = 50  # candidate depth per cell; provisional until the dry run sizes it
 TARGET_POOL_STRATA = ("candidate", "random_named", "random_null")
 TARGET_POOL_STRATUM_N = 500  # rows per random stratum
 TARGET_POOL_SEED = 7

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -116,7 +116,7 @@ COMMENT_SAMPLES_MAX_BODY_CHARS = 500
 
 # The target-verifier pool (pipeline/receipts.py): the candidates the
 # verifier screens, plus two random strata carried as evidence only.
-TARGET_POOL_K = 50  # candidate depth per cell; provisional until the dry run sizes it
+TARGET_POOL_K = 50  # candidate depth per cell; 216/218 full cells fill 10 within it (2025-26)
 TARGET_POOL_STRATA = ("candidate", "random_named", "random_null")
 TARGET_POOL_STRATUM_N = 500  # rows per random stratum
 TARGET_POOL_SEED = 7


### PR DESCRIPTION
#91 step 3, PR A of two. PR B (the samples consumer) follows.

**What this adds.** The receipts second pass as a pipeline stage run, end to end:

1. `load_attributed_frame` extracted from `aggregate_sentiment` — the frame every consumer of the model starts from.
2. `pipeline/receipts.py` — `select_receipt_candidates` (build_comment_samples' candidacy and ranking, factored out; the samples builder now calls it) and `build_target_pool` (top-K per player × polar sentiment with the target gate lifted, plus two seeded random evidence strata; one row per comment). `TARGET_POOL_SCHEMA` and `SENTIMENT_TARGETS_SCHEMA` in `schemas.py`.
3. `scripts/prepare_targets` writes `pool.parquet` (stamped with the config it was selected under) and the stage's request files; `write_request_file` moved into `batch.py` for both prepares. `collect_results` dispatches assembly on the stage: target joins verdicts to the pool (`build_targets_dataframe`) and writes `data/<season>/processed/sentiment_targets.parquet` stamped with the stage's identity keys (`ClassifierStage.stamp_keys`) and the pool's config version.
4. K frozen at 50.

**The 2025-26 run (data, not committed).** Submitted through `run_batches --stage target`; identity recorded at submission — the first native exercise of #90's flow. 15,806 requests, 0 errored, 0 invalid parses, model cross-check passed, actual cost $5.05. Results and the PR B decisions are on #91 (amendment 2026-09-09): 73% of candidates affirmed; 216 of 218 full-depth cells fill 10 verified receipts within K=50 (the two that don't are Luka neg and Haliburton neg at 9 — thinning visibly is the posture); precision preview 22.6% misdirected over the would-have-shipped top-10.

**Verification.**
- Aggregation re-run for 2025-26 after the extraction and the shared selection: all seven parquet outputs data- and stamp-identical to the pre-branch files; `aggregates.json` identical minus `generated_at`.
- Pool built on real data: one row per comment, strata sizes exact, storyline cells at full depth; request line carries thinking-off and no temperature; dry-run estimate $9.53 ceiling.
- Unit tests: receipts (selection with the gate on/off, strata membership, collision rule, capping, determinism), sidecar assembly (join order, parse-failure rows, failed requests absent, unknown verdict raises, list normalization), request-file writer, `load_attributed_frame`.

**Process note.** The planned K sync dry run was dropped as redundant once the full pool cost under $10; K was sized from the run itself. The orchestrator was killed twice by the OS for low system memory mid-poll; state persisted and `--no-wait` resumed cleanly each time.

Follow-ups filed: #100 (`prepare_targets --top-up`).
